### PR TITLE
feat(base-parsing): generic expression and template parser infrastructure

### DIFF
--- a/base-parsing/pom.xml
+++ b/base-parsing/pom.xml
@@ -38,6 +38,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>

--- a/base-parsing/src/main/java/build/base/parsing/ExpressionParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/ExpressionParser.java
@@ -1,0 +1,128 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.resolvers.AtomNodeResolver;
+import build.base.parsing.resolvers.BinaryNodeResolver;
+import build.base.parsing.resolvers.SectionBeginNodeResolver;
+import build.base.parsing.resolvers.SectionEndNodeResolver;
+import build.base.parsing.resolvers.UnaryNodeResolver;
+import build.base.parsing.tokenparsers.AtomTokenParser;
+import build.base.parsing.tokenparsers.BinaryTokenParser;
+import build.base.parsing.tokenparsers.SectionBeginTokenParser;
+import build.base.parsing.tokenparsers.SectionEndTokenParser;
+import build.base.parsing.tokenparsers.TokenParser;
+import build.base.parsing.tokenparsers.UnaryTokenParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Parses an expression string into a node of type {@code N} using a configured set of token parsers.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class ExpressionParser<N> {
+
+    private final List<TokenParser<N>> tokenParsers;
+
+    /**
+     * Constructs a new {@link ExpressionParser}.
+     */
+    public ExpressionParser() {
+        this.tokenParsers = new ArrayList<>();
+    }
+
+    /**
+     * Defines an atom (leaf) token parser.
+     *
+     * @param pattern        the regex pattern to match
+     * @param implementation the function that creates a node from the matched token
+     */
+    public void defineAtom(final String pattern, final Function<Token<N>, N> implementation) {
+        this.tokenParsers.add(new AtomTokenParser<>(pattern, 0, token -> new AtomNodeResolver<>(token, implementation)));
+    }
+
+    /**
+     * Defines a unary (prefix) token parser.
+     *
+     * @param template       the exact string to match
+     * @param priority       operator precedence
+     * @param implementation the function that creates a node given its operand
+     */
+    public void defineUnary(final String template, final int priority, final Function<N, N> implementation) {
+        this.tokenParsers.add(new UnaryTokenParser<>(template, priority, token -> new UnaryNodeResolver<>(token, implementation)));
+    }
+
+    /**
+     * Defines a binary (infix) token parser.
+     *
+     * @param template       the exact string to match
+     * @param priority       operator precedence
+     * @param implementation the function that creates a node given its two operands
+     */
+    public void defineBinary(final String template, final int priority, final BiFunction<N, N, N> implementation) {
+        this.tokenParsers.add(new BinaryTokenParser<>(template, priority, token -> new BinaryNodeResolver<>(token, implementation)));
+    }
+
+    /**
+     * Defines a paired section (e.g. parentheses).
+     *
+     * @param openTemplate  the opening delimiter string
+     * @param closeTemplate the closing delimiter string
+     */
+    public void defineSection(final String openTemplate, final String closeTemplate) {
+        this.tokenParsers.add(new SectionBeginTokenParser<>(openTemplate, 0, SectionBeginNodeResolver::new));
+        this.tokenParsers.add(new SectionEndTokenParser<>(closeTemplate, 9999, SectionEndNodeResolver::new));
+    }
+
+    /**
+     * Parses the expression string and returns the root node, or {@code null} if the expression is blank.
+     *
+     * @param expression the expression to parse
+     * @return the parsed node, or {@code null} for a blank expression
+     * @throws ExpressionParserException if the expression is malformed
+     */
+    public N parse(final String expression) {
+        if (expression == null || expression.isBlank()) {
+            return null;
+        }
+
+        final var tokenizer = new Tokenizer<>(this.tokenParsers);
+        final var tokens = tokenizer.tokenize(expression);
+        final var stackManager = new ExpressionStackManager<N>();
+        try {
+            for (final var token : tokens) {
+                stackManager.push(token.tokenParser().createNodeResolver(token));
+            }
+            return stackManager.getExpressionRoot().resolve();
+        } catch (final ExpressionParserException e) {
+            throw e; // preserve domain exceptions — ExpressionParserException extends RuntimeException
+        } catch (final RuntimeException e) {
+            throw new ExpressionParserException("There was an error parsing the expression", e);
+        }
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/ExpressionParserException.java
+++ b/base-parsing/src/main/java/build/base/parsing/ExpressionParserException.java
@@ -1,0 +1,49 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Represents an exception that occurs during expression parsing.
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class ExpressionParserException extends RuntimeException {
+
+    /**
+     * Constructs a new {@link ExpressionParserException} with the specified message.
+     *
+     * @param message the exception message
+     */
+    public ExpressionParserException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@link ExpressionParserException} with the specified message and cause.
+     *
+     * @param message the exception message
+     * @param cause   the exception that caused this exception
+     */
+    public ExpressionParserException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/ExpressionStackManager.java
+++ b/base-parsing/src/main/java/build/base/parsing/ExpressionStackManager.java
@@ -1,0 +1,145 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.resolvers.AtomNodeResolver;
+import build.base.parsing.resolvers.NodeResolver;
+import build.base.parsing.resolvers.SectionBeginNodeResolver;
+import build.base.parsing.resolvers.SectionEndNodeResolver;
+
+import java.util.Optional;
+import java.util.Stack;
+
+/**
+ * Manages the resolver stack during expression parsing, handling operator precedence and parenthesised sections.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class ExpressionStackManager<N> {
+
+    private final Stack<Stack<NodeResolver<N>>> stackOfStacks;
+    private Stack<NodeResolver<N>> activeResolverStack;
+
+    /**
+     * Constructs a new {@link ExpressionStackManager}.
+     */
+    public ExpressionStackManager() {
+        this.stackOfStacks = new Stack<>();
+        this.activeResolverStack = new Stack<>();
+    }
+
+    /**
+     * Pushes a resolver onto the active stack, consolidating preceding operators where precedence requires it.
+     *
+     * @param nodeResolver the resolver to push
+     */
+    public void push(final NodeResolver<N> nodeResolver) {
+        if (nodeResolver instanceof SectionBeginNodeResolver) {
+            this.beginSection();
+            return;
+        }
+
+        final var activeNodeResolver = nodeResolver instanceof SectionEndNodeResolver
+            ? this.completeSection((SectionEndNodeResolver<N>) nodeResolver)
+            : nodeResolver;
+
+        if (!(activeNodeResolver instanceof AtomNodeResolver)) {
+            var lastOperator = getLastRelevantOperator();
+            while (lastOperator.isPresent()) {
+                final var lastOperatorResolver = lastOperator.get();
+                if (activeNodeResolver.getTokenParser().getPrecedence() >= lastOperatorResolver.getTokenParser().getPrecedence()) {
+                    lastOperatorResolver.consolidate(this.activeResolverStack);
+                    lastOperator = getLastRelevantOperator();
+                } else {
+                    break;
+                }
+            }
+        }
+        this.activeResolverStack.push(activeNodeResolver);
+    }
+
+    /**
+     * Consolidates the entire stack and returns the root resolver.
+     *
+     * @return the root resolver
+     * @throws ExpressionParserException if the expression is malformed
+     */
+    public NodeResolver<N> getExpressionRoot() {
+        if (!this.stackOfStacks.isEmpty()) {
+            throw new ExpressionParserException("The expression is malformed");
+        }
+        return this.getStackRoot();
+    }
+
+    private NodeResolver<N> getStackRoot() {
+        while (this.activeResolverStack.size() > 1) {
+            final var operator = this.getLastRelevantOperator();
+            if (operator.isEmpty()) {
+                throw new ExpressionParserException("The expression is malformed");
+            }
+            operator.get().consolidate(this.activeResolverStack);
+        }
+
+        final var root = this.activeResolverStack.pop();
+        if (!root.isConsolidated()) {
+            throw new ExpressionParserException("The expression is malformed");
+        }
+        return root;
+    }
+
+    private void beginSection() {
+        this.stackOfStacks.push(this.activeResolverStack);
+        this.activeResolverStack = new Stack<>();
+    }
+
+    private NodeResolver<N> completeSection(final SectionEndNodeResolver<N> nodeResolver) {
+        if (this.stackOfStacks.isEmpty()) {
+            throw new ExpressionParserException(
+                "The expression contains an unknown or unexpected token at " + nodeResolver.getTokenLocation());
+        }
+        final var rootNodeResolver = this.getStackRoot();
+        this.activeResolverStack = this.stackOfStacks.pop();
+        return rootNodeResolver;
+    }
+
+    private Optional<NodeResolver<N>> getLastRelevantOperator() {
+        final var stackSize = this.activeResolverStack.size();
+
+        if (stackSize >= 2) {
+            final var lastResolver = this.activeResolverStack.get(stackSize - 1);
+            if (!lastResolver.isConsolidated()) {
+                return Optional.empty();
+            }
+
+            final var resolver = this.activeResolverStack.get(stackSize - 2);
+            if (resolver instanceof AtomNodeResolver || resolver.isConsolidated()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(resolver);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/TemplateParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/TemplateParser.java
@@ -1,0 +1,117 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.resolvers.AtomNodeResolver;
+import build.base.parsing.tokenparsers.TemplateAtomTokenParser;
+import build.base.parsing.tokenparsers.TokenParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Parses a template string into an ordered list of nodes of type {@code N}.
+ * <p>
+ * Unlike {@link ExpressionParser}, template parsing is purely linear: whitespace is preserved,
+ * there is no operator precedence, and every token is resolved independently into a node.
+ * <p>
+ * An optional {@code tryMerge} function can be supplied to consolidate adjacent nodes — for example,
+ * combining two adjacent string-literal nodes into one. The function receives the previous node and
+ * the current node and returns the merged result, or {@link Optional#empty()} if the two nodes
+ * should not be merged.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Mar-2025
+ */
+public class TemplateParser<N> {
+
+    private final List<TokenParser<N>> tokenParsers;
+    private final BiFunction<N, N, Optional<N>> tryMerge;
+
+    /**
+     * Constructs a new {@link TemplateParser} with no adjacent-node merging.
+     */
+    public TemplateParser() {
+        this(null);
+    }
+
+    /**
+     * Constructs a new {@link TemplateParser}.
+     *
+     * @param tryMerge a function that attempts to merge two adjacent nodes into one, or
+     *                 {@code null} to disable merging
+     */
+    public TemplateParser(final BiFunction<N, N, Optional<N>> tryMerge) {
+        this.tokenParsers = new ArrayList<>();
+        this.tryMerge = tryMerge;
+    }
+
+    /**
+     * Defines an atom token parser for this template grammar.
+     *
+     * @param pattern        the regex pattern to match
+     * @param implementation the function that creates a node from the matched token
+     */
+    public void defineAtom(final String pattern, final Function<Token<N>, N> implementation) {
+        this.tokenParsers.add(new TemplateAtomTokenParser<>(pattern, 0, token -> new AtomNodeResolver<>(token, implementation)));
+    }
+
+    /**
+     * Parses the template string and returns an ordered list of nodes.
+     * Returns an empty list if the expression is {@code null} or blank.
+     *
+     * @param expression the template string to parse
+     * @return the list of parsed nodes
+     * @throws ExpressionParserException if the template contains an unrecognised token
+     */
+    public List<N> parse(final String expression) {
+        if (expression == null || expression.isBlank()) {
+            return List.of();
+        }
+
+        final var tokenizer = new Tokenizer<>(this.tokenParsers, false);
+        final var tokens = tokenizer.tokenize(expression);
+        try {
+            final var nodes = new ArrayList<N>();
+            for (final var token : tokens) {
+                final var node = token.tokenParser().createNodeResolver(token).resolve();
+                if (this.tryMerge != null && !nodes.isEmpty()) {
+                    final var merged = this.tryMerge.apply(nodes.getLast(), node);
+                    if (merged.isPresent()) {
+                        nodes.set(nodes.size() - 1, merged.get());
+                        continue;
+                    }
+                }
+                nodes.add(node);
+            }
+            return nodes;
+        } catch (final ExpressionParserException e) {
+            throw e; // preserve domain exceptions — ExpressionParserException extends RuntimeException
+        } catch (final RuntimeException e) {
+            throw new ExpressionParserException("There was an error parsing the expression", e);
+        }
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/Token.java
+++ b/base-parsing/src/main/java/build/base/parsing/Token.java
@@ -1,0 +1,47 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.io.LookaheadReader;
+import build.base.parsing.tokenparsers.TokenParser;
+
+/**
+ * Represents a token extracted from an expression string.
+ *
+ * @param <N>         the node type produced by the parser
+ * @param tokenParser the {@link TokenParser} that produced this token
+ * @param location    the location of the token in the source expression
+ * @param value       the raw text of the token
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public record Token<N>(TokenParser<N> tokenParser, LookaheadReader.Location location, String value) {
+
+    /**
+     * Returns the token value with the first and last characters removed (useful for stripping quotes).
+     *
+     * @return the trimmed value
+     */
+    public String trimFirstAndLast() {
+        return this.value.substring(1, this.value.length() - 1);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/Tokenizer.java
+++ b/base-parsing/src/main/java/build/base/parsing/Tokenizer.java
@@ -1,0 +1,94 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.tokenparsers.TokenParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts an expression string into a list of {@link Token}s using a configured set of {@link TokenParser}s.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class Tokenizer<N> {
+
+    private final List<TokenParser<N>> tokenParsers;
+    private final boolean ignoreWhitespace;
+
+    /**
+     * Constructs a {@link Tokenizer} that ignores whitespace.
+     *
+     * @param tokenParsers the token parsers to apply
+     */
+    public Tokenizer(final List<TokenParser<N>> tokenParsers) {
+        this(tokenParsers, true);
+    }
+
+    /**
+     * Constructs a {@link Tokenizer}.
+     *
+     * @param tokenParsers     the token parsers to apply
+     * @param ignoreWhitespace whether to skip whitespace between tokens
+     */
+    public Tokenizer(final List<TokenParser<N>> tokenParsers, final boolean ignoreWhitespace) {
+        this.tokenParsers = tokenParsers;
+        this.ignoreWhitespace = ignoreWhitespace;
+    }
+
+    /**
+     * Tokenizes the expression string.
+     *
+     * @param expression the expression to tokenize
+     * @return the list of tokens
+     * @throws ExpressionParserException if an unknown token is encountered
+     */
+    public List<Token<N>> tokenize(final String expression) {
+        final var scanner = new Scanner(expression);
+        if (this.ignoreWhitespace) {
+            scanner.register(Filter.WHITESPACE);
+        }
+
+        final var tokens = new ArrayList<Token<N>>();
+
+        while (scanner.hasNext()) {
+            var tokenProcessed = false;
+            for (final var tokenParser : this.tokenParsers) {
+                final var token = tokenParser.attemptExtractToken(scanner, tokens);
+                if (token.isPresent()) {
+                    tokens.add(token.get());
+                    tokenProcessed = true;
+                    break;
+                }
+            }
+            if (!tokenProcessed) {
+                throw new ExpressionParserException(
+                    "The expression contains an unknown or unexpected token at " + scanner.getLocation());
+            }
+        }
+
+        return tokens;
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/AbstractNodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/AbstractNodeResolver.java
@@ -1,0 +1,72 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.io.LookaheadReader;
+import build.base.parsing.Token;
+import build.base.parsing.tokenparsers.TokenParser;
+
+import java.util.Stack;
+
+/**
+ * Base implementation of {@link NodeResolver}.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public abstract class AbstractNodeResolver<N>
+    implements NodeResolver<N> {
+
+    protected final Token<N> token;
+    protected boolean isConsolidated;
+
+    /**
+     * Constructs a new {@link AbstractNodeResolver}.
+     *
+     * @param token the token to resolve
+     */
+    protected AbstractNodeResolver(final Token<N> token) {
+        this.token = token;
+        this.isConsolidated = false;
+    }
+
+    @Override
+    public TokenParser<N> getTokenParser() {
+        return this.token.tokenParser();
+    }
+
+    @Override
+    public LookaheadReader.Location getTokenLocation() {
+        return this.token.location();
+    }
+
+    @Override
+    public boolean isConsolidated() {
+        return this.isConsolidated;
+    }
+
+    @Override
+    public void consolidate(final Stack<NodeResolver<N>> stack) {
+        this.isConsolidated = true;
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/AtomNodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/AtomNodeResolver.java
@@ -1,0 +1,56 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+
+import java.util.function.Function;
+
+/**
+ * A {@link NodeResolver} that resolves a leaf (atom) token into a node.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class AtomNodeResolver<N>
+    extends AbstractNodeResolver<N> {
+
+    private final Function<Token<N>, N> createNodeRunnable;
+
+    /**
+     * Constructs a new {@link AtomNodeResolver}.
+     *
+     * @param token              the token to resolve
+     * @param createNodeRunnable the function that creates the node from the token
+     */
+    public AtomNodeResolver(final Token<N> token, final Function<Token<N>, N> createNodeRunnable) {
+        super(token);
+        this.createNodeRunnable = createNodeRunnable;
+        this.isConsolidated = true;
+    }
+
+    @Override
+    public N resolve() {
+        return this.createNodeRunnable.apply(this.token);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/BinaryNodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/BinaryNodeResolver.java
@@ -1,0 +1,83 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+
+import java.util.Stack;
+import java.util.function.BiFunction;
+
+/**
+ * A {@link NodeResolver} that resolves a binary operation into a node.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class BinaryNodeResolver<N>
+    extends AbstractNodeResolver<N> {
+
+    private final BiFunction<N, N, N> createNodeRunnable;
+
+    private NodeResolver<N> left;
+    private NodeResolver<N> right;
+
+    /**
+     * Constructs a new {@link BinaryNodeResolver}.
+     *
+     * @param token              the token to resolve
+     * @param createNodeRunnable the function that creates the node from the left and right operands
+     */
+    public BinaryNodeResolver(final Token<N> token, final BiFunction<N, N, N> createNodeRunnable) {
+        super(token);
+        this.createNodeRunnable = createNodeRunnable;
+    }
+
+    @Override
+    public void consolidate(final Stack<NodeResolver<N>> stack) {
+        if (this != stack.get(stack.size() - 2)) {
+            throw new IllegalStateException("This BinaryNodeResolver should be the second to last element in the stack.");
+        }
+        if (this.isConsolidated) {
+            throw new IllegalStateException("This BinaryNodeResolver has already been consolidated.");
+        }
+        if (stack.size() < 3) {
+            throw new IllegalStateException("There should be at least 3 elements in the stack.");
+        }
+
+        this.right = stack.pop();
+        stack.pop(); // self
+        this.left = stack.pop();
+
+        stack.push(this);
+
+        super.consolidate(stack);
+    }
+
+    @Override
+    public N resolve() {
+        if (!this.isConsolidated) {
+            throw new IllegalStateException("The NodeResolver has not been consolidated.");
+        }
+        return this.createNodeRunnable.apply(this.left.resolve(), this.right.resolve());
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/NodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/NodeResolver.java
@@ -1,0 +1,67 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.io.LookaheadReader;
+import build.base.parsing.tokenparsers.TokenParser;
+
+import java.util.Stack;
+
+/**
+ * Resolves a parsed node of type {@code N} from a token in the expression stack.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public interface NodeResolver<N> {
+
+    /**
+     * Returns the {@link TokenParser} that produced the token behind this resolver.
+     */
+    TokenParser<N> getTokenParser();
+
+    /**
+     * Returns the source location of the token behind this resolver.
+     */
+    LookaheadReader.Location getTokenLocation();
+
+    /**
+     * Returns {@code true} once this resolver has been consolidated (i.e. its operands have been
+     * popped from the stack and attached).
+     */
+    boolean isConsolidated();
+
+    /**
+     * Pops operand resolvers from the stack and attaches them to this resolver.
+     *
+     * @param stack the active resolver stack
+     */
+    void consolidate(Stack<NodeResolver<N>> stack);
+
+    /**
+     * Produces the node value for this resolver.
+     *
+     * @return the resolved node
+     */
+    N resolve();
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/SectionBeginNodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/SectionBeginNodeResolver.java
@@ -1,0 +1,50 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+
+/**
+ * Marks the beginning of a grouped section (e.g. an opening parenthesis).
+ * Never resolved — consumed by the matching {@link SectionEndNodeResolver}.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class SectionBeginNodeResolver<N>
+    extends AbstractNodeResolver<N> {
+
+    /**
+     * Constructs a new {@link SectionBeginNodeResolver}.
+     *
+     * @param token the token to resolve
+     */
+    public SectionBeginNodeResolver(final Token<N> token) {
+        super(token);
+    }
+
+    @Override
+    public N resolve() {
+        throw new IllegalStateException("'resolve' should never be called on SectionBeginNodeResolver.");
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/SectionEndNodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/SectionEndNodeResolver.java
@@ -1,0 +1,50 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+
+/**
+ * Marks the end of a grouped section (e.g. a closing parenthesis).
+ * Never resolved directly — triggers stack consolidation in {@link build.base.parsing.ExpressionStackManager}.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class SectionEndNodeResolver<N>
+    extends AbstractNodeResolver<N> {
+
+    /**
+     * Constructs a new {@link SectionEndNodeResolver}.
+     *
+     * @param token the token to resolve
+     */
+    public SectionEndNodeResolver(final Token<N> token) {
+        super(token);
+    }
+
+    @Override
+    public N resolve() {
+        throw new IllegalStateException("'resolve' should never be called on SectionEndNodeResolver.");
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/resolvers/UnaryNodeResolver.java
+++ b/base-parsing/src/main/java/build/base/parsing/resolvers/UnaryNodeResolver.java
@@ -1,0 +1,78 @@
+package build.base.parsing.resolvers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+
+import java.util.Stack;
+import java.util.function.Function;
+
+/**
+ * A {@link NodeResolver} that resolves a unary operation into a node.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class UnaryNodeResolver<N>
+    extends AbstractNodeResolver<N> {
+
+    private final Function<N, N> createNodeRunnable;
+
+    private NodeResolver<N> operand;
+
+    /**
+     * Constructs a new {@link UnaryNodeResolver}.
+     *
+     * @param token              the token to resolve
+     * @param createNodeRunnable the function that creates the node from the operand
+     */
+    public UnaryNodeResolver(final Token<N> token, final Function<N, N> createNodeRunnable) {
+        super(token);
+        this.createNodeRunnable = createNodeRunnable;
+    }
+
+    @Override
+    public void consolidate(final Stack<NodeResolver<N>> stack) {
+        if (this != stack.get(stack.size() - 2)) {
+            throw new IllegalStateException("This UnaryNodeResolver should be the second to last element in the stack.");
+        }
+        if (this.isConsolidated) {
+            throw new IllegalStateException("This UnaryNodeResolver has already been consolidated.");
+        }
+        if (stack.size() < 2) {
+            throw new IllegalStateException("There should be at least 2 elements in the stack.");
+        }
+
+        this.operand = stack.pop();
+
+        super.consolidate(stack);
+    }
+
+    @Override
+    public N resolve() {
+        if (!this.isConsolidated) {
+            throw new IllegalStateException("The NodeResolver has not been consolidated.");
+        }
+        return this.createNodeRunnable.apply(this.operand.resolve());
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/AbstractTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/AbstractTokenParser.java
@@ -1,0 +1,89 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Scanner;
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Base implementation of {@link TokenParser}.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public abstract class AbstractTokenParser<N>
+    implements TokenParser<N> {
+
+    private final int precedence;
+    private final Function<Token<N>, NodeResolver<N>> resolverFactory;
+
+    /**
+     * Constructs a new {@link AbstractTokenParser}.
+     *
+     * @param precedence the precedence (higher = lower operator precedence)
+     * @param resolverFactory   the function that creates the {@link NodeResolver} for a matched token
+     */
+    protected AbstractTokenParser(final int precedence, final Function<Token<N>, NodeResolver<N>> resolverFactory) {
+        this.precedence = precedence;
+        this.resolverFactory = resolverFactory;
+    }
+
+    @Override
+    public int getPrecedence() {
+        return this.precedence;
+    }
+
+    @Override
+    public Optional<Token<N>> attemptExtractToken(final Scanner scanner, final List<Token<N>> parsedTokens) {
+        if (isNextToken(scanner) && isAllowedAfter(parsedTokens)) {
+            final var token = new Token<N>(this, scanner.getLocation(), extractToken(scanner));
+            return Optional.of(token);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public NodeResolver<N> createNodeResolver(final Token<N> token) {
+        return this.resolverFactory.apply(token);
+    }
+
+    /**
+     * Returns {@code true} if the scanner's current position matches this token.
+     */
+    protected abstract boolean isNextToken(Scanner scanner);
+
+    /**
+     * Extracts and consumes the token text from the scanner.
+     */
+    protected abstract String extractToken(Scanner scanner);
+
+    /**
+     * Returns {@code true} if this token is valid given the tokens parsed so far.
+     */
+    protected abstract boolean isAllowedAfter(List<Token<N>> tokens);
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/AtomTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/AtomTokenParser.java
@@ -1,0 +1,62 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * A {@link TokenParser} for leaf (atom) tokens matched by a regular expression.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class AtomTokenParser<N>
+    extends PatternTokenParser<N> {
+
+    /**
+     * Constructs a new {@link AtomTokenParser}.
+     *
+     * @param pattern    the regex pattern to match
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    public AtomTokenParser(final String pattern,
+                           final int precedence,
+                           final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(Pattern.compile(pattern), precedence, runnable);
+    }
+
+    @Override
+    protected boolean isAllowedAfter(final List<Token<N>> tokens) {
+        if (tokens.isEmpty()) {
+            return true;
+        }
+        final var last = tokens.getLast().tokenParser();
+        return !(last instanceof AtomTokenParser) && !(last instanceof SectionEndTokenParser);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/BinaryTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/BinaryTokenParser.java
@@ -1,0 +1,61 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A {@link TokenParser} for binary (infix) operator tokens matched by an exact string.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class BinaryTokenParser<N>
+    extends StringTokenParser<N> {
+
+    /**
+     * Constructs a new {@link BinaryTokenParser}.
+     *
+     * @param template   the operator string
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    public BinaryTokenParser(final String template,
+                             final int precedence,
+                             final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(template, precedence, runnable);
+    }
+
+    @Override
+    protected boolean isAllowedAfter(final List<Token<N>> tokens) {
+        if (tokens.isEmpty()) {
+            return false;
+        }
+        final var last = tokens.getLast().tokenParser();
+        return !(last instanceof BinaryTokenParser) && !(last instanceof SectionBeginTokenParser);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/PatternTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/PatternTokenParser.java
@@ -1,0 +1,66 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Scanner;
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * A {@link TokenParser} that matches via a regular expression {@link Pattern}.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public abstract class PatternTokenParser<N>
+    extends AbstractTokenParser<N> {
+
+    private final Pattern pattern;
+
+    /**
+     * Constructs a new {@link PatternTokenParser}.
+     *
+     * @param pattern    the pattern to match
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    protected PatternTokenParser(final Pattern pattern,
+                                 final int precedence,
+                                 final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(precedence, runnable);
+        this.pattern = pattern;
+    }
+
+    @Override
+    protected boolean isNextToken(final Scanner scanner) {
+        return scanner.follows(this.pattern);
+    }
+
+    @Override
+    protected String extractToken(final Scanner scanner) {
+        return scanner.consume(this.pattern);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/SectionBeginTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/SectionBeginTokenParser.java
@@ -1,0 +1,61 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A {@link TokenParser} for the opening delimiter of a grouped section (e.g. {@code (}).
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class SectionBeginTokenParser<N>
+    extends StringTokenParser<N> {
+
+    /**
+     * Constructs a new {@link SectionBeginTokenParser}.
+     *
+     * @param template   the opening delimiter string
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    public SectionBeginTokenParser(final String template,
+                                   final int precedence,
+                                   final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(template, precedence, runnable);
+    }
+
+    @Override
+    protected boolean isAllowedAfter(final List<Token<N>> tokens) {
+        if (tokens.isEmpty()) {
+            return true;
+        }
+        final var last = tokens.getLast().tokenParser();
+        return !(last instanceof AtomTokenParser) && !(last instanceof SectionEndTokenParser);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/SectionEndTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/SectionEndTokenParser.java
@@ -1,0 +1,60 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A {@link TokenParser} for the closing delimiter of a grouped section (e.g. {@code )}).
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class SectionEndTokenParser<N>
+    extends StringTokenParser<N> {
+
+    /**
+     * Constructs a new {@link SectionEndTokenParser}.
+     *
+     * @param template   the closing delimiter string
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    public SectionEndTokenParser(final String template,
+                                 final int precedence,
+                                 final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(template, precedence, runnable);
+    }
+
+    @Override
+    protected boolean isAllowedAfter(final List<Token<N>> tokens) {
+        if (tokens.isEmpty()) {
+            return false;
+        }
+        return !(tokens.getLast().tokenParser() instanceof BinaryTokenParser);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/StringTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/StringTokenParser.java
@@ -1,0 +1,65 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Scanner;
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.function.Function;
+
+/**
+ * A {@link TokenParser} that matches via an exact string template.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public abstract class StringTokenParser<N>
+    extends AbstractTokenParser<N> {
+
+    private final String template;
+
+    /**
+     * Constructs a new {@link StringTokenParser}.
+     *
+     * @param template   the string to match
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    protected StringTokenParser(final String template,
+                                final int precedence,
+                                final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(precedence, runnable);
+        this.template = template;
+    }
+
+    @Override
+    protected boolean isNextToken(final Scanner scanner) {
+        return scanner.follows(this.template);
+    }
+
+    @Override
+    protected String extractToken(final Scanner scanner) {
+        return scanner.consume(this.template);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/TemplateAtomTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/TemplateAtomTokenParser.java
@@ -1,0 +1,60 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * A {@link TokenParser} for leaf (atom) tokens in template expressions, matched by a regular expression.
+ * Unlike {@link AtomTokenParser}, this parser is always allowed regardless of the preceding token —
+ * template grammars have no operator precedence and permit any token sequence.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Mar-2025
+ */
+public class TemplateAtomTokenParser<N>
+    extends PatternTokenParser<N> {
+
+    /**
+     * Constructs a new {@link TemplateAtomTokenParser}.
+     *
+     * @param pattern    the regex pattern to match
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    public TemplateAtomTokenParser(final String pattern,
+                                   final int precedence,
+                                   final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(Pattern.compile(pattern), precedence, runnable);
+    }
+
+    @Override
+    protected boolean isAllowedAfter(final List<Token<N>> tokens) {
+        return true;
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/TokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/TokenParser.java
@@ -1,0 +1,61 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Scanner;
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Attempts to extract a {@link Token} from a {@link Scanner} and produce the corresponding {@link NodeResolver}.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public interface TokenParser<N> {
+
+    /**
+     * Returns the precedence of this token parser. Higher values mean lower precedence (evaluated later).
+     */
+    int getPrecedence();
+
+    /**
+     * Attempts to extract the next token from the scanner.
+     *
+     * @param scanner      the scanner positioned at the current parse location
+     * @param parsedTokens the tokens extracted so far (used for context-sensitive matching)
+     * @return the extracted token, or empty if this parser does not match
+     */
+    Optional<Token<N>> attemptExtractToken(Scanner scanner, List<Token<N>> parsedTokens);
+
+    /**
+     * Creates a {@link NodeResolver} for the given token.
+     *
+     * @param token the extracted token
+     * @return the resolver
+     */
+    NodeResolver<N> createNodeResolver(Token<N> token);
+}

--- a/base-parsing/src/main/java/build/base/parsing/tokenparsers/UnaryTokenParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/tokenparsers/UnaryTokenParser.java
@@ -1,0 +1,61 @@
+package build.base.parsing.tokenparsers;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Token;
+import build.base.parsing.resolvers.NodeResolver;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A {@link TokenParser} for unary (prefix) operator tokens matched by an exact string.
+ *
+ * @param <N> the node type
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+public class UnaryTokenParser<N>
+    extends StringTokenParser<N> {
+
+    /**
+     * Constructs a new {@link UnaryTokenParser}.
+     *
+     * @param template   the operator string
+     * @param precedence the precedence
+     * @param runnable   the resolver factory
+     */
+    public UnaryTokenParser(final String template,
+                            final int precedence,
+                            final Function<Token<N>, NodeResolver<N>> runnable) {
+        super(template, precedence, runnable);
+    }
+
+    @Override
+    protected boolean isAllowedAfter(final List<Token<N>> tokens) {
+        if (tokens.isEmpty()) {
+            return true;
+        }
+        final var last = tokens.getLast().tokenParser();
+        return !(last instanceof AtomTokenParser) && !(last instanceof SectionEndTokenParser);
+    }
+}

--- a/base-parsing/src/main/java/module-info.java
+++ b/base-parsing/src/main/java/module-info.java
@@ -28,4 +28,6 @@ module build.base.parsing {
     requires build.base.io;
 
     exports build.base.parsing;
+    exports build.base.parsing.resolvers;
+    exports build.base.parsing.tokenparsers;
 }

--- a/base-parsing/src/test/java/build/base/parsing/ExpressionParserTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/ExpressionParserTests.java
@@ -1,0 +1,274 @@
+package build.base.parsing;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ExpressionParser}.
+ *
+ * @author tim.berston
+ * @since Nov-2024
+ */
+class ExpressionParserTests {
+
+    // Minimal node hierarchy for testing — records give structural equals() for free.
+    sealed interface Node permits Num, Var, Neg, Not, Add, Sub, Mul, Div, Mod, Pow, And, Or {}
+    record Num(String value) implements Node {}
+    record Var(String name)  implements Node {}
+    record Neg(Node operand) implements Node {}
+    record Not(Node operand) implements Node {}
+    record Add(Node left, Node right) implements Node {}
+    record Sub(Node left, Node right) implements Node {}
+    record Mul(Node left, Node right) implements Node {}
+    record Div(Node left, Node right) implements Node {}
+    record Mod(Node left, Node right) implements Node {}
+    record Pow(Node left, Node right) implements Node {}
+    record And(Node left, Node right) implements Node {}
+    record Or(Node left, Node right)  implements Node {}
+
+    private ExpressionParser<Node> parser;
+
+    @BeforeEach
+    void init() {
+        parser = new ExpressionParser<>();
+        parser.defineSection("(", ")");
+        parser.defineAtom("[0-9]+(?:[.][0-9]+)?", token -> new Num(token.value()));
+        parser.defineAtom("\\[[^]]+\\]", token -> new Var(token.trimFirstAndLast()));
+        parser.defineUnary("-", 1, Neg::new);
+        parser.defineBinary("^", 2, Pow::new);
+        parser.defineBinary("*", 3, Mul::new);
+        parser.defineBinary("/", 3, Div::new);
+        parser.defineBinary("%", 3, Mod::new);
+        parser.defineBinary("-", 4, Sub::new);
+        parser.defineBinary("+", 4, Add::new);
+        parser.defineUnary("not", 11, Not::new);
+        parser.defineBinary("and", 12, And::new);
+        parser.defineBinary("or", 13, Or::new);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = { "", "      " })
+    void shouldReturnNullForEmptyExpression(final String expr) {
+        assertThat(parser.parse(expr)).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1", " 1", "1 " })
+    void shouldParseSingleLiteral(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Num("1"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1 + 2", "1+2", "1    +2 " })
+    void shouldParseSimpleAddition(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Add(new Num("1"), new Num("2")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1 * 2", "1*2" })
+    void shouldParseSimpleMultiplication(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Mul(new Num("1"), new Num("2")));
+    }
+
+    // 1 + 2 * 3  →  Add(1, Mul(2, 3))  because * binds tighter than +
+    @ParameterizedTest
+    @ValueSource(strings = { "1 + 2 * 3", "1+2*3" })
+    void shouldRespectPrecedence_addThenMul(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Add(new Num("1"), new Mul(new Num("2"), new Num("3"))));
+    }
+
+    // 1 * 2 + 3  →  Add(Mul(1, 2), 3)
+    @ParameterizedTest
+    @ValueSource(strings = { "1 * 2 + 3", "1*2+3" })
+    void shouldRespectPrecedence_mulThenAdd(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Add(new Mul(new Num("1"), new Num("2")), new Num("3")));
+    }
+
+    // 1 + 2 - 3  →  Sub(Add(1, 2), 3)  — left-associative at equal precedence
+    @ParameterizedTest
+    @ValueSource(strings = { "1 + 2 - 3", "1+2-3" })
+    void shouldParseEqualPrecedenceLeftAssociatively(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Sub(new Add(new Num("1"), new Num("2")), new Num("3")));
+    }
+
+    // 1 + 2 * 3 - 4  →  Sub(Add(1, Mul(2, 3)), 4)
+    @ParameterizedTest
+    @ValueSource(strings = { "1 + 2 * 3 - 4", "1+2*3-4" })
+    void shouldParseMultiOperatorExpressionCorrectly(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(
+            new Sub(new Add(new Num("1"), new Mul(new Num("2"), new Num("3"))), new Num("4")));
+    }
+
+    @Test
+    void shouldParseUnaryNegation() {
+        assertThat(parser.parse("-1")).isEqualTo(new Neg(new Num("1")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "-1 + 2", "-1+2" })
+    void shouldParseUnaryAtStartOfExpression(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Add(new Neg(new Num("1")), new Num("2")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1 + -2", "1+-2" })
+    void shouldParseUnaryWithinExpression(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Add(new Num("1"), new Neg(new Num("2"))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "--1", "-   -1" })
+    void shouldParseDoubleUnary(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Neg(new Neg(new Num("1"))));
+    }
+
+    // (1 + 2) * 3  →  Mul(Add(1, 2), 3)
+    @ParameterizedTest
+    @ValueSource(strings = { "(1 + 2) * 3", "(1+2)*3" })
+    void shouldParseSectionAtStart(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Mul(new Add(new Num("1"), new Num("2")), new Num("3")));
+    }
+
+    // 4 * (1 + 2) * 3  →  Mul(Mul(4, Add(1, 2)), 3)
+    @ParameterizedTest
+    @ValueSource(strings = { "4 * (1 + 2) * 3", "4*(1+2)*3" })
+    void shouldParseSectionWithinExpression(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(
+            new Mul(new Mul(new Num("4"), new Add(new Num("1"), new Num("2"))), new Num("3")));
+    }
+
+    // 4 * (1 + (5 - 2)) * 3
+    @ParameterizedTest
+    @ValueSource(strings = { "4 * (1 + (5 - 2)) * 3", "4*(1+(5-2))*3" })
+    void shouldParseNestedSections(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(
+            new Mul(
+                new Mul(new Num("4"), new Add(new Num("1"), new Sub(new Num("5"), new Num("2")))),
+                new Num("3")));
+    }
+
+    // (1 + 2) * (3 - 4)
+    @ParameterizedTest
+    @ValueSource(strings = { "(1 + 2) * (3 - 4)", "(1+2)*(3-4)" })
+    void shouldParseMultipleSections(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(
+            new Mul(new Add(new Num("1"), new Num("2")), new Sub(new Num("3"), new Num("4"))));
+    }
+
+    // (1) - 2  →  Sub(1, 2) — section-end should allow binary to follow
+    @Test
+    void shouldParseBinaryAfterSectionEnd() {
+        assertThat(parser.parse("(1)-2")).isEqualTo(new Sub(new Num("1"), new Num("2")));
+    }
+
+    @Test
+    void shouldParseDecimalLiteral() {
+        assertThat(parser.parse("1.5 + 2.25")).isEqualTo(new Add(new Num("1.5"), new Num("2.25")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "3 % 2", "3%2" })
+    void shouldParseModulo(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Mod(new Num("3"), new Num("2")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "3 ^ 2", "3^2" })
+    void shouldParseExponent(final String expr) {
+        assertThat(parser.parse(expr)).isEqualTo(new Pow(new Num("3"), new Num("2")));
+    }
+
+    // 3 * 1 ^ 2  →  Mul(3, Pow(1, 2))  because ^ binds tighter than *
+    @Test
+    void shouldParseExponentPrecedence() {
+        assertThat(parser.parse("3 * 1 ^ 2")).isEqualTo(new Mul(new Num("3"), new Pow(new Num("1"), new Num("2"))));
+    }
+
+    @Test
+    void shouldParseVariableAtom() {
+        assertThat(parser.parse("[bob]")).isEqualTo(new Var("bob"));
+    }
+
+    @Test
+    void shouldParseVariableInExpression() {
+        assertThat(parser.parse("[bob] * 5")).isEqualTo(new Mul(new Var("bob"), new Num("5")));
+    }
+
+    @Test
+    void shouldParseLogicalNot() {
+        assertThat(parser.parse("not [flag]")).isEqualTo(new Not(new Var("flag")));
+    }
+
+    @Test
+    void shouldParseLogicalAnd() {
+        assertThat(parser.parse("[a] and [b]")).isEqualTo(new And(new Var("a"), new Var("b")));
+    }
+
+    @Test
+    void shouldParseLogicalOr() {
+        assertThat(parser.parse("[a] or [b]")).isEqualTo(new Or(new Var("a"), new Var("b")));
+    }
+
+    // [a] and not ([b] or [c])
+    @Test
+    void shouldParseComplexLogicalExpression() {
+        assertThat(parser.parse("[a] and not ([b] or [c])")).isEqualTo(
+            new And(new Var("a"), new Not(new Or(new Var("b"), new Var("c")))));
+    }
+
+    // ([a] or not [b]) or ([c] and [d])
+    @Test
+    void shouldParseNestedLogicalExpression() {
+        assertThat(parser.parse("[a] or [b] or (not [c]) or ([d] and [e])")).isEqualTo(
+            new Or(
+                new Or(
+                    new Or(new Var("a"), new Var("b")),
+                    new Not(new Var("c"))),
+                new And(new Var("d"), new Var("e"))));
+    }
+
+    // Stress test — long expression must parse without error
+    @Test
+    void shouldParseLongExpressionWithoutError() {
+        final var expr = String.join(" and ",
+            java.util.Collections.nCopies(50, "([a] or not [b])"));
+        assertThat(parser.parse(expr)).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "(1 + 2", "1 +", "-" })
+    void shouldThrowOnMalformedExpression(final String expr) {
+        assertThatThrownBy(() -> parser.parse(expr))
+            .isInstanceOf(ExpressionParserException.class)
+            .hasMessage("The expression is malformed");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unknownTokenCases")
+    void shouldThrowOnUnknownToken(final String expr, final int column) {
+        assertThatThrownBy(() -> parser.parse(expr))
+            .isInstanceOf(ExpressionParserException.class)
+            .hasMessageContaining("Location 1:" + column);
+    }
+
+    static Stream<Arguments> unknownTokenCases() {
+        return Stream.of(
+            Arguments.of("1 + 2 # 3", 7),
+            Arguments.of("{1 + 1}", 1),
+            Arguments.of("1 + 2)", 6),
+            Arguments.of("(1 + 2))", 8),
+            Arguments.of("1 2", 3)
+        );
+    }
+}

--- a/base-parsing/src/test/java/build/base/parsing/TemplateParserTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/TemplateParserTests.java
@@ -1,0 +1,106 @@
+package build.base.parsing;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TemplateParser}.
+ *
+ * @author tim.berston
+ * @since Mar-2025
+ */
+class TemplateParserTests {
+
+    // Two node types: plain text and interpolated variable references.
+    sealed interface Node permits Text, Var {}
+    record Text(String value) implements Node {}
+    record Var(String name)   implements Node {}
+
+    // Adjacent Text nodes are merged; Var nodes are never merged.
+    private static final java.util.function.BiFunction<Node, Node, Optional<Node>> MERGE =
+        (a, b) -> (a instanceof Text ta && b instanceof Text tb)
+            ? Optional.of(new Text(ta.value() + tb.value()))
+            : Optional.empty();
+
+    private static TemplateParser<Node> parser;
+
+    @BeforeAll
+    static void init() {
+        parser = new TemplateParser<>(MERGE);
+        // `[[` is an escape sequence producing a literal `[`
+        parser.defineAtom("\\[\\[", _ -> new Text("["));
+        // `[name]` is a variable reference
+        parser.defineAtom("\\[[^]]+\\]", token -> new Var(token.trimFirstAndLast()));
+        // Everything else (non-bracket runs) is plain text
+        parser.defineAtom("[^\\[]+", token -> new Text(token.value()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void shouldParseTemplateCorrectly(final String expression, final List<Node> expected) {
+        assertThat(parser.parse(expression)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> cases() {
+        return Stream.of(
+            // Plain text — no interpolation
+            Arguments.of("some text",
+                List.of(new Text("some text"))),
+
+            // Escape sequence `[[` → literal `[`, followed by `]`
+            Arguments.of("[[]",
+                List.of(new Text("[]"))),
+
+            // Text then escape: `:[[ ` → `:[`
+            Arguments.of(":[[",
+                List.of(new Text(":["))),
+
+            // Multiple escapes and characters
+            Arguments.of("[[\\[[\\]]+",
+                List.of(new Text("[\\[\\]]+"))),
+
+            // Text, variable, text
+            Arguments.of("[[ [variable] ]",
+                List.of(new Text("[ "), new Var("variable"), new Text(" ]"))),
+
+            // Just a double-quote character
+            Arguments.of("\"",
+                List.of(new Text("\""))),
+
+            // Text before escape, variable, text after
+            Arguments.of("\"[[[variable]]\"",
+                List.of(new Text("\"["), new Var("variable"), new Text("]\""))),
+
+            Arguments.of("'[[[variable]]'",
+                List.of(new Text("'["), new Var("variable"), new Text("]'"))),
+
+            // Two variables separated by text
+            Arguments.of("[template]:[expression]",
+                List.of(new Var("template"), new Text(":"), new Var("expression"))),
+
+            // Escape at start, then variable
+            Arguments.of("[[template]:[expression]",
+                List.of(new Text("[template]:"), new Var("expression"))),
+
+            // Escape, variable, text, variable
+            Arguments.of("[[[template]:[expression]",
+                List.of(new Text("["), new Var("template"), new Text(":"), new Var("expression"))),
+
+            // Variable, space+parens text, variable, closing text
+            Arguments.of("[instance] ([class])",
+                List.of(new Var("instance"), new Text(" ("), new Var("class"), new Text(")"))),
+
+            // Newline between two variables
+            Arguments.of("[prev]\n[curr]",
+                List.of(new Var("prev"), new Text("\n"), new Var("curr")))
+        );
+    }
+}


### PR DESCRIPTION
Extracts the expression parsing engine from `codemodel.build/expression-codemodel` into `base-parsing` as a fully generic, reusable framework.

What's new:
- `ExpressionParser<N>` — configurable parser supporting atoms, unary/binary operators, operator precedence, and parenthesised sections; returns a single root node of type N
- `TemplateParser<N>` — linear tokenizer (no precedence) for template strings; returns `List<N>` with optional adjacent-node merging
- Full tokenparsers and resolvers package hierarchies supporting the above
- `ExpressionParserException` — unified domain exception for parse errors
- 93 tests covering precedence, nesting, unary/binary disambiguation, error cases, and template interpolation

Notable fixes over the `codemodel` original:
- `ExpressionStackManager` is now local to each `parse()` call — the original shared instance left dirty state after a failed parse
- `BinaryTokenParser.isAllowedAfter` now correctly rejects binary operators following an opening section delimiter (e.g. (+ 3) now produces a useful error at tokenization time)
- Internal invariant violations in resolvers throw `IllegalStateException` rather than raw `RuntimeException`