### PR TITLE
fix(base-assertion): resolve JPMS module path compatibility with JUnit 6 and AssertJ

### DIFF
--- a/base-assertion/src/test/java/build/base/assertion/test/CompletableFutureAssertionTests.java
+++ b/base-assertion/src/test/java/build/base/assertion/test/CompletableFutureAssertionTests.java
@@ -1,5 +1,6 @@
-package build.base.assertion;
+package build.base.assertion.test;
 
+import build.base.assertion.CompletableFutureAssertion;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;

--- a/base-assertion/src/test/java/build/base/assertion/test/EventuallyTests.java
+++ b/base-assertion/src/test/java/build/base/assertion/test/EventuallyTests.java
@@ -1,5 +1,6 @@
-package build.base.assertion;
+package build.base.assertion.test;
 
+import build.base.assertion.Eventually;
 import build.base.option.Timeout;
 import build.base.retryable.EphemerallyFailingRetryable;
 import build.base.retryable.PermanentFailureException;

--- a/base-assertion/src/test/java/build/base/assertion/test/IteratorAssertTests.java
+++ b/base-assertion/src/test/java/build/base/assertion/test/IteratorAssertTests.java
@@ -1,5 +1,8 @@
-package build.base.assertion;
+package build.base.assertion.test;
 
+import build.base.assertion.Eventually;
+import build.base.assertion.IteratorAssert;
+import build.base.assertion.IteratorPatternMatcherRetryableAssertion;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/base-assertion/src/test/java/build/base/assertion/test/IteratorPatternMatcherRetryableAssertionTests.java
+++ b/base-assertion/src/test/java/build/base/assertion/test/IteratorPatternMatcherRetryableAssertionTests.java
@@ -1,5 +1,6 @@
-package build.base.assertion;
+package build.base.assertion.test;
 
+import build.base.assertion.IteratorPatternMatcherRetryableAssertion;
 import build.base.option.Timeout;
 import build.base.retryable.Retryable;
 import org.junit.jupiter.api.Test;

--- a/base-assertion/src/test/java/module-info.java
+++ b/base-assertion/src/test/java/module-info.java
@@ -1,0 +1,29 @@
+/*-
+ * #%L
+ * base.build Assertion
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+module build.base.assertion.test {
+    requires build.base.assertion;
+    requires build.base.retryable;
+    requires build.base.option;
+
+    requires org.assertj.core;
+    requires org.junit.jupiter.api;
+
+    opens build.base.assertion.test to org.junit.platform.commons;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -336,15 +336,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 


### PR DESCRIPTION
base-assertion is unique in the project in that it declares assertj-core as a compile dependency (necessarily, since it exports assertion utilities built on AssertJ). AssertJ's module descriptor includes requires org.junit.jupiter.api static, which pulls junit-platform-commons onto the module path as a named module. This caused Surefire's launcher — which runs in the unnamed module — to fail with IllegalAccessError when trying to access junit-platform-commons internals.

The fix introduces a proper JPMS test module (build.base.assertion.test) via a module-info.java in src/test/java. Test classes are moved to the build.base.assertion.test subpackage to avoid the split-package constraint. This gives the test module a clean, explicit requires org.junit.jupiter.api without polluting the production module descriptor.
                                                                                                                                                                                                                                                           
Also removes the global <useModulePath>false</useModulePath> from the root Surefire configuration, which was suppressing JPMS for all modules and is incorrect for a JPMS-first project. 