### PR TITLE
feat(base-graph): immutable graph library with traversal, ordering, and path algorithms

### DIFF
--- a/base-graph/pom.xml
+++ b/base-graph/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>build.base</groupId>
+        <artifactId>base-project</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>base-graph</artifactId>
+
+    <name>base.build Graph</name>
+    <description>Immutable directed and weighted graph primitives with algorithms for traversal, ordering, cycle detection, and reachability.</description>
+
+    <dependencies>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/base-graph/src/main/java/build/base/graph/Component.java
+++ b/base-graph/src/main/java/build/base/graph/Component.java
@@ -1,0 +1,90 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A strongly connected component (SCC) in a {@link Graph} — a maximal set of vertices
+ * such that every vertex is reachable from every other vertex within the component.
+ * <p>
+ * A component containing a single vertex is a trivial SCC.
+ *
+ * @param <V>      the vertex type
+ * @param vertices the set of vertices in this component (non-empty)
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public record Component<V>(Set<V> vertices) {
+
+    /**
+     * Constructs a {@link Component}, defensive-copying the vertex set and ensuring it is non-empty.
+     *
+     * @param vertices the vertices in this component
+     */
+    public Component {
+        Objects.requireNonNull(vertices, "The vertices set cannot be null");
+
+        if (vertices.isEmpty()) {
+            throw new IllegalArgumentException("A component must contain at least one vertex");
+        }
+
+        vertices = Set.copyOf(vertices);
+    }
+
+    /**
+     * Returns the number of vertices in this component.
+     *
+     * @return the size of this component
+     */
+    public int size() {
+        return vertices.size();
+    }
+
+    /**
+     * Returns {@code true} if this component contains more than one vertex.
+     *
+     * @return {@code true} if this component is non-trivial
+     */
+    public boolean isNonTrivial() {
+        return vertices.size() > 1;
+    }
+
+    /**
+     * Returns {@code true} if this component contains exactly one vertex.
+     *
+     * @return {@code true} if this component is trivial
+     */
+    public boolean isTrivial() {
+        return vertices.size() == 1;
+    }
+
+    /**
+     * Returns {@code true} if this component contains the given vertex.
+     *
+     * @param vertex the vertex to check
+     * @return {@code true} if {@code vertex} is in this component
+     */
+    public boolean contains(final V vertex) {
+        return vertices.contains(vertex);
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/Edge.java
+++ b/base-graph/src/main/java/build/base/graph/Edge.java
@@ -1,0 +1,65 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Objects;
+
+/**
+ * A directed edge in a {@link Graph}, connecting a source vertex {@code from} to a
+ * target vertex {@code to}.
+ *
+ * @param <V>  the vertex type
+ * @param from the source vertex
+ * @param to   the target vertex
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public record Edge<V>(V from, V to) {
+
+    /**
+     * Constructs an {@link Edge}, validating that neither endpoint is {@code null}.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     */
+    public Edge {
+        Objects.requireNonNull(from, "The from vertex cannot be null");
+        Objects.requireNonNull(to, "The to vertex cannot be null");
+    }
+
+    /**
+     * Returns a new {@link Edge} with the direction reversed.
+     *
+     * @return a reversed {@link Edge} from {@code to} to {@code from}
+     */
+    public Edge<V> reversed() {
+        return new Edge<>(to, from);
+    }
+
+    /**
+     * Returns {@code true} if this edge is a self-loop (i.e. {@code from} equals {@code to}).
+     *
+     * @return {@code true} if this is a self-loop
+     */
+    public boolean isSelfLoop() {
+        return from.equals(to);
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/Graph.java
+++ b/base-graph/src/main/java/build/base/graph/Graph.java
@@ -1,0 +1,432 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An immutable directed or undirected graph.
+ * <p>
+ * Graphs are constructed via {@link Builder} obtained from {@link #directed()} or
+ * {@link #undirected()}.  Once built, the graph is fully immutable — vertices and edges
+ * cannot be added or removed.
+ * <p>
+ * The underlying collection types used for vertex sets, adjacency maps, and edge caches are
+ * configurable via {@link GraphCollections}.  The default uses standard JDK collections;
+ * high-performance alternatives (e.g. fastutil) may be substituted via
+ * {@link Builder#withCollections(GraphCollections)}.
+ * <p>
+ * For algorithms operating on graphs, see {@link Graphs}.
+ *
+ * @param <V> the vertex type
+ * @author reed.von.redwitz
+ * @see Graphs
+ * @see GraphCollections
+ * @since Apr-2026
+ */
+public final class Graph<V> implements VertexGraph<V> {
+
+    /**
+     * Whether this graph treats edges as directed.
+     */
+    private final boolean directed;
+
+    /**
+     * The collection factories used for this graph's storage and algorithm scratch.
+     */
+    private final GraphCollections<V> collections;
+
+    /**
+     * All vertices in this graph, in insertion order.
+     */
+    private final Set<V> vertices;
+
+    /**
+     * Outgoing adjacency: vertex → set of successor vertices.
+     */
+    private final Map<V, Set<V>> successors;
+
+    /**
+     * Incoming adjacency: vertex → set of predecessor vertices.
+     */
+    private final Map<V, Set<V>> predecessors;
+
+    /**
+     * The complete set of edges derived from the adjacency maps.
+     */
+    private final Set<Edge<V>> edges;
+
+    /**
+     * Constructs a {@link Graph} from the given builder state using the provided collections.
+     *
+     * @param directed     whether the graph is directed
+     * @param collections  the collection factories for storage and algorithm scratch
+     * @param vertices     mutable insertion-ordered vertex set (will be deep-copied)
+     * @param successors   mutable outgoing adjacency map (will be deep-copied)
+     * @param predecessors mutable incoming adjacency map (will be deep-copied)
+     */
+    private Graph(final boolean directed,
+                  final GraphCollections<V> collections,
+                  final Set<V> vertices,
+                  final Map<V, Set<V>> successors,
+                  final Map<V, Set<V>> predecessors) {
+        this.directed = directed;
+        this.collections = collections;
+
+        final Set<V> vSet = collections.newVertexSet();
+        vSet.addAll(vertices);
+        this.vertices = Collections.unmodifiableSet(vSet);
+
+        this.successors = deepUnmodifiable(successors, collections);
+        this.predecessors = deepUnmodifiable(predecessors, collections);
+
+        final Set<Edge<V>> edgeSet = collections.newEdgeSet();
+        for (final var entry : successors.entrySet()) {
+            final V from = entry.getKey();
+            for (final V to : entry.getValue()) {
+                if (directed || !edgeSet.contains(new Edge<>(to, from))) {
+                    edgeSet.add(new Edge<>(from, to));
+                }
+            }
+        }
+        this.edges = Collections.unmodifiableSet(edgeSet);
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link Builder} for constructing a directed {@link Graph}.
+     *
+     * @param <V> the vertex type
+     * @return a new directed {@link Builder}
+     */
+    public static <V> Builder<V> directed() {
+        return new Builder<>(true);
+    }
+
+    /**
+     * Returns a {@link Builder} for constructing an undirected {@link Graph}.
+     * <p>
+     * When an edge {@code (u, v)} is added to an undirected graph, the reverse edge
+     * {@code (v, u)} is automatically implied.
+     *
+     * @param <V> the vertex type
+     * @return a new undirected {@link Builder}
+     */
+    public static <V> Builder<V> undirected() {
+        return new Builder<>(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Query methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all vertices in this graph.
+     *
+     * @return unmodifiable, insertion-ordered set of vertices
+     */
+    @Override
+    public Set<V> vertices() {
+        return vertices;
+    }
+
+    /**
+     * Returns all edges in this graph.
+     * <p>
+     * For undirected graphs, each undirected edge is represented as a single {@link Edge}
+     * with the {@code from} vertex being the one added first.
+     *
+     * @return unmodifiable set of edges
+     */
+    public Set<Edge<V>> edges() {
+        return edges;
+    }
+
+    /**
+     * Returns the set of vertices that {@code vertex} has outgoing edges to (its successors).
+     * Returns an empty set if {@code vertex} is not in the graph.
+     *
+     * @param vertex the vertex to query
+     * @return unmodifiable set of successor vertices
+     */
+    @Override
+    public Set<V> successors(final V vertex) {
+        return successors.getOrDefault(vertex, Set.of());
+    }
+
+    /**
+     * Returns the set of vertices that have outgoing edges to {@code vertex} (its predecessors).
+     * Returns an empty set if {@code vertex} is not in the graph.
+     *
+     * @param vertex the vertex to query
+     * @return unmodifiable set of predecessor vertices
+     */
+    @Override
+    public Set<V> predecessors(final V vertex) {
+        return predecessors.getOrDefault(vertex, Set.of());
+    }
+
+    /**
+     * Returns {@code true} if this graph contains the specified vertex.
+     *
+     * @param vertex the vertex to check
+     * @return {@code true} if {@code vertex} is in this graph
+     */
+    @Override
+    public boolean contains(final V vertex) {
+        return vertices.contains(vertex);
+    }
+
+    /**
+     * Returns {@code true} if this graph contains a directed edge from {@code from} to {@code to}.
+     * <p>
+     * For undirected graphs, also returns {@code true} if the reverse edge exists.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return {@code true} if the edge exists
+     */
+    @Override
+    public boolean hasEdge(final V from, final V to) {
+        return successors.getOrDefault(from, Set.of()).contains(to);
+    }
+
+    /**
+     * Returns {@code true} if this graph is directed.
+     *
+     * @return {@code true} for directed graphs, {@code false} for undirected
+     */
+    @Override
+    public boolean isDirected() {
+        return directed;
+    }
+
+    /**
+     * Returns the number of vertices in this graph.
+     *
+     * @return the vertex count
+     */
+    @Override
+    public int vertexCount() {
+        return vertices.size();
+    }
+
+    /**
+     * Returns the number of edges in this graph.
+     *
+     * @return the edge count
+     */
+    @Override
+    public int edgeCount() {
+        return edges.size();
+    }
+
+    /**
+     * Returns {@code true} if this graph has no vertices.
+     *
+     * @return {@code true} if the graph is empty
+     */
+    @Override
+    public boolean isEmpty() {
+        return vertices.isEmpty();
+    }
+
+    /**
+     * Returns the {@link GraphCollections} factory associated with this graph.
+     * <p>
+     * Graph algorithms in {@link Graphs} use this factory to allocate scratch collections
+     * (visited sets, parent maps, etc.) that match the backend in use for this graph.
+     *
+     * @return the collections factory
+     */
+    @Override
+    public GraphCollections<V> collections() {
+        return collections;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a deeply unmodifiable copy of the given adjacency map, using the supplied
+     * collections factory to allocate the backing sets.
+     *
+     * @param map  the mutable adjacency map
+     * @param col  the collections factory
+     * @param <V>  the vertex type
+     * @return unmodifiable adjacency map with unmodifiable neighbour sets
+     */
+    private static <V> Map<V, Set<V>> deepUnmodifiable(
+            final Map<V, Set<V>> map,
+            final GraphCollections<V> col) {
+        final Map<V, Set<V>> copy = col.newAdjacencyMap();
+        for (final var entry : map.entrySet()) {
+            final Set<V> neighbors = col.newNeighborSet();
+            neighbors.addAll(entry.getValue());
+            copy.put(entry.getKey(), Collections.unmodifiableSet(neighbors));
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    @Override
+    public String toString() {
+        return "Graph{directed=" + directed
+            + ", vertices=" + vertexCount()
+            + ", edges=" + edgeCount() + '}';
+    }
+
+    // =========================================================================
+    // Builder
+    // =========================================================================
+
+    /**
+     * A fluent builder for constructing immutable {@link Graph} instances.
+     * <p>
+     * The collection backend used by the resulting {@link Graph} may be configured via
+     * {@link #withCollections(GraphCollections)} before any vertices or edges are added.
+     *
+     * @param <V> the vertex type
+     */
+    public static final class Builder<V> {
+
+        /**
+         * Whether the graph being built is directed.
+         */
+        private final boolean directed;
+
+        /**
+         * The collections factory to use for the built graph.
+         */
+        private GraphCollections<V> collections = GraphCollections.standard();
+
+        /**
+         * Vertices in insertion order (builder scratch — always standard LinkedHashSet).
+         */
+        private final Set<V> vertices = new LinkedHashSet<>();
+
+        /**
+         * Mutable outgoing adjacency map (builder scratch — always standard LinkedHashSet).
+         */
+        private final java.util.HashMap<V, Set<V>> successors = new java.util.HashMap<>();
+
+        /**
+         * Mutable incoming adjacency map (builder scratch — always standard LinkedHashSet).
+         */
+        private final java.util.HashMap<V, Set<V>> predecessors = new java.util.HashMap<>();
+
+        /**
+         * Constructs a {@link Builder} for a directed or undirected graph.
+         *
+         * @param directed {@code true} for directed
+         */
+        private Builder(final boolean directed) {
+            this.directed = directed;
+        }
+
+        /**
+         * Sets the {@link GraphCollections} factory that the built {@link Graph} will use for
+         * its internal storage and for algorithm scratch allocations.
+         * <p>
+         * This method may be called at any point before {@link #build()}.
+         *
+         * @param collections the collections factory (must not be {@code null})
+         * @return this builder
+         */
+        public Builder<V> withCollections(final GraphCollections<V> collections) {
+            this.collections = Objects.requireNonNull(collections, "The collections factory cannot be null");
+            return this;
+        }
+
+        /**
+         * Adds the specified vertex to the graph being built.  If the vertex is already
+         * present, this is a no-op.
+         *
+         * @param vertex the vertex to add
+         * @return this builder
+         */
+        public Builder<V> addVertex(final V vertex) {
+            Objects.requireNonNull(vertex, "The vertex cannot be null");
+            vertices.add(vertex);
+            successors.computeIfAbsent(vertex, _ -> new LinkedHashSet<>());
+            predecessors.computeIfAbsent(vertex, _ -> new LinkedHashSet<>());
+            return this;
+        }
+
+        /**
+         * Adds a directed edge from {@code from} to {@code to}, implicitly adding both
+         * vertices if they are not already present.
+         * <p>
+         * For undirected graphs, the reverse edge is also recorded.
+         *
+         * @param from the source vertex
+         * @param to   the target vertex
+         * @return this builder
+         */
+        public Builder<V> addEdge(final V from, final V to) {
+            Objects.requireNonNull(from, "The from vertex cannot be null");
+            Objects.requireNonNull(to, "The to vertex cannot be null");
+
+            addVertex(from);
+            addVertex(to);
+
+            successors.get(from).add(to);
+            predecessors.get(to).add(from);
+
+            if (!directed) {
+                successors.get(to).add(from);
+                predecessors.get(from).add(to);
+            }
+
+            return this;
+        }
+
+        /**
+         * Adds the given {@link Edge} to the graph being built.
+         *
+         * @param edge the edge to add
+         * @return this builder
+         */
+        public Builder<V> addEdge(final Edge<V> edge) {
+            Objects.requireNonNull(edge, "The edge cannot be null");
+            return addEdge(edge.from(), edge.to());
+        }
+
+        /**
+         * Builds and returns an immutable {@link Graph} from the current builder state.
+         * <p>
+         * The graph's internal storage is allocated using the configured {@link GraphCollections}
+         * factory.
+         *
+         * @return a new immutable {@link Graph}
+         */
+        public Graph<V> build() {
+            return new Graph<>(directed, collections, vertices, successors, predecessors);
+        }
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphCollections.java
+++ b/base-graph/src/main/java/build/base/graph/GraphCollections.java
@@ -1,0 +1,139 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A factory for the collection types used by {@link Graph} and the graph algorithms in
+ * {@link Graphs}.
+ * <p>
+ * The default implementation, obtained via {@link #standard()}, uses standard JDK collections
+ * ({@code LinkedHashSet}, {@code HashMap}, etc.).  Alternative implementations may substitute
+ * higher-performance backends such as
+ * <a href="https://fastutil.di.unimi.it/">fastutil</a> open-addressing maps and sets.
+ * <p>
+ * A custom implementation is supplied to a {@link Graph.Builder} via
+ * {@link Graph.Builder#withCollections(GraphCollections)}:
+ * <pre>{@code
+ * Graph.<Integer>directed()
+ *     .withCollections(new MyFastutilGraphCollections())
+ *     .addEdge(1, 2)
+ *     .build();
+ * }</pre>
+ * <p>
+ * The interface covers both <em>graph storage</em> (the vertex set, adjacency maps, and edge
+ * cache held inside a {@link Graph}) and <em>algorithm scratch allocations</em> (the visited
+ * sets, parent maps, distance maps, and index maps used internally by {@link Graphs}).
+ *
+ * @param <V> the vertex type
+ * @author reed.von.redwitz
+ * @see WeightedGraphCollections
+ * @since Apr-2026
+ */
+public interface GraphCollections<V> {
+
+    // -------------------------------------------------------------------------
+    // Graph storage factories
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a new empty set for storing graph vertices, preserving insertion order.
+     *
+     * @return a new empty vertex set
+     */
+    Set<V> newVertexSet();
+
+    /**
+     * Returns a new empty map for storing adjacency information (vertex → neighbour set).
+     * <p>
+     * Used for both the successor and predecessor maps inside {@link Graph}.
+     *
+     * @return a new empty adjacency map
+     */
+    Map<V, Set<V>> newAdjacencyMap();
+
+    /**
+     * Returns a new empty set for storing the neighbours of a single vertex.
+     *
+     * @return a new empty neighbour set
+     */
+    Set<V> newNeighborSet();
+
+    /**
+     * Returns a new empty set for storing {@link Edge} objects (the edge cache).
+     *
+     * @return a new empty edge set
+     */
+    Set<Edge<V>> newEdgeSet();
+
+    // -------------------------------------------------------------------------
+    // Algorithm scratch factories
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a new empty set for algorithm scratch use (e.g. visited sets,
+     * on-stack markers, SCC membership).
+     * <p>
+     * Ordering within this set is not guaranteed.
+     *
+     * @return a new empty scratch set
+     */
+    Set<V> newSet();
+
+    /**
+     * Returns a new empty map from vertices to an arbitrary value type {@code T}, for
+     * algorithm scratch use (e.g. parent maps, distance maps, colour maps).
+     *
+     * @param <T> the value type
+     * @return a new empty scratch map
+     */
+    <T> Map<V, T> newMap();
+
+    /**
+     * Returns a new empty map from vertices to {@link Integer} values, for algorithm
+     * scratch use (e.g. in-degree counts, DFS index and lowlink values, layer numbers).
+     * <p>
+     * A dedicated method is provided so that implementations may substitute a
+     * primitive-value specialisation (e.g. {@code fastutil}'s {@code Object2IntOpenHashMap}
+     * or {@code IntIntOpenHashMap}) to avoid boxing overhead.
+     *
+     * @return a new empty integer-valued scratch map
+     */
+    Map<V, Integer> newIntMap();
+
+    // -------------------------------------------------------------------------
+    // Default implementation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the standard JDK-backed implementation of {@link GraphCollections}.
+     * <p>
+     * Uses {@code LinkedHashSet} for ordered sets and {@code HashMap} for maps.
+     *
+     * @param <V> the vertex type
+     * @return the standard {@link GraphCollections} implementation
+     */
+    static <V> GraphCollections<V> standard() {
+        return new StandardGraphCollections<>();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphConnectivity.java
+++ b/base-graph/src/main/java/build/base/graph/GraphConnectivity.java
@@ -1,0 +1,153 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Connectivity algorithms operating on {@link VertexGraph}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class GraphConnectivity {
+
+    private GraphConnectivity() {
+        // utility class
+    }
+
+    /**
+     * Returns all strongly connected components (SCCs) of the graph using Tarjan's algorithm.
+     * <p>
+     * The components are returned in reverse topological order of the condensation DAG.
+     * A single-vertex component is a trivial SCC.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the directed graph to analyse
+     * @return list of SCCs in reverse topological order
+     * @throws IllegalArgumentException if the graph is undirected
+     */
+    public static <V> List<Component<V>> stronglyConnectedComponents(final VertexGraph<V> graph) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        if (!graph.isDirected()) {
+            throw new IllegalArgumentException("Strongly connected components requires a directed graph");
+        }
+
+        final TarjanState<V> state = new TarjanState<>(graph.collections());
+
+        for (final V vertex : graph.vertices()) {
+            if (!state.index.containsKey(vertex)) {
+                tarjanDfs(graph, vertex, state);
+            }
+        }
+
+        return List.copyOf(state.components);
+    }
+
+    /**
+     * Iterative Tarjan's SCC algorithm state.
+     *
+     * @param <V> the vertex type
+     */
+    private static final class TarjanState<V> {
+
+        final GraphCollections<V> col;
+        int counter = 0;
+        final Map<V, Integer> index;
+        final Map<V, Integer> lowlink;
+        final Set<V> onStack;
+        final ArrayDeque<V> stack = new ArrayDeque<>();
+        final List<Component<V>> components = new ArrayList<>();
+
+        TarjanState(final GraphCollections<V> col) {
+            this.col = col;
+            this.index = col.newIntMap();
+            this.lowlink = col.newIntMap();
+            this.onStack = col.newSet();
+        }
+    }
+
+    /**
+     * Iterative DFS for Tarjan's SCC.
+     */
+    private static <V> void tarjanDfs(final VertexGraph<V> graph,
+                                       final V root,
+                                       final TarjanState<V> state) {
+        record Frame<V>(V vertex, java.util.Iterator<V> iterator) {
+        }
+
+        final ArrayDeque<Frame<V>> callStack = new ArrayDeque<>();
+
+        state.index.put(root, state.counter);
+        state.lowlink.put(root, state.counter);
+        state.counter++;
+        state.stack.push(root);
+        state.onStack.add(root);
+        callStack.push(new Frame<>(root, graph.successors(root).iterator()));
+
+        while (!callStack.isEmpty()) {
+            final Frame<V> frame = callStack.peek();
+            final V v = frame.vertex();
+
+            if (frame.iterator().hasNext()) {
+                final V w = frame.iterator().next();
+
+                if (!state.index.containsKey(w)) {
+                    state.index.put(w, state.counter);
+                    state.lowlink.put(w, state.counter);
+                    state.counter++;
+                    state.stack.push(w);
+                    state.onStack.add(w);
+                    callStack.push(new Frame<>(w, graph.successors(w).iterator()));
+                } else if (state.onStack.contains(w)) {
+                    state.lowlink.merge(v, state.index.get(w), Math::min);
+                }
+            } else {
+                callStack.pop();
+
+                if (!callStack.isEmpty()) {
+                    final V parent = callStack.peek().vertex();
+                    state.lowlink.merge(parent, state.lowlink.get(v), Math::min);
+                }
+
+                if (state.lowlink.get(v).equals(state.index.get(v))) {
+                    final Set<V> component = state.col.newSet();
+                    V w;
+                    do {
+                        w = state.stack.pop();
+                        state.onStack.remove(w);
+                        component.add(w);
+                    }
+                    while (!w.equals(v));
+
+                    state.components.add(new Component<>(component));
+                }
+            }
+        }
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphCycles.java
+++ b/base-graph/src/main/java/build/base/graph/GraphCycles.java
@@ -1,0 +1,150 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Cycle detection algorithms operating on {@link VertexGraph}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class GraphCycles {
+
+    private GraphCycles() {
+        // utility class
+    }
+
+    /**
+     * Returns {@code true} if the graph contains at least one directed cycle.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the graph to check
+     * @return {@code true} if a cycle exists
+     */
+    public static <V> boolean hasCycle(final VertexGraph<V> graph) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        return findCycle(graph).isPresent();
+    }
+
+    /**
+     * Attempts to find a directed cycle in the graph and returns it as an ordered list
+     * of vertices forming the cycle.
+     * <p>
+     * If a cycle exists, the returned list begins and ends with the same vertex
+     * (e.g. {@code [A, B, C, A]}).  If no cycle exists, {@link Optional#empty()} is returned.
+     * <p>
+     * Uses iterative DFS with tri-colour marking (white/gray/black).
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the graph to search
+     * @return an {@link Optional} containing a cycle path, or empty if the graph is acyclic
+     */
+    public static <V> Optional<List<V>> findCycle(final VertexGraph<V> graph) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+
+        final GraphCollections<V> col = graph.collections();
+
+        // 0 = unvisited, 1 = in-progress (gray), 2 = done (black)
+        final Map<V, Integer> color = col.newIntMap();
+        final Map<V, V> parent = col.newMap();
+
+        for (final V vertex : graph.vertices()) {
+            color.put(vertex, 0);
+        }
+
+        for (final V start : graph.vertices()) {
+            if (color.get(start) != 0) {
+                continue;
+            }
+
+            final ArrayDeque<V> dfsStack = new ArrayDeque<>();
+            final Map<V, java.util.Iterator<V>> iteratorState = col.newMap();
+
+            color.put(start, 1);
+            dfsStack.push(start);
+            iteratorState.put(start, graph.successors(start).iterator());
+
+            while (!dfsStack.isEmpty()) {
+                final V current = dfsStack.peek();
+                final java.util.Iterator<V> iter = iteratorState.get(current);
+
+                if (iter.hasNext()) {
+                    final V next = iter.next();
+                    final int nextColor = color.getOrDefault(next, 0);
+
+                    if (nextColor == 1) {
+                        // Back edge found — reconstruct cycle
+                        return Optional.of(reconstructCycle(parent, next, current));
+                    } else if (nextColor == 0) {
+                        color.put(next, 1);
+                        parent.put(next, current);
+                        dfsStack.push(next);
+                        iteratorState.put(next, graph.successors(next).iterator());
+                    }
+                    // nextColor == 2: already fully explored, skip
+                } else {
+                    color.put(current, 2);
+                    dfsStack.pop();
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Reconstructs the cycle path from parent tracking.
+     *
+     * @param parent   the parent map from DFS
+     * @param cycleEnd the vertex where the back edge lands (start of cycle)
+     * @param current  the vertex with the back edge (end of cycle before wrap)
+     * @param <V>      the vertex type
+     * @return the cycle as a list from {@code cycleEnd} back to {@code cycleEnd}
+     */
+    private static <V> List<V> reconstructCycle(final Map<V, V> parent,
+                                                 final V cycleEnd,
+                                                 final V current) {
+        final ArrayDeque<V> cycle = new ArrayDeque<>();
+        cycle.addFirst(cycleEnd);
+
+        V node = current;
+        while (!node.equals(cycleEnd)) {
+            cycle.addFirst(node);
+            node = parent.get(node);
+            if (node == null) {
+                break;
+            }
+        }
+
+        cycle.addFirst(cycleEnd);
+        return List.copyOf(cycle);
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphOrdering.java
+++ b/base-graph/src/main/java/build/base/graph/GraphOrdering.java
@@ -1,0 +1,182 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Topological ordering algorithms operating on {@link VertexGraph}.
+ * <p>
+ * All methods require the input graph to be a DAG (directed acyclic graph).
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class GraphOrdering {
+
+    private GraphOrdering() {
+        // utility class
+    }
+
+    /**
+     * Returns a topological ordering of all vertices in the graph using Kahn's algorithm.
+     * <p>
+     * In a topological order, for every directed edge {@code (u, v)}, vertex {@code u}
+     * appears before vertex {@code v}.  This is the natural build order for a dependency graph.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the directed graph to sort (must be a DAG)
+     * @return vertices in topological order
+     * @throws IllegalArgumentException if the graph is undirected, or contains a cycle
+     */
+    public static <V> List<V> topologicalSort(final VertexGraph<V> graph) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        if (!graph.isDirected()) {
+            throw new IllegalArgumentException("Topological sort requires a directed graph");
+        }
+
+        // Edge convention: A → B means "A depends on B". Nodes with no outgoing edges
+        // (no dependencies) are processed first — this is the natural build order.
+        final GraphCollections<V> col = graph.collections();
+        final Map<V, Integer> outDegree = col.newIntMap();
+
+        for (final V vertex : graph.vertices()) {
+            outDegree.put(vertex, graph.successors(vertex).size());
+        }
+
+        final ArrayDeque<V> queue = new ArrayDeque<>();
+        for (final V vertex : graph.vertices()) {
+            if (outDegree.get(vertex) == 0) {
+                queue.add(vertex);
+            }
+        }
+
+        final List<V> result = new ArrayList<>(graph.vertexCount());
+
+        while (!queue.isEmpty()) {
+            final V current = queue.poll();
+            result.add(current);
+
+            for (final V predecessor : graph.predecessors(current)) {
+                final int remaining = outDegree.merge(predecessor, -1, Integer::sum);
+                if (remaining == 0) {
+                    queue.add(predecessor);
+                }
+            }
+        }
+
+        if (result.size() != graph.vertexCount()) {
+            throw new IllegalArgumentException(
+                "The graph contains a cycle and cannot be topologically sorted");
+        }
+
+        return List.copyOf(result);
+    }
+
+    /**
+     * Returns the vertices of a DAG grouped into parallelizable layers.
+     * <p>
+     * Layer 0 contains vertices with no predecessors.  Layer {@code k} contains vertices
+     * whose predecessors all appear in earlier layers.  All vertices within the same layer
+     * are independent of each other and may be processed concurrently.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the directed graph to partition (must be a DAG)
+     * @return ordered list of layers; each layer is an unmodifiable set of vertices
+     * @throws IllegalArgumentException if the graph is undirected, or contains a cycle
+     */
+    public static <V> List<Set<V>> parallelizableGroups(final VertexGraph<V> graph) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        if (!graph.isDirected()) {
+            throw new IllegalArgumentException("Parallelizable groups requires a directed graph");
+        }
+
+        // Edge convention: A → B means "A depends on B". Layer 0 = nodes with no outgoing
+        // edges (no dependencies). Layer k = nodes all of whose dependencies are in layers 0..k-1.
+        final GraphCollections<V> col = graph.collections();
+        final Map<V, Integer> layer = col.newIntMap();
+        final Map<V, Integer> remaining = col.newIntMap();  // unprocessed successor count
+
+        for (final V vertex : graph.vertices()) {
+            remaining.put(vertex, graph.successors(vertex).size());
+        }
+
+        final ArrayDeque<V> queue = new ArrayDeque<>();
+        for (final V vertex : graph.vertices()) {
+            if (remaining.get(vertex) == 0) {
+                queue.add(vertex);
+                layer.put(vertex, 0);
+            }
+        }
+
+        int processedCount = 0;
+
+        while (!queue.isEmpty()) {
+            final V current = queue.poll();
+            processedCount++;
+            final int currentLayer = layer.get(current);
+
+            for (final V predecessor : graph.predecessors(current)) {
+                // predecessor can be placed in at least currentLayer + 1
+                layer.merge(predecessor, currentLayer + 1, Math::max);
+
+                final int rem = remaining.merge(predecessor, -1, Integer::sum);
+                if (rem == 0) {
+                    queue.add(predecessor);
+                }
+            }
+        }
+
+        if (processedCount != graph.vertexCount()) {
+            throw new IllegalArgumentException(
+                "The graph contains a cycle and cannot be partitioned into parallelizable groups");
+        }
+
+        if (layer.isEmpty()) {
+            return List.of();
+        }
+
+        final int maxLayer = layer.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+        final List<Set<V>> groups = new ArrayList<>(maxLayer + 1);
+
+        for (int i = 0; i <= maxLayer; i++) {
+            groups.add(col.newSet());
+        }
+
+        for (final Map.Entry<V, Integer> entry : layer.entrySet()) {
+            groups.get(entry.getValue()).add(entry.getKey());
+        }
+
+        return groups.stream()
+            .map(Collections::unmodifiableSet)
+            .toList();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphPaths.java
+++ b/base-graph/src/main/java/build/base/graph/GraphPaths.java
@@ -1,0 +1,194 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.function.BinaryOperator;
+
+/**
+ * Shortest-path algorithms operating on {@link VertexGraph} and {@link WeightedGraph}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class GraphPaths {
+
+    private GraphPaths() {
+        // utility class
+    }
+
+    /**
+     * Finds the shortest path (by number of hops) between {@code start} and {@code end}
+     * in an unweighted graph using BFS.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the graph to search
+     * @param start the starting vertex
+     * @param end   the target vertex
+     * @return an {@link Optional} containing the shortest {@link Path}, or empty if unreachable
+     */
+    public static <V> Optional<Path<V>> shortestPath(final VertexGraph<V> graph,
+                                                      final V start,
+                                                      final V end) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(start, "The start vertex cannot be null");
+        Objects.requireNonNull(end, "The end vertex cannot be null");
+
+        if (start.equals(end)) {
+            return Optional.of(Path.of(start));
+        }
+
+        final GraphCollections<V> col = graph.collections();
+        final Map<V, V> parent = col.newMap();
+        final ArrayDeque<V> queue = new ArrayDeque<>();
+
+        parent.put(start, null);
+        queue.add(start);
+
+        while (!queue.isEmpty()) {
+            final V current = queue.poll();
+
+            for (final V successor : graph.successors(current)) {
+                if (!parent.containsKey(successor)) {
+                    parent.put(successor, current);
+
+                    if (successor.equals(end)) {
+                        return Optional.of(buildPath(parent, start, end));
+                    }
+
+                    queue.add(successor);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Finds the shortest (minimum weight) path between {@code start} and {@code end} in a
+     * weighted graph using Dijkstra's algorithm.
+     * <p>
+     * The weight type {@code W} must be {@link Comparable}.  A {@code zero} value (the additive
+     * identity) and a {@code add} operator are required to accumulate path weights.
+     * <p>
+     * Time complexity: O(E log E) — uses lazy deletion to avoid O(V) priority-queue removes.
+     * <p>
+     * Example for integer weights:
+     * <pre>{@code
+     * GraphPaths.shortestPath(graph, "A", "D", 0, Integer::sum)
+     * }</pre>
+     *
+     * @param <V>   the vertex type
+     * @param <W>   the weight type (must be {@link Comparable})
+     * @param graph the weighted graph to search
+     * @param start the starting vertex
+     * @param end   the target vertex
+     * @param zero  the zero (additive identity) value for the weight type
+     * @param add   the binary operator used to accumulate edge weights
+     * @return an {@link Optional} containing the shortest {@link WeightedPath}, or empty if unreachable
+     */
+    public static <V, W extends Comparable<W>> Optional<WeightedPath<V, W>> shortestPath(final WeightedGraph<V, W> graph,
+                                                                                          final V start,
+                                                                                          final V end,
+                                                                                          final W zero,
+                                                                                          final BinaryOperator<W> add) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(start, "The start vertex cannot be null");
+        Objects.requireNonNull(end, "The end vertex cannot be null");
+        Objects.requireNonNull(zero, "The zero value cannot be null");
+        Objects.requireNonNull(add, "The add operator cannot be null");
+
+        if (start.equals(end)) {
+            return Optional.of(WeightedPath.of(start, zero));
+        }
+
+        final GraphCollections<V> col = graph.collections();
+        final Map<V, W> dist = col.newMap();
+        final Map<V, WeightedPath<V, W>> paths = col.newMap();
+        final Set<V> settled = col.newSet();
+        final PriorityQueue<V> pq = new PriorityQueue<>((a, b) -> dist.get(a).compareTo(dist.get(b)));
+
+        dist.put(start, zero);
+        paths.put(start, WeightedPath.of(start, zero));
+        pq.add(start);
+
+        while (!pq.isEmpty()) {
+            final V current = pq.poll();
+
+            // Lazy deletion: skip stale entries (a shorter path was already settled)
+            if (!settled.add(current)) {
+                continue;
+            }
+
+            if (current.equals(end)) {
+                return Optional.of(paths.get(current));
+            }
+
+            final W currentDist = dist.get(current);
+
+            for (final V successor : graph.successors(current)) {
+                if (settled.contains(successor)) {
+                    continue;
+                }
+                final WeightedEdge<V, W> edge = graph.edge(current, successor).orElseThrow();
+                final W newDist = add.apply(currentDist, edge.weight());
+                final W existing = dist.get(successor);
+
+                if (existing == null || newDist.compareTo(existing) < 0) {
+                    dist.put(successor, newDist);
+                    paths.put(successor, paths.get(current).extend(successor, edge, add));
+                    pq.add(successor); // old entry remains; will be skipped when polled
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Reconstructs a {@link Path} from a BFS parent map.
+     *
+     * @param parent the parent map from BFS ({@code null} value for {@code start})
+     * @param start  the start vertex
+     * @param end    the end vertex
+     * @param <V>    the vertex type
+     * @return the reconstructed path
+     */
+    private static <V> Path<V> buildPath(final Map<V, V> parent, final V start, final V end) {
+        final ArrayDeque<V> pathStack = new ArrayDeque<>();
+        V current = end;
+
+        while (current != null) {
+            pathStack.addFirst(current);
+            current = parent.get(current);
+        }
+
+        return Path.of(new ArrayList<>(pathStack));
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphReduction.java
+++ b/base-graph/src/main/java/build/base/graph/GraphReduction.java
@@ -1,0 +1,89 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Graph reduction algorithms operating on {@link VertexGraph}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class GraphReduction {
+
+    private GraphReduction() {
+        // utility class
+    }
+
+    /**
+     * Returns a transitively reduced version of the given directed graph — the graph with
+     * the fewest edges that preserves all reachability relationships.
+     * <p>
+     * An edge {@code (u, v)} is removed if {@code v} is reachable from {@code u} via a path
+     * of length ≥ 2 (i.e. the direct edge is redundant).
+     * <p>
+     * Time complexity: O(V · (V + E)) — reachability is precomputed once per vertex via BFS,
+     * then each edge check is O(1).
+     *
+     * @param <V>   the vertex type
+     * @param graph the directed graph to reduce
+     * @return a new {@link Graph} with redundant edges removed
+     * @throws IllegalArgumentException if the graph is undirected
+     */
+    public static <V> Graph<V> transitiveReduction(final VertexGraph<V> graph) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        if (!graph.isDirected()) {
+            throw new IllegalArgumentException("Transitive reduction requires a directed graph");
+        }
+
+        final GraphCollections<V> col = graph.collections();
+
+        // Precompute reachability from every vertex once: O(V · (V+E))
+        final Map<V, Set<V>> reachable = col.newMap();
+        for (final V v : graph.vertices()) {
+            reachable.put(v, GraphTraversal.reachableFrom(graph, v));
+        }
+
+        final Graph.Builder<V> builder = Graph.<V>directed().withCollections(col);
+        graph.vertices().forEach(builder::addVertex);
+
+        for (final V u : graph.vertices()) {
+            for (final V v : graph.successors(u)) {
+                // Edge (u,v) is redundant if v is reachable from u via another successor
+                boolean redundant = false;
+                for (final V w : graph.successors(u)) {
+                    if (!w.equals(v) && reachable.get(w).contains(v)) {
+                        redundant = true;
+                        break;
+                    }
+                }
+                if (!redundant) {
+                    builder.addEdge(u, v);
+                }
+            }
+        }
+
+        return builder.build();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/GraphTraversal.java
+++ b/base-graph/src/main/java/build/base/graph/GraphTraversal.java
@@ -1,0 +1,226 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Graph traversal and reachability algorithms operating on {@link VertexGraph}.
+ * <p>
+ * All methods are stateless and accept any {@link VertexGraph} implementation —
+ * {@link Graph}, {@link WeightedGraph}, or future types such as multigraphs.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class GraphTraversal {
+
+    private GraphTraversal() {
+        // utility class
+    }
+
+    // =========================================================================
+    // Traversal
+    // =========================================================================
+
+    /**
+     * Returns a breadth-first traversal of the graph starting from {@code start}.
+     * <p>
+     * Only vertices reachable from {@code start} are included.  If {@code start} is not in
+     * the graph, a list containing only {@code start} is returned.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the graph to traverse
+     * @param start the starting vertex
+     * @return vertices in BFS order, beginning with {@code start}
+     */
+    public static <V> List<V> breadthFirstSearch(final VertexGraph<V> graph, final V start) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(start, "The start vertex cannot be null");
+
+        final GraphCollections<V> col = graph.collections();
+        final List<V> result = new ArrayList<>();
+        final Set<V> visited = col.newSet();
+        final ArrayDeque<V> queue = new ArrayDeque<>();
+
+        queue.add(start);
+        visited.add(start);
+
+        while (!queue.isEmpty()) {
+            final V current = queue.poll();
+            result.add(current);
+
+            for (final V successor : graph.successors(current)) {
+                if (visited.add(successor)) {
+                    queue.add(successor);
+                }
+            }
+        }
+
+        return List.copyOf(result);
+    }
+
+    /**
+     * Returns a depth-first traversal of the graph starting from {@code start}.
+     * <p>
+     * Only vertices reachable from {@code start} are included.  The traversal uses an
+     * iterative approach to avoid stack overflow on deep graphs.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the graph to traverse
+     * @param start the starting vertex
+     * @return vertices in DFS order (pre-order), beginning with {@code start}
+     */
+    public static <V> List<V> depthFirstSearch(final VertexGraph<V> graph, final V start) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(start, "The start vertex cannot be null");
+
+        final GraphCollections<V> col = graph.collections();
+        final List<V> result = new ArrayList<>();
+        final Set<V> visited = col.newSet();
+        final ArrayDeque<V> stack = new ArrayDeque<>();
+
+        stack.push(start);
+
+        while (!stack.isEmpty()) {
+            final V current = stack.pop();
+
+            if (visited.add(current)) {
+                result.add(current);
+
+                // Push in reverse to preserve natural iteration order
+                final List<V> successors = new ArrayList<>(graph.successors(current));
+                Collections.reverse(successors);
+                for (final V successor : successors) {
+                    if (!visited.contains(successor)) {
+                        stack.push(successor);
+                    }
+                }
+            }
+        }
+
+        return List.copyOf(result);
+    }
+
+    // =========================================================================
+    // Reachability
+    // =========================================================================
+
+    /**
+     * Returns all vertices reachable from {@code start} via outgoing edges, excluding
+     * {@code start} itself (unless there is a cycle back to it).
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>   the vertex type
+     * @param graph the graph to query
+     * @param start the starting vertex
+     * @return unmodifiable set of reachable vertices (not including {@code start} unless cyclic)
+     */
+    public static <V> Set<V> reachableFrom(final VertexGraph<V> graph, final V start) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(start, "The start vertex cannot be null");
+
+        final GraphCollections<V> col = graph.collections();
+        final Set<V> reachable = col.newSet();
+        final ArrayDeque<V> queue = new ArrayDeque<>();
+
+        for (final V successor : graph.successors(start)) {
+            if (reachable.add(successor)) {
+                queue.add(successor);
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            final V current = queue.poll();
+            for (final V successor : graph.successors(current)) {
+                if (reachable.add(successor)) {
+                    queue.add(successor);
+                }
+            }
+        }
+
+        return Collections.unmodifiableSet(reachable);
+    }
+
+    /**
+     * Returns all ancestors of {@code vertex} — vertices from which {@code vertex} is reachable
+     * by following outgoing edges.  The vertex itself is not included unless there is a cycle.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>    the vertex type
+     * @param graph  the graph to query
+     * @param vertex the vertex whose ancestors to find
+     * @return unmodifiable set of ancestor vertices
+     */
+    public static <V> Set<V> ancestors(final VertexGraph<V> graph, final V vertex) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(vertex, "The vertex cannot be null");
+
+        final GraphCollections<V> col = graph.collections();
+        final Set<V> result = col.newSet();
+        final ArrayDeque<V> queue = new ArrayDeque<>();
+
+        for (final V pred : graph.predecessors(vertex)) {
+            if (result.add(pred)) {
+                queue.add(pred);
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            final V current = queue.poll();
+            for (final V pred : graph.predecessors(current)) {
+                if (result.add(pred)) {
+                    queue.add(pred);
+                }
+            }
+        }
+
+        return Collections.unmodifiableSet(result);
+    }
+
+    /**
+     * Returns all descendants of {@code vertex} — vertices reachable from {@code vertex}
+     * by following outgoing edges.  The vertex itself is not included unless there is a cycle.
+     * <p>
+     * Time complexity: O(V + E).
+     *
+     * @param <V>    the vertex type
+     * @param graph  the graph to query
+     * @param vertex the vertex whose descendants to find
+     * @return unmodifiable set of descendant vertices
+     */
+    public static <V> Set<V> descendants(final VertexGraph<V> graph, final V vertex) {
+        Objects.requireNonNull(graph, "The graph cannot be null");
+        Objects.requireNonNull(vertex, "The vertex cannot be null");
+        return reachableFrom(graph, vertex);
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/Graphs.java
+++ b/base-graph/src/main/java/build/base/graph/Graphs.java
@@ -1,0 +1,172 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BinaryOperator;
+
+/**
+ * Convenience facade over all graph algorithm classes.
+ * <p>
+ * Delegates to the domain-specific classes:
+ * <ul>
+ *   <li>Traversal and reachability — {@link GraphTraversal}</li>
+ *   <li>Topological ordering — {@link GraphOrdering}</li>
+ *   <li>Cycle detection — {@link GraphCycles}</li>
+ *   <li>Shortest paths — {@link GraphPaths}</li>
+ *   <li>Strongly connected components — {@link GraphConnectivity}</li>
+ *   <li>Transitive reduction — {@link GraphReduction}</li>
+ * </ul>
+ * All methods accept any {@link VertexGraph} implementation.  Prefer calling the domain
+ * classes directly when only a single algorithm family is needed.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public final class Graphs {
+
+    private Graphs() {
+        // utility class
+    }
+
+    // =========================================================================
+    // Traversal — delegates to GraphTraversal
+    // =========================================================================
+
+    /**
+     * @see GraphTraversal#breadthFirstSearch(VertexGraph, Object)
+     */
+    public static <V> List<V> breadthFirstSearch(final VertexGraph<V> graph, final V start) {
+        return GraphTraversal.breadthFirstSearch(graph, start);
+    }
+
+    /**
+     * @see GraphTraversal#depthFirstSearch(VertexGraph, Object)
+     */
+    public static <V> List<V> depthFirstSearch(final VertexGraph<V> graph, final V start) {
+        return GraphTraversal.depthFirstSearch(graph, start);
+    }
+
+    /**
+     * @see GraphTraversal#reachableFrom(VertexGraph, Object)
+     */
+    public static <V> Set<V> reachableFrom(final VertexGraph<V> graph, final V start) {
+        return GraphTraversal.reachableFrom(graph, start);
+    }
+
+    /**
+     * @see GraphTraversal#ancestors(VertexGraph, Object)
+     */
+    public static <V> Set<V> ancestors(final VertexGraph<V> graph, final V vertex) {
+        return GraphTraversal.ancestors(graph, vertex);
+    }
+
+    /**
+     * @see GraphTraversal#descendants(VertexGraph, Object)
+     */
+    public static <V> Set<V> descendants(final VertexGraph<V> graph, final V vertex) {
+        return GraphTraversal.descendants(graph, vertex);
+    }
+
+    // =========================================================================
+    // Ordering — delegates to GraphOrdering
+    // =========================================================================
+
+    /**
+     * @see GraphOrdering#topologicalSort(VertexGraph)
+     */
+    public static <V> List<V> topologicalSort(final VertexGraph<V> graph) {
+        return GraphOrdering.topologicalSort(graph);
+    }
+
+    /**
+     * @see GraphOrdering#parallelizableGroups(VertexGraph)
+     */
+    public static <V> List<Set<V>> parallelizableGroups(final VertexGraph<V> graph) {
+        return GraphOrdering.parallelizableGroups(graph);
+    }
+
+    // =========================================================================
+    // Cycles — delegates to GraphCycles
+    // =========================================================================
+
+    /**
+     * @see GraphCycles#hasCycle(VertexGraph)
+     */
+    public static <V> boolean hasCycle(final VertexGraph<V> graph) {
+        return GraphCycles.hasCycle(graph);
+    }
+
+    /**
+     * @see GraphCycles#findCycle(VertexGraph)
+     */
+    public static <V> Optional<List<V>> findCycle(final VertexGraph<V> graph) {
+        return GraphCycles.findCycle(graph);
+    }
+
+    // =========================================================================
+    // Shortest paths — delegates to GraphPaths
+    // =========================================================================
+
+    /**
+     * @see GraphPaths#shortestPath(VertexGraph, Object, Object)
+     */
+    public static <V> Optional<Path<V>> shortestPath(final VertexGraph<V> graph,
+                                                      final V start,
+                                                      final V end) {
+        return GraphPaths.shortestPath(graph, start, end);
+    }
+
+    /**
+     * @see GraphPaths#shortestPath(WeightedGraph, Object, Object, Comparable, BinaryOperator)
+     */
+    public static <V, W extends Comparable<W>> Optional<WeightedPath<V, W>> shortestPath(final WeightedGraph<V, W> graph,
+                                                                                          final V start,
+                                                                                          final V end,
+                                                                                          final W zero,
+                                                                                          final BinaryOperator<W> add) {
+        return GraphPaths.shortestPath(graph, start, end, zero, add);
+    }
+
+    // =========================================================================
+    // Connectivity — delegates to GraphConnectivity
+    // =========================================================================
+
+    /**
+     * @see GraphConnectivity#stronglyConnectedComponents(VertexGraph)
+     */
+    public static <V> List<Component<V>> stronglyConnectedComponents(final VertexGraph<V> graph) {
+        return GraphConnectivity.stronglyConnectedComponents(graph);
+    }
+
+    // =========================================================================
+    // Reduction — delegates to GraphReduction
+    // =========================================================================
+
+    /**
+     * @see GraphReduction#transitiveReduction(VertexGraph)
+     */
+    public static <V> Graph<V> transitiveReduction(final VertexGraph<V> graph) {
+        return GraphReduction.transitiveReduction(graph);
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/MultiEdge.java
+++ b/base-graph/src/main/java/build/base/graph/MultiEdge.java
@@ -1,0 +1,106 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Objects;
+
+/**
+ * A directed edge in a {@link Multigraph} with reference-based identity.
+ * <p>
+ * Unlike {@link Edge}, which is a record whose identity is defined by its {@code (from, to)}
+ * vertex pair, {@code MultiEdge} uses default {@link Object} identity — two {@code MultiEdge}
+ * instances are equal only if they are the same object.  This allows multiple parallel edges
+ * between the same pair of vertices to coexist and remain independently referenceable.
+ * <p>
+ * Instances are created exclusively by {@link Multigraph.Builder#addEdge(Object, Object)},
+ * which returns the created edge so callers can retain a reference to each specific edge.
+ *
+ * @param <V> the vertex type
+ * @author reed.von.redwitz
+ * @see Edge
+ * @see Multigraph
+ * @since Apr-2026
+ */
+public final class MultiEdge<V> {
+
+    private final V from;
+    private final V to;
+
+    /**
+     * Constructs a {@link MultiEdge}.  Package-private — created only by
+     * {@link Multigraph.Builder}.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     */
+    MultiEdge(final V from, final V to) {
+        this.from = Objects.requireNonNull(from, "The from vertex cannot be null");
+        this.to = Objects.requireNonNull(to, "The to vertex cannot be null");
+    }
+
+    /**
+     * Returns the source vertex of this edge.
+     *
+     * @return the source vertex
+     */
+    public V from() {
+        return from;
+    }
+
+    /**
+     * Returns the target vertex of this edge.
+     *
+     * @return the target vertex
+     */
+    public V to() {
+        return to;
+    }
+
+    /**
+     * Returns {@code true} if this edge is a self-loop (i.e. {@code from} equals {@code to}).
+     *
+     * @return {@code true} if this is a self-loop
+     */
+    public boolean isSelfLoop() {
+        return from.equals(to);
+    }
+
+    /**
+     * Returns the unweighted {@link Edge} representation of this edge, discarding identity.
+     * <p>
+     * Note: the returned {@link Edge} is a value type — any other edge with the same
+     * {@code (from, to)} pair will be considered equal to it.
+     *
+     * @return an {@link Edge} with the same endpoints
+     */
+    public Edge<V> toEdge() {
+        return new Edge<>(from, to);
+    }
+
+    // No equals/hashCode override — identity is reference identity (Object default).
+    // This is intentional: two MultiEdge instances are the same edge only if they are
+    // the same object, allowing parallel edges between the same vertex pair.
+
+    @Override
+    public String toString() {
+        return "MultiEdge{" + from + " -> " + to + "}@" + Integer.toHexString(System.identityHashCode(this));
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/Multigraph.java
+++ b/base-graph/src/main/java/build/base/graph/Multigraph.java
@@ -1,0 +1,376 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An immutable directed or undirected multigraph — a graph that permits multiple parallel
+ * edges between the same pair of vertices.
+ * <p>
+ * Graphs are constructed via {@link Builder} obtained from {@link #directed()} or
+ * {@link #undirected()}.  Once built, the graph is fully immutable.
+ * <p>
+ * Unlike {@link Graph}, which uses the {@code (from, to)} vertex pair as edge identity,
+ * {@link Multigraph} uses {@link MultiEdge} instances with reference identity.  Each call
+ * to {@link Builder#addEdge(Object, Object)} creates a new, distinct edge even if an edge
+ * between the same vertices already exists.  The builder returns the created {@link MultiEdge}
+ * so callers can retain references to specific edges.
+ * <p>
+ * Because {@link Multigraph} implements {@link VertexGraph}, all graph algorithms in
+ * {@link GraphTraversal}, {@link GraphOrdering}, {@link GraphCycles}, {@link GraphConnectivity},
+ * and {@link GraphReduction} apply directly without conversion.
+ *
+ * @param <V> the vertex type
+ * @author reed.von.redwitz
+ * @see Graph
+ * @see MultiEdge
+ * @see VertexGraph
+ * @since Apr-2026
+ */
+public final class Multigraph<V> implements VertexGraph<V> {
+
+    private final boolean directed;
+    private final GraphCollections<V> collections;
+    private final Set<V> vertices;
+
+    /**
+     * Outgoing adjacency: vertex → list of outgoing edges (in insertion order).
+     * Lists may contain multiple edges to the same target vertex.
+     */
+    private final Map<V, List<MultiEdge<V>>> outgoing;
+
+    /**
+     * Incoming adjacency: vertex → list of incoming edges (in insertion order).
+     */
+    private final Map<V, List<MultiEdge<V>>> incoming;
+
+    /**
+     * All edges in insertion order.
+     */
+    private final List<MultiEdge<V>> edges;
+
+    private Multigraph(final boolean directed,
+                       final GraphCollections<V> collections,
+                       final Set<V> vertices,
+                       final Map<V, List<MultiEdge<V>>> outgoing,
+                       final Map<V, List<MultiEdge<V>>> incoming,
+                       final List<MultiEdge<V>> edges) {
+        this.directed = directed;
+        this.collections = collections;
+
+        final Set<V> vSet = collections.newVertexSet();
+        vSet.addAll(vertices);
+        this.vertices = Collections.unmodifiableSet(vSet);
+
+        final Map<V, List<MultiEdge<V>>> outCopy = new LinkedHashMap<>();
+        for (final var entry : outgoing.entrySet()) {
+            outCopy.put(entry.getKey(), List.copyOf(entry.getValue()));
+        }
+        this.outgoing = Collections.unmodifiableMap(outCopy);
+
+        final Map<V, List<MultiEdge<V>>> inCopy = new LinkedHashMap<>();
+        for (final var entry : incoming.entrySet()) {
+            inCopy.put(entry.getKey(), List.copyOf(entry.getValue()));
+        }
+        this.incoming = Collections.unmodifiableMap(inCopy);
+
+        this.edges = List.copyOf(edges);
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link Builder} for constructing a directed {@link Multigraph}.
+     *
+     * @param <V> the vertex type
+     * @return a new directed {@link Builder}
+     */
+    public static <V> Builder<V> directed() {
+        return new Builder<>(true);
+    }
+
+    /**
+     * Returns a {@link Builder} for constructing an undirected {@link Multigraph}.
+     *
+     * @param <V> the vertex type
+     * @return a new undirected {@link Builder}
+     */
+    public static <V> Builder<V> undirected() {
+        return new Builder<>(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // VertexGraph implementation
+    // -------------------------------------------------------------------------
+
+    @Override
+    public Set<V> vertices() {
+        return vertices;
+    }
+
+    @Override
+    public Set<V> successors(final V vertex) {
+        final List<MultiEdge<V>> adj = outgoing.get(vertex);
+        if (adj == null || adj.isEmpty()) {
+            return Set.of();
+        }
+        final Set<V> result = new LinkedHashSet<>();
+        for (final MultiEdge<V> edge : adj) {
+            result.add(edge.to());
+        }
+        return Collections.unmodifiableSet(result);
+    }
+
+    @Override
+    public Set<V> predecessors(final V vertex) {
+        final List<MultiEdge<V>> adj = incoming.get(vertex);
+        if (adj == null || adj.isEmpty()) {
+            return Set.of();
+        }
+        final Set<V> result = new LinkedHashSet<>();
+        for (final MultiEdge<V> edge : adj) {
+            result.add(edge.from());
+        }
+        return Collections.unmodifiableSet(result);
+    }
+
+    @Override
+    public boolean hasEdge(final V from, final V to) {
+        final List<MultiEdge<V>> adj = outgoing.get(from);
+        if (adj == null) {
+            return false;
+        }
+        for (final MultiEdge<V> edge : adj) {
+            if (edge.to().equals(to)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final V vertex) {
+        return vertices.contains(vertex);
+    }
+
+    @Override
+    public boolean isDirected() {
+        return directed;
+    }
+
+    @Override
+    public int vertexCount() {
+        return vertices.size();
+    }
+
+    @Override
+    public int edgeCount() {
+        return edges.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return vertices.isEmpty();
+    }
+
+    @Override
+    public GraphCollections<V> collections() {
+        return collections;
+    }
+
+    // -------------------------------------------------------------------------
+    // Multigraph-specific query methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all edges in this graph, in insertion order.
+     * <p>
+     * For undirected graphs, each logical undirected edge appears once.
+     *
+     * @return unmodifiable list of all edges
+     */
+    public List<MultiEdge<V>> edges() {
+        return edges;
+    }
+
+    /**
+     * Returns all edges from {@code from} to {@code to}, in insertion order.
+     * Returns an empty list if no such edges exist.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return unmodifiable list of parallel edges from {@code from} to {@code to}
+     */
+    public List<MultiEdge<V>> edgesConnecting(final V from, final V to) {
+        final List<MultiEdge<V>> adj = outgoing.get(from);
+        if (adj == null) {
+            return List.of();
+        }
+        final List<MultiEdge<V>> result = new ArrayList<>();
+        for (final MultiEdge<V> edge : adj) {
+            if (edge.to().equals(to)) {
+                result.add(edge);
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * Returns the number of edges from {@code from} to {@code to} (the multiplicity).
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return the number of parallel edges between the two vertices
+     */
+    public int multiplicity(final V from, final V to) {
+        return edgesConnecting(from, to).size();
+    }
+
+    /**
+     * Returns a simple {@link Graph} derived from this multigraph by collapsing all
+     * parallel edges between each vertex pair into a single edge.
+     *
+     * @return the simple graph equivalent of this multigraph
+     */
+    public Graph<V> toSimpleGraph() {
+        final Graph.Builder<V> builder = directed ? Graph.directed() : Graph.undirected();
+        builder.withCollections(collections);
+        vertices.forEach(builder::addVertex);
+        for (final MultiEdge<V> edge : edges) {
+            builder.addEdge(edge.from(), edge.to());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public String toString() {
+        return "Multigraph{directed=" + directed
+            + ", vertices=" + vertexCount()
+            + ", edges=" + edgeCount() + '}';
+    }
+
+    // =========================================================================
+    // Builder
+    // =========================================================================
+
+    /**
+     * A fluent builder for constructing immutable {@link Multigraph} instances.
+     * <p>
+     * Unlike {@link Graph.Builder}, {@link #addEdge(Object, Object)} returns the created
+     * {@link MultiEdge} rather than the builder, since callers typically need to retain
+     * references to specific parallel edges.  Use {@link #addVertex(Object)} for fluent
+     * vertex-only chains.
+     *
+     * @param <V> the vertex type
+     */
+    public static final class Builder<V> {
+
+        private final boolean directed;
+        private GraphCollections<V> collections = GraphCollections.standard();
+        private final Set<V> vertices = new LinkedHashSet<>();
+        private final Map<V, List<MultiEdge<V>>> outgoing = new LinkedHashMap<>();
+        private final Map<V, List<MultiEdge<V>>> incoming = new LinkedHashMap<>();
+        private final List<MultiEdge<V>> edges = new ArrayList<>();
+
+        private Builder(final boolean directed) {
+            this.directed = directed;
+        }
+
+        /**
+         * Sets the {@link GraphCollections} factory for the built graph.
+         *
+         * @param collections the collections factory (must not be {@code null})
+         * @return this builder
+         */
+        public Builder<V> withCollections(final GraphCollections<V> collections) {
+            this.collections = Objects.requireNonNull(collections, "The collections factory cannot be null");
+            return this;
+        }
+
+        /**
+         * Adds the specified vertex to the graph being built.  If the vertex is already
+         * present, this is a no-op.
+         *
+         * @param vertex the vertex to add
+         * @return this builder
+         */
+        public Builder<V> addVertex(final V vertex) {
+            Objects.requireNonNull(vertex, "The vertex cannot be null");
+            vertices.add(vertex);
+            outgoing.computeIfAbsent(vertex, _ -> new ArrayList<>());
+            incoming.computeIfAbsent(vertex, _ -> new ArrayList<>());
+            return this;
+        }
+
+        /**
+         * Adds a new directed edge from {@code from} to {@code to}, implicitly adding
+         * both vertices if they are not already present.
+         * <p>
+         * Each call creates a distinct {@link MultiEdge} even if an edge between the same
+         * pair already exists.  The created edge is returned so callers can retain a
+         * reference to it.
+         *
+         * @param from the source vertex
+         * @param to   the target vertex
+         * @return the newly created {@link MultiEdge}
+         */
+        public MultiEdge<V> addEdge(final V from, final V to) {
+            Objects.requireNonNull(from, "The from vertex cannot be null");
+            Objects.requireNonNull(to, "The to vertex cannot be null");
+
+            addVertex(from);
+            addVertex(to);
+
+            final MultiEdge<V> edge = new MultiEdge<>(from, to);
+            outgoing.get(from).add(edge);
+            incoming.get(to).add(edge);
+            edges.add(edge);
+
+            if (!directed) {
+                final MultiEdge<V> reverse = new MultiEdge<>(to, from);
+                outgoing.get(to).add(reverse);
+                incoming.get(from).add(reverse);
+                // reverse not added to edges list — logically the same undirected edge
+            }
+
+            return edge;
+        }
+
+        /**
+         * Builds and returns an immutable {@link Multigraph} from the current builder state.
+         *
+         * @return a new immutable {@link Multigraph}
+         */
+        public Multigraph<V> build() {
+            return new Multigraph<>(directed, collections, vertices, outgoing, incoming, edges);
+        }
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/Path.java
+++ b/base-graph/src/main/java/build/base/graph/Path.java
@@ -1,0 +1,127 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An immutable path through a {@link Graph}, represented as an ordered sequence of vertices
+ * and the {@link Edge}s connecting them.
+ * <p>
+ * For a path of {@code n} vertices there are {@code n - 1} edges.  A path consisting of a
+ * single vertex has no edges.
+ *
+ * @param <V>      the vertex type
+ * @param vertices the ordered list of vertices along the path (at least one)
+ * @param edges    the ordered list of edges connecting consecutive vertices
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public record Path<V>(List<V> vertices, List<Edge<V>> edges) {
+
+    /**
+     * Constructs a {@link Path}, defensive-copying both lists and validating consistency.
+     *
+     * @param vertices the vertices along the path
+     * @param edges    the edges connecting consecutive vertices
+     */
+    public Path {
+        Objects.requireNonNull(vertices, "The vertices list cannot be null");
+        Objects.requireNonNull(edges, "The edges list cannot be null");
+
+        if (vertices.isEmpty()) {
+            throw new IllegalArgumentException("A path must contain at least one vertex");
+        }
+
+        if (edges.size() != vertices.size() - 1) {
+            throw new IllegalArgumentException(
+                "A path with %d vertices must have %d edge(s), but got %d"
+                    .formatted(vertices.size(), vertices.size() - 1, edges.size()));
+        }
+
+        vertices = List.copyOf(vertices);
+        edges = List.copyOf(edges);
+    }
+
+    /**
+     * Creates a {@link Path} from an ordered sequence of vertices, deriving edges automatically.
+     *
+     * @param <V>      the vertex type
+     * @param vertices the vertices along the path (must contain at least one vertex)
+     * @return a {@link Path} for the given vertices
+     */
+    public static <V> Path<V> of(final List<V> vertices) {
+        Objects.requireNonNull(vertices, "The vertices list cannot be null");
+
+        if (vertices.isEmpty()) {
+            throw new IllegalArgumentException("A path must contain at least one vertex");
+        }
+
+        final List<Edge<V>> edges = new ArrayList<>(vertices.size() - 1);
+
+        for (int i = 0; i < vertices.size() - 1; i++) {
+            edges.add(new Edge<>(vertices.get(i), vertices.get(i + 1)));
+        }
+
+        return new Path<>(vertices, edges);
+    }
+
+    /**
+     * Creates a single-vertex {@link Path} with no edges.
+     *
+     * @param <V>    the vertex type
+     * @param vertex the single vertex
+     * @return a {@link Path} containing only {@code vertex}
+     */
+    public static <V> Path<V> of(final V vertex) {
+        Objects.requireNonNull(vertex, "The vertex cannot be null");
+        return new Path<>(List.of(vertex), List.of());
+    }
+
+    /**
+     * Returns the first vertex of this path.
+     *
+     * @return the start vertex
+     */
+    public V start() {
+        return vertices.getFirst();
+    }
+
+    /**
+     * Returns the last vertex of this path.
+     *
+     * @return the end vertex
+     */
+    public V end() {
+        return vertices.getLast();
+    }
+
+    /**
+     * Returns the number of edges in this path.  A single-vertex path has length {@code 0}.
+     *
+     * @return the path length (number of edges)
+     */
+    public int length() {
+        return edges.size();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/StandardGraphCollections.java
+++ b/base-graph/src/main/java/build/base/graph/StandardGraphCollections.java
@@ -1,0 +1,77 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Standard JDK-backed implementation of {@link GraphCollections}.
+ * <p>
+ * Uses {@link LinkedHashSet} for ordered sets (vertices, neighbours, edges) and
+ * {@link HashMap} for maps, matching the existing behaviour of the graph library prior
+ * to the introduction of pluggable collection backends.
+ *
+ * @param <V> the vertex type
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+final class StandardGraphCollections<V> implements GraphCollections<V> {
+
+    @Override
+    public Set<V> newVertexSet() {
+        return new LinkedHashSet<>();
+    }
+
+    @Override
+    public Map<V, Set<V>> newAdjacencyMap() {
+        return new LinkedHashMap<>();
+    }
+
+    @Override
+    public Set<V> newNeighborSet() {
+        return new LinkedHashSet<>();
+    }
+
+    @Override
+    public Set<Edge<V>> newEdgeSet() {
+        return new LinkedHashSet<>();
+    }
+
+    @Override
+    public Set<V> newSet() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public <T> Map<V, T> newMap() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Map<V, Integer> newIntMap() {
+        return new HashMap<>();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/StandardWeightedGraphCollections.java
+++ b/base-graph/src/main/java/build/base/graph/StandardWeightedGraphCollections.java
@@ -1,0 +1,97 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Standard JDK-backed implementation of {@link WeightedGraphCollections}.
+ *
+ * @param <V> the vertex type
+ * @param <W> the weight type
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+final class StandardWeightedGraphCollections<V, W> implements WeightedGraphCollections<V, W> {
+
+    // -------------------------------------------------------------------------
+    // GraphCollections (storage + algorithm scratch)
+    // -------------------------------------------------------------------------
+
+    @Override
+    public Set<V> newVertexSet() {
+        return new LinkedHashSet<>();
+    }
+
+    @Override
+    public Map<V, Set<V>> newAdjacencyMap() {
+        return new LinkedHashMap<>();
+    }
+
+    @Override
+    public Set<V> newNeighborSet() {
+        return new LinkedHashSet<>();
+    }
+
+    @Override
+    public Set<Edge<V>> newEdgeSet() {
+        return new LinkedHashSet<>();
+    }
+
+    @Override
+    public Set<V> newSet() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public <T> Map<V, T> newMap() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Map<V, Integer> newIntMap() {
+        return new HashMap<>();
+    }
+
+    // -------------------------------------------------------------------------
+    // WeightedGraphCollections (weighted storage)
+    // -------------------------------------------------------------------------
+
+    @Override
+    public Map<V, Map<V, WeightedEdge<V, W>>> newOutgoingMap() {
+        return new LinkedHashMap<>();
+    }
+
+    @Override
+    public Map<V, WeightedEdge<V, W>> newEdgeMap() {
+        return new LinkedHashMap<>();
+    }
+
+    @Override
+    public Set<WeightedEdge<V, W>> newWeightedEdgeSet() {
+        return new LinkedHashSet<>();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/VertexGraph.java
+++ b/base-graph/src/main/java/build/base/graph/VertexGraph.java
@@ -1,0 +1,134 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Set;
+
+/**
+ * The common vertex-structure interface for all graph types in this library.
+ * <p>
+ * Exposes the vertex set, adjacency (successors and predecessors), and the
+ * {@link GraphCollections} factory used for both graph storage and algorithm scratch
+ * allocations.  All graph algorithms in the domain classes ({@link GraphTraversal},
+ * {@link GraphOrdering}, {@link GraphCycles}, {@link GraphConnectivity},
+ * {@link GraphReduction}) operate against this interface, making them applicable to
+ * any conforming implementation.
+ * <p>
+ * Current implementations:
+ * <ul>
+ *   <li>{@link Graph} — simple directed or undirected graph</li>
+ *   <li>{@link WeightedGraph} — directed or undirected graph with typed edge weights</li>
+ * </ul>
+ * Future implementations (e.g. multigraph) will also implement this interface, at which
+ * point the existing algorithms will automatically apply to them without modification.
+ * <p>
+ * This interface does not expose edge objects directly, as the edge type varies across
+ * implementations ({@link Edge}, {@link WeightedEdge}, and future multi-edge types).
+ * Edge-type-specific operations are found on the concrete classes.
+ *
+ * @param <V> the vertex type
+ * @author reed.von.redwitz
+ * @see Graph
+ * @see WeightedGraph
+ * @since Apr-2026
+ */
+public interface VertexGraph<V> {
+
+    /**
+     * Returns all vertices in this graph.
+     *
+     * @return unmodifiable, insertion-ordered set of vertices
+     */
+    Set<V> vertices();
+
+    /**
+     * Returns the set of vertices that {@code vertex} has outgoing edges to (its successors).
+     * Returns an empty set if {@code vertex} is not in the graph.
+     *
+     * @param vertex the vertex to query
+     * @return unmodifiable set of successor vertices
+     */
+    Set<V> successors(V vertex);
+
+    /**
+     * Returns the set of vertices that have outgoing edges to {@code vertex} (its predecessors).
+     * Returns an empty set if {@code vertex} is not in the graph.
+     *
+     * @param vertex the vertex to query
+     * @return unmodifiable set of predecessor vertices
+     */
+    Set<V> predecessors(V vertex);
+
+    /**
+     * Returns {@code true} if this graph contains a directed edge from {@code from} to {@code to}.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return {@code true} if the edge exists
+     */
+    boolean hasEdge(V from, V to);
+
+    /**
+     * Returns {@code true} if this graph contains the specified vertex.
+     *
+     * @param vertex the vertex to check
+     * @return {@code true} if {@code vertex} is in this graph
+     */
+    boolean contains(V vertex);
+
+    /**
+     * Returns {@code true} if this graph is directed.
+     *
+     * @return {@code true} for directed graphs, {@code false} for undirected
+     */
+    boolean isDirected();
+
+    /**
+     * Returns the number of vertices in this graph.
+     *
+     * @return the vertex count
+     */
+    int vertexCount();
+
+    /**
+     * Returns the number of edges in this graph.
+     *
+     * @return the edge count
+     */
+    int edgeCount();
+
+    /**
+     * Returns {@code true} if this graph has no vertices.
+     *
+     * @return {@code true} if the graph is empty
+     */
+    boolean isEmpty();
+
+    /**
+     * Returns the {@link GraphCollections} factory associated with this graph.
+     * <p>
+     * Graph algorithms use this factory to allocate scratch collections (visited sets,
+     * parent maps, etc.) that match the backend in use for this graph.
+     *
+     * @return the collections factory
+     */
+    GraphCollections<V> collections();
+}

--- a/base-graph/src/main/java/build/base/graph/WeightedEdge.java
+++ b/base-graph/src/main/java/build/base/graph/WeightedEdge.java
@@ -1,0 +1,78 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Objects;
+
+/**
+ * A directed, weighted edge in a {@link WeightedGraph}, connecting a source vertex
+ * {@code from} to a target vertex {@code to} with an associated {@code weight}.
+ *
+ * @param <V> the vertex type
+ * @param <W> the weight type
+ * @param from   the source vertex
+ * @param to     the target vertex
+ * @param weight the edge weight
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public record WeightedEdge<V, W>(V from, V to, W weight) {
+
+    /**
+     * Constructs a {@link WeightedEdge}, validating that neither endpoint nor weight is {@code null}.
+     *
+     * @param from   the source vertex
+     * @param to     the target vertex
+     * @param weight the edge weight
+     */
+    public WeightedEdge {
+        Objects.requireNonNull(from, "The from vertex cannot be null");
+        Objects.requireNonNull(to, "The to vertex cannot be null");
+        Objects.requireNonNull(weight, "The weight cannot be null");
+    }
+
+    /**
+     * Returns a new {@link WeightedEdge} with the direction reversed, preserving the weight.
+     *
+     * @return a reversed {@link WeightedEdge} from {@code to} to {@code from}
+     */
+    public WeightedEdge<V, W> reversed() {
+        return new WeightedEdge<>(to, from, weight);
+    }
+
+    /**
+     * Returns the unweighted {@link Edge} equivalent of this edge.
+     *
+     * @return an {@link Edge} with the same {@code from} and {@code to} vertices
+     */
+    public Edge<V> toEdge() {
+        return new Edge<>(from, to);
+    }
+
+    /**
+     * Returns {@code true} if this edge is a self-loop (i.e. {@code from} equals {@code to}).
+     *
+     * @return {@code true} if this is a self-loop
+     */
+    public boolean isSelfLoop() {
+        return from.equals(to);
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/WeightedGraph.java
+++ b/base-graph/src/main/java/build/base/graph/WeightedGraph.java
@@ -1,0 +1,455 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An immutable directed or undirected weighted graph.
+ * <p>
+ * Graphs are constructed via {@link Builder} obtained from {@link #directed()} or
+ * {@link #undirected()}.  Once built, the graph is fully immutable.
+ * <p>
+ * If multiple edges are added between the same pair of vertices, the last weight wins.
+ * <p>
+ * The underlying collection types are configurable via {@link WeightedGraphCollections}.
+ * The default uses standard JDK collections; high-performance alternatives may be substituted
+ * via {@link Builder#withCollections(WeightedGraphCollections)}.
+ * <p>
+ * For algorithms operating on weighted graphs (e.g. Dijkstra's shortest path), see
+ * {@link Graphs}.
+ *
+ * @param <V> the vertex type
+ * @param <W> the weight type
+ * @author reed.von.redwitz
+ * @see Graphs
+ * @see WeightedGraphCollections
+ * @since Apr-2026
+ */
+public final class WeightedGraph<V, W> implements VertexGraph<V> {
+
+    /**
+     * Whether this graph treats edges as directed.
+     */
+    private final boolean directed;
+
+    /**
+     * The collection factories used for this graph's storage and algorithm scratch.
+     */
+    private final WeightedGraphCollections<V, W> collections;
+
+    /**
+     * All vertices in this graph, in insertion order.
+     */
+    private final Set<V> vertices;
+
+    /**
+     * Outgoing weighted adjacency: vertex → (successor → WeightedEdge).
+     */
+    private final Map<V, Map<V, WeightedEdge<V, W>>> outgoing;
+
+    /**
+     * All edges in this graph, in insertion order.
+     */
+    private final Set<WeightedEdge<V, W>> edges;
+
+    /**
+     * Incoming adjacency: vertex → set of predecessor vertices.
+     */
+    private final Map<V, Set<V>> incoming;
+
+    /**
+     * Constructs a {@link WeightedGraph} from builder state using the provided collections.
+     *
+     * @param directed    whether the graph is directed
+     * @param collections the collection factories for storage and algorithm scratch
+     * @param vertices    mutable insertion-ordered vertex set (will be deep-copied)
+     * @param outgoing    mutable outgoing adjacency map (will be deep-copied)
+     */
+    private WeightedGraph(final boolean directed,
+                          final WeightedGraphCollections<V, W> collections,
+                          final Set<V> vertices,
+                          final Map<V, Map<V, WeightedEdge<V, W>>> outgoing) {
+        this.directed = directed;
+        this.collections = collections;
+
+        final Set<V> vSet = collections.newVertexSet();
+        vSet.addAll(vertices);
+        this.vertices = Collections.unmodifiableSet(vSet);
+
+        final Map<V, Map<V, WeightedEdge<V, W>>> copy = collections.newOutgoingMap();
+        for (final var entry : outgoing.entrySet()) {
+            final Map<V, WeightedEdge<V, W>> edgeMap = collections.newEdgeMap();
+            edgeMap.putAll(entry.getValue());
+            copy.put(entry.getKey(), Collections.unmodifiableMap(edgeMap));
+        }
+        this.outgoing = Collections.unmodifiableMap(copy);
+
+        final Set<WeightedEdge<V, W>> edgeSet = collections.newWeightedEdgeSet();
+        for (final var adj : outgoing.values()) {
+            edgeSet.addAll(adj.values());
+        }
+        this.edges = Collections.unmodifiableSet(edgeSet);
+
+        // Build incoming (predecessors) map from outgoing
+        final Map<V, Set<V>> incomingMut = collections.newAdjacencyMap();
+        for (final V v : vertices) {
+            incomingMut.put(v, collections.newNeighborSet());
+        }
+        for (final var entry : outgoing.entrySet()) {
+            final V from = entry.getKey();
+            for (final V to : entry.getValue().keySet()) {
+                incomingMut.computeIfAbsent(to, _ -> collections.newNeighborSet()).add(from);
+            }
+        }
+        final Map<V, Set<V>> incomingCopy = collections.newAdjacencyMap();
+        for (final var e : incomingMut.entrySet()) {
+            incomingCopy.put(e.getKey(), Collections.unmodifiableSet(e.getValue()));
+        }
+        this.incoming = Collections.unmodifiableMap(incomingCopy);
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link Builder} for constructing a directed {@link WeightedGraph}.
+     *
+     * @param <V> the vertex type
+     * @param <W> the weight type
+     * @return a new directed {@link Builder}
+     */
+    public static <V, W> Builder<V, W> directed() {
+        return new Builder<>(true);
+    }
+
+    /**
+     * Returns a {@link Builder} for constructing an undirected {@link WeightedGraph}.
+     *
+     * @param <V> the vertex type
+     * @param <W> the weight type
+     * @return a new undirected {@link Builder}
+     */
+    public static <V, W> Builder<V, W> undirected() {
+        return new Builder<>(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Query methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all vertices in this graph.
+     *
+     * @return unmodifiable, insertion-ordered set of vertices
+     */
+    @Override
+    public Set<V> vertices() {
+        return vertices;
+    }
+
+    /**
+     * Returns all edges in this graph.
+     *
+     * @return unmodifiable set of weighted edges
+     */
+    public Set<WeightedEdge<V, W>> edges() {
+        return edges;
+    }
+
+    /**
+     * Returns the set of successor vertices for the given vertex — vertices that {@code vertex}
+     * has an outgoing edge to.  Returns an empty set if {@code vertex} is not in the graph.
+     *
+     * @param vertex the vertex to query
+     * @return unmodifiable set of successor vertices
+     */
+    @Override
+    public Set<V> successors(final V vertex) {
+        final var adj = outgoing.get(vertex);
+        return adj == null ? Set.of() : Collections.unmodifiableSet(adj.keySet());
+    }
+
+    /**
+     * Returns the set of vertices that have outgoing edges to {@code vertex} (its predecessors).
+     * Returns an empty set if {@code vertex} is not in the graph.
+     *
+     * @param vertex the vertex to query
+     * @return unmodifiable set of predecessor vertices
+     */
+    @Override
+    public Set<V> predecessors(final V vertex) {
+        return incoming.getOrDefault(vertex, Set.of());
+    }
+
+    /**
+     * Returns the {@link WeightedEdge} from {@code from} to {@code to}, if it exists.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return an {@link Optional} containing the edge, or empty if no such edge exists
+     */
+    public Optional<WeightedEdge<V, W>> edge(final V from, final V to) {
+        final var adj = outgoing.get(from);
+        return adj == null ? Optional.empty() : Optional.ofNullable(adj.get(to));
+    }
+
+    /**
+     * Returns the weight of the edge from {@code from} to {@code to}, if it exists.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return an {@link Optional} containing the weight, or empty if no such edge exists
+     */
+    public Optional<W> weight(final V from, final V to) {
+        return edge(from, to).map(WeightedEdge::weight);
+    }
+
+    /**
+     * Returns {@code true} if this graph contains an edge from {@code from} to {@code to}.
+     *
+     * @param from the source vertex
+     * @param to   the target vertex
+     * @return {@code true} if the edge exists
+     */
+    @Override
+    public boolean hasEdge(final V from, final V to) {
+        final var adj = outgoing.get(from);
+        return adj != null && adj.containsKey(to);
+    }
+
+    /**
+     * Returns {@code true} if this graph contains the specified vertex.
+     *
+     * @param vertex the vertex to check
+     * @return {@code true} if {@code vertex} is in this graph
+     */
+    @Override
+    public boolean contains(final V vertex) {
+        return vertices.contains(vertex);
+    }
+
+    /**
+     * Returns {@code true} if this graph is directed.
+     *
+     * @return {@code true} for directed, {@code false} for undirected
+     */
+    @Override
+    public boolean isDirected() {
+        return directed;
+    }
+
+    /**
+     * Returns the number of vertices in this graph.
+     *
+     * @return the vertex count
+     */
+    @Override
+    public int vertexCount() {
+        return vertices.size();
+    }
+
+    /**
+     * Returns the number of edges in this graph.
+     *
+     * @return the edge count
+     */
+    @Override
+    public int edgeCount() {
+        return edges.size();
+    }
+
+    /**
+     * Returns {@code true} if this graph has no vertices.
+     *
+     * @return {@code true} if the graph is empty
+     */
+    @Override
+    public boolean isEmpty() {
+        return vertices.isEmpty();
+    }
+
+    /**
+     * Returns the {@link WeightedGraphCollections} factory associated with this graph.
+     * <p>
+     * Graph algorithms in {@link Graphs} use this factory to allocate scratch collections
+     * that match the backend in use for this graph.
+     *
+     * @return the collections factory
+     */
+    @Override
+    public WeightedGraphCollections<V, W> collections() {
+        return collections;
+    }
+
+    /**
+     * Returns a new unweighted {@link Graph} containing the same vertices and edge structure,
+     * discarding all weights.
+     *
+     * @return the unweighted equivalent of this graph
+     */
+    public Graph<V> toUnweightedGraph() {
+        final Graph.Builder<V> builder = directed ? Graph.directed() : Graph.undirected();
+        vertices.forEach(builder::addVertex);
+        edges.forEach(e -> builder.addEdge(e.from(), e.to()));
+        return builder.build();
+    }
+
+    /**
+     * Returns the internal outgoing adjacency map (package-private for use by {@link Graphs}).
+     *
+     * @return the outgoing adjacency map
+     */
+    Map<V, Map<V, WeightedEdge<V, W>>> outgoing() {
+        return outgoing;
+    }
+
+    @Override
+    public String toString() {
+        return "WeightedGraph{directed=" + directed
+            + ", vertices=" + vertexCount()
+            + ", edges=" + edgeCount() + '}';
+    }
+
+    // =========================================================================
+    // Builder
+    // =========================================================================
+
+    /**
+     * A fluent builder for constructing immutable {@link WeightedGraph} instances.
+     *
+     * @param <V> the vertex type
+     * @param <W> the weight type
+     */
+    public static final class Builder<V, W> {
+
+        /**
+         * Whether the graph being built is directed.
+         */
+        private final boolean directed;
+
+        /**
+         * The collections factory to use for the built graph.
+         */
+        private WeightedGraphCollections<V, W> collections = WeightedGraphCollections.standard();
+
+        /**
+         * Vertices in insertion order (builder scratch — always standard LinkedHashSet).
+         */
+        private final Set<V> vertices = new LinkedHashSet<>();
+
+        /**
+         * Mutable outgoing adjacency map (builder scratch — always standard LinkedHashMap).
+         */
+        private final Map<V, Map<V, WeightedEdge<V, W>>> outgoing = new LinkedHashMap<>();
+
+        /**
+         * Constructs a {@link Builder} for a directed or undirected weighted graph.
+         *
+         * @param directed {@code true} for directed
+         */
+        private Builder(final boolean directed) {
+            this.directed = directed;
+        }
+
+        /**
+         * Sets the {@link WeightedGraphCollections} factory that the built {@link WeightedGraph}
+         * will use for its internal storage and for algorithm scratch allocations.
+         *
+         * @param collections the collections factory (must not be {@code null})
+         * @return this builder
+         */
+        public Builder<V, W> withCollections(final WeightedGraphCollections<V, W> collections) {
+            this.collections = Objects.requireNonNull(collections, "The collections factory cannot be null");
+            return this;
+        }
+
+        /**
+         * Adds the specified vertex to the graph being built.  If the vertex is already
+         * present, this is a no-op.
+         *
+         * @param vertex the vertex to add
+         * @return this builder
+         */
+        public Builder<V, W> addVertex(final V vertex) {
+            Objects.requireNonNull(vertex, "The vertex cannot be null");
+            vertices.add(vertex);
+            outgoing.computeIfAbsent(vertex, _ -> new LinkedHashMap<>());
+            return this;
+        }
+
+        /**
+         * Adds a weighted edge from {@code from} to {@code to} with the specified weight,
+         * implicitly adding both vertices if not already present.
+         * <p>
+         * If an edge between the same pair already exists, its weight is replaced.
+         * For undirected graphs, the reverse edge is also recorded with the same weight.
+         *
+         * @param from   the source vertex
+         * @param to     the target vertex
+         * @param weight the edge weight
+         * @return this builder
+         */
+        public Builder<V, W> addEdge(final V from, final V to, final W weight) {
+            Objects.requireNonNull(from, "The from vertex cannot be null");
+            Objects.requireNonNull(to, "The to vertex cannot be null");
+            Objects.requireNonNull(weight, "The weight cannot be null");
+
+            addVertex(from);
+            addVertex(to);
+
+            outgoing.get(from).put(to, new WeightedEdge<>(from, to, weight));
+
+            if (!directed) {
+                outgoing.get(to).put(from, new WeightedEdge<>(to, from, weight));
+            }
+
+            return this;
+        }
+
+        /**
+         * Adds the given {@link WeightedEdge} to the graph being built.
+         *
+         * @param edge the weighted edge to add
+         * @return this builder
+         */
+        public Builder<V, W> addEdge(final WeightedEdge<V, W> edge) {
+            Objects.requireNonNull(edge, "The edge cannot be null");
+            return addEdge(edge.from(), edge.to(), edge.weight());
+        }
+
+        /**
+         * Builds and returns an immutable {@link WeightedGraph} from the current builder state.
+         *
+         * @return a new immutable {@link WeightedGraph}
+         */
+        public WeightedGraph<V, W> build() {
+            return new WeightedGraph<>(directed, collections, vertices, outgoing);
+        }
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/WeightedGraphCollections.java
+++ b/base-graph/src/main/java/build/base/graph/WeightedGraphCollections.java
@@ -1,0 +1,87 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A factory for the collection types used by {@link WeightedGraph} and the weighted graph
+ * algorithms in {@link Graphs} (e.g. Dijkstra's shortest path).
+ * <p>
+ * Extends {@link GraphCollections} so that a single implementation covers both the weighted
+ * graph's storage needs and the unweighted scratch collections used by algorithms that operate
+ * on the underlying vertex-keyed maps.
+ * <p>
+ * The default implementation, obtained via {@link #standard()}, uses standard JDK collections.
+ * Alternative implementations may substitute higher-performance backends such as fastutil.
+ * <p>
+ * A custom implementation is supplied to a {@link WeightedGraph.Builder} via
+ * {@link WeightedGraph.Builder#withCollections(WeightedGraphCollections)}:
+ * <pre>{@code
+ * WeightedGraph.<Integer, Double>directed()
+ *     .withCollections(new MyFastutilWeightedGraphCollections())
+ *     .addEdge(1, 2, 1.5)
+ *     .build();
+ * }</pre>
+ *
+ * @param <V> the vertex type
+ * @param <W> the weight type
+ * @author reed.von.redwitz
+ * @see GraphCollections
+ * @since Apr-2026
+ */
+public interface WeightedGraphCollections<V, W> extends GraphCollections<V> {
+
+    /**
+     * Returns a new empty map for storing outgoing edges per vertex:
+     * {@code vertex → (successor → WeightedEdge)}.
+     *
+     * @return a new empty outgoing adjacency map
+     */
+    Map<V, Map<V, WeightedEdge<V, W>>> newOutgoingMap();
+
+    /**
+     * Returns a new empty map for storing the neighbours and their edges for a single vertex:
+     * {@code successor → WeightedEdge}.
+     *
+     * @return a new empty edge map
+     */
+    Map<V, WeightedEdge<V, W>> newEdgeMap();
+
+    /**
+     * Returns a new empty set for storing {@link WeightedEdge} objects (the edge cache).
+     *
+     * @return a new empty weighted edge set
+     */
+    Set<WeightedEdge<V, W>> newWeightedEdgeSet();
+
+    /**
+     * Returns the standard JDK-backed implementation of {@link WeightedGraphCollections}.
+     *
+     * @param <V> the vertex type
+     * @param <W> the weight type
+     * @return the standard {@link WeightedGraphCollections} implementation
+     */
+    static <V, W> WeightedGraphCollections<V, W> standard() {
+        return new StandardWeightedGraphCollections<>();
+    }
+}

--- a/base-graph/src/main/java/build/base/graph/WeightedPath.java
+++ b/base-graph/src/main/java/build/base/graph/WeightedPath.java
@@ -1,0 +1,144 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BinaryOperator;
+
+/**
+ * An immutable weighted path through a {@link WeightedGraph}, represented as an ordered
+ * sequence of vertices, the {@link WeightedEdge}s connecting them, and the total accumulated
+ * {@code weight} of the path.
+ *
+ * @param <V>         the vertex type
+ * @param <W>         the weight type
+ * @param vertices    the ordered list of vertices along the path (at least one)
+ * @param edges       the ordered list of weighted edges connecting consecutive vertices
+ * @param totalWeight the total accumulated weight of all edges in the path
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+public record WeightedPath<V, W>(List<V> vertices, List<WeightedEdge<V, W>> edges, W totalWeight) {
+
+    /**
+     * Constructs a {@link WeightedPath}, defensive-copying both lists and validating consistency.
+     *
+     * @param vertices    the vertices along the path
+     * @param edges       the weighted edges connecting consecutive vertices
+     * @param totalWeight the total accumulated weight
+     */
+    public WeightedPath {
+        Objects.requireNonNull(vertices, "The vertices list cannot be null");
+        Objects.requireNonNull(edges, "The edges list cannot be null");
+        Objects.requireNonNull(totalWeight, "The totalWeight cannot be null");
+
+        if (vertices.isEmpty()) {
+            throw new IllegalArgumentException("A path must contain at least one vertex");
+        }
+
+        if (edges.size() != vertices.size() - 1) {
+            throw new IllegalArgumentException(
+                "A path with %d vertices must have %d edge(s), but got %d"
+                    .formatted(vertices.size(), vertices.size() - 1, edges.size()));
+        }
+
+        vertices = List.copyOf(vertices);
+        edges = List.copyOf(edges);
+    }
+
+    /**
+     * Creates a single-vertex {@link WeightedPath} with no edges and the supplied zero weight.
+     *
+     * @param <V>         the vertex type
+     * @param <W>         the weight type
+     * @param vertex      the single vertex
+     * @param zeroWeight  the zero-value weight (e.g. {@code 0} for integers)
+     * @return a {@link WeightedPath} containing only {@code vertex}
+     */
+    public static <V, W> WeightedPath<V, W> of(final V vertex, final W zeroWeight) {
+        Objects.requireNonNull(vertex, "The vertex cannot be null");
+        Objects.requireNonNull(zeroWeight, "The zeroWeight cannot be null");
+        return new WeightedPath<>(List.of(vertex), List.of(), zeroWeight);
+    }
+
+    /**
+     * Returns a new {@link WeightedPath} extended by one edge and vertex, accumulating weight
+     * using the supplied {@code add} operator.
+     *
+     * @param next the next vertex to append
+     * @param edge the weighted edge connecting the current end vertex to {@code next}
+     * @param add  the binary operator used to accumulate weight
+     * @return the extended path
+     */
+    public WeightedPath<V, W> extend(final V next, final WeightedEdge<V, W> edge, final BinaryOperator<W> add) {
+        Objects.requireNonNull(next, "The next vertex cannot be null");
+        Objects.requireNonNull(edge, "The edge cannot be null");
+        Objects.requireNonNull(add, "The add operator cannot be null");
+
+        final var newVertices = new java.util.ArrayList<>(vertices);
+        newVertices.add(next);
+
+        final var newEdges = new java.util.ArrayList<>(edges);
+        newEdges.add(edge);
+
+        return new WeightedPath<>(newVertices, newEdges, add.apply(totalWeight, edge.weight()));
+    }
+
+    /**
+     * Returns the first vertex of this path.
+     *
+     * @return the start vertex
+     */
+    public V start() {
+        return vertices.getFirst();
+    }
+
+    /**
+     * Returns the last vertex of this path.
+     *
+     * @return the end vertex
+     */
+    public V end() {
+        return vertices.getLast();
+    }
+
+    /**
+     * Returns the number of edges in this path.  A single-vertex path has length {@code 0}.
+     *
+     * @return the path length (number of edges)
+     */
+    public int length() {
+        return edges.size();
+    }
+
+    /**
+     * Returns this path as an unweighted {@link Path}, discarding edge weights.
+     *
+     * @return the equivalent unweighted {@link Path}
+     */
+    public Path<V> toUnweightedPath() {
+        final List<Edge<V>> unweightedEdges = edges.stream()
+            .map(WeightedEdge::toEdge)
+            .toList();
+        return new Path<>(vertices, unweightedEdges);
+    }
+}

--- a/base-graph/src/main/java/module-info.java
+++ b/base-graph/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Provides immutable directed and weighted graph primitives with algorithms for traversal,
+ * topological ordering, cycle detection, reachability, shortest paths, strongly connected
+ * components, and parallelizable scheduling groups.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+module build.base.graph {
+    exports build.base.graph;
+}

--- a/base-graph/src/test/java/build/base/graph/EdgeTests.java
+++ b/base-graph/src/test/java/build/base/graph/EdgeTests.java
@@ -1,0 +1,186 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link Edge} and {@link WeightedEdge}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+class EdgeTests {
+
+    // -------------------------------------------------------------------------
+    // Edge
+    // -------------------------------------------------------------------------
+
+    @Test
+    void edgeShouldStoreFromAndTo() {
+        final var edge = new Edge<>("A", "B");
+        assertThat(edge.from()).isEqualTo("A");
+        assertThat(edge.to()).isEqualTo("B");
+    }
+
+    @Test
+    void edgeShouldRejectNullFrom() {
+        assertThatThrownBy(() -> new Edge<>(null, "B"))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void edgeShouldRejectNullTo() {
+        assertThatThrownBy(() -> new Edge<>("A", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void edgeShouldReverse() {
+        final var edge = new Edge<>("A", "B");
+        final var reversed = edge.reversed();
+        assertThat(reversed.from()).isEqualTo("B");
+        assertThat(reversed.to()).isEqualTo("A");
+    }
+
+    @Test
+    void edgeSelfLoopShouldBeDetected() {
+        assertThat(new Edge<>("A", "A").isSelfLoop()).isTrue();
+        assertThat(new Edge<>("A", "B").isSelfLoop()).isFalse();
+    }
+
+    @Test
+    void edgeShouldSupportValueEquality() {
+        final var e1 = new Edge<>("A", "B");
+        final var e2 = new Edge<>("A", "B");
+        final var e3 = new Edge<>("B", "A");
+        assertThat(e1).isEqualTo(e2);
+        assertThat(e1).isNotEqualTo(e3);
+    }
+
+    // -------------------------------------------------------------------------
+    // WeightedEdge
+    // -------------------------------------------------------------------------
+
+    @Test
+    void weightedEdgeShouldStoreFields() {
+        final var edge = new WeightedEdge<>("A", "B", 5);
+        assertThat(edge.from()).isEqualTo("A");
+        assertThat(edge.to()).isEqualTo("B");
+        assertThat(edge.weight()).isEqualTo(5);
+    }
+
+    @Test
+    void weightedEdgeShouldRejectNullWeight() {
+        assertThatThrownBy(() -> new WeightedEdge<>("A", "B", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void weightedEdgeShouldReverse() {
+        final var edge = new WeightedEdge<>("A", "B", 10);
+        final var reversed = edge.reversed();
+        assertThat(reversed.from()).isEqualTo("B");
+        assertThat(reversed.to()).isEqualTo("A");
+        assertThat(reversed.weight()).isEqualTo(10);
+    }
+
+    @Test
+    void weightedEdgeShouldConvertToEdge() {
+        final var weighted = new WeightedEdge<>("X", "Y", 42);
+        final var edge = weighted.toEdge();
+        assertThat(edge).isEqualTo(new Edge<>("X", "Y"));
+    }
+
+    @Test
+    void weightedEdgeSelfLoopShouldBeDetected() {
+        assertThat(new WeightedEdge<>("A", "A", 1).isSelfLoop()).isTrue();
+        assertThat(new WeightedEdge<>("A", "B", 1).isSelfLoop()).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pathShouldBuildFromVertices() {
+        final var path = Path.of(java.util.List.of("A", "B", "C"));
+        assertThat(path.start()).isEqualTo("A");
+        assertThat(path.end()).isEqualTo("C");
+        assertThat(path.length()).isEqualTo(2);
+        assertThat(path.edges()).containsExactly(new Edge<>("A", "B"), new Edge<>("B", "C"));
+    }
+
+    @Test
+    void pathShouldBuildFromSingleVertex() {
+        final var path = Path.of("A");
+        assertThat(path.start()).isEqualTo("A");
+        assertThat(path.end()).isEqualTo("A");
+        assertThat(path.length()).isEqualTo(0);
+        assertThat(path.edges()).isEmpty();
+    }
+
+    @Test
+    void pathShouldRejectEmptyVertexList() {
+        assertThatThrownBy(() -> Path.of(java.util.List.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void pathShouldRejectMismatchedEdgeCount() {
+        assertThatThrownBy(() -> new Path<>(java.util.List.of("A", "B"), java.util.List.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Component
+    // -------------------------------------------------------------------------
+
+    @Test
+    void componentShouldStoreVertices() {
+        final var component = new Component<>(java.util.Set.of("A", "B", "C"));
+        assertThat(component.vertices()).containsExactlyInAnyOrder("A", "B", "C");
+        assertThat(component.size()).isEqualTo(3);
+    }
+
+    @Test
+    void componentShouldRejectEmptySet() {
+        assertThatThrownBy(() -> new Component<>(java.util.Set.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void trivialComponentShouldBeDetected() {
+        assertThat(new Component<>(java.util.Set.of("A")).isTrivial()).isTrue();
+        assertThat(new Component<>(java.util.Set.of("A", "B")).isTrivial()).isFalse();
+        assertThat(new Component<>(java.util.Set.of("A", "B")).isNonTrivial()).isTrue();
+    }
+
+    @Test
+    void componentShouldCheckContainment() {
+        final var component = new Component<>(java.util.Set.of("A", "B"));
+        assertThat(component.contains("A")).isTrue();
+        assertThat(component.contains("C")).isFalse();
+    }
+}

--- a/base-graph/src/test/java/build/base/graph/GraphTests.java
+++ b/base-graph/src/test/java/build/base/graph/GraphTests.java
@@ -1,0 +1,221 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link Graph} construction and structural queries.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+class GraphTests {
+
+    // -------------------------------------------------------------------------
+    // Empty graph
+    // -------------------------------------------------------------------------
+
+    @Test
+    void emptyDirectedGraphShouldHaveNoVerticesOrEdges() {
+        final var graph = Graph.<String>directed().build();
+        assertThat(graph.vertices()).isEmpty();
+        assertThat(graph.edges()).isEmpty();
+        assertThat(graph.vertexCount()).isEqualTo(0);
+        assertThat(graph.edgeCount()).isEqualTo(0);
+        assertThat(graph.isEmpty()).isTrue();
+        assertThat(graph.isDirected()).isTrue();
+    }
+
+    @Test
+    void emptyUndirectedGraphShouldBeEmpty() {
+        final var graph = Graph.<String>undirected().build();
+        assertThat(graph.isEmpty()).isTrue();
+        assertThat(graph.isDirected()).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Vertices
+    // -------------------------------------------------------------------------
+
+    @Test
+    void addedVerticesShouldBePresent() {
+        final var graph = Graph.<String>directed()
+            .addVertex("A")
+            .addVertex("B")
+            .addVertex("C")
+            .build();
+
+        assertThat(graph.vertices()).containsExactly("A", "B", "C");
+        assertThat(graph.vertexCount()).isEqualTo(3);
+        assertThat(graph.contains("A")).isTrue();
+        assertThat(graph.contains("Z")).isFalse();
+    }
+
+    @Test
+    void duplicateVerticesShouldBeIgnored() {
+        final var graph = Graph.<String>directed()
+            .addVertex("A")
+            .addVertex("A")
+            .build();
+
+        assertThat(graph.vertexCount()).isEqualTo(1);
+    }
+
+    @Test
+    void addVertexShouldRejectNull() {
+        assertThatThrownBy(() -> Graph.<String>directed().addVertex(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Directed edges
+    // -------------------------------------------------------------------------
+
+    @Test
+    void addedEdgesShouldCreateVerticesImplicitly() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .addEdge("B", "C")
+            .build();
+
+        assertThat(graph.vertices()).containsExactly("A", "B", "C");
+        assertThat(graph.edgeCount()).isEqualTo(2);
+    }
+
+    @Test
+    void directedGraphShouldHaveCorrectSuccessorsAndPredecessors() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .addEdge("A", "C")
+            .addEdge("B", "C")
+            .build();
+
+        assertThat(graph.successors("A")).containsExactlyInAnyOrder("B", "C");
+        assertThat(graph.successors("B")).containsExactly("C");
+        assertThat(graph.successors("C")).isEmpty();
+
+        assertThat(graph.predecessors("A")).isEmpty();
+        assertThat(graph.predecessors("B")).containsExactly("A");
+        assertThat(graph.predecessors("C")).containsExactlyInAnyOrder("A", "B");
+    }
+
+    @Test
+    void directedGraphShouldCorrectlyReportEdgeExistence() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .build();
+
+        assertThat(graph.hasEdge("A", "B")).isTrue();
+        assertThat(graph.hasEdge("B", "A")).isFalse();
+    }
+
+    @Test
+    void addEdgeViaEdgeRecordShouldWork() {
+        final var graph = Graph.<String>directed()
+            .addEdge(new Edge<>("X", "Y"))
+            .build();
+
+        assertThat(graph.hasEdge("X", "Y")).isTrue();
+        assertThat(graph.edgeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void duplicateEdgesShouldBeIgnored() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .addEdge("A", "B")
+            .build();
+
+        assertThat(graph.edgeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void selfLoopShouldBeSupported() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "A")
+            .build();
+
+        assertThat(graph.hasEdge("A", "A")).isTrue();
+        assertThat(graph.successors("A")).containsExactly("A");
+        assertThat(graph.predecessors("A")).containsExactly("A");
+    }
+
+    // -------------------------------------------------------------------------
+    // Undirected edges
+    // -------------------------------------------------------------------------
+
+    @Test
+    void undirectedEdgeShouldBeNavigableInBothDirections() {
+        final var graph = Graph.<String>undirected()
+            .addEdge("A", "B")
+            .build();
+
+        assertThat(graph.hasEdge("A", "B")).isTrue();
+        assertThat(graph.hasEdge("B", "A")).isTrue();
+        assertThat(graph.successors("A")).containsExactly("B");
+        assertThat(graph.successors("B")).containsExactly("A");
+    }
+
+    @Test
+    void undirectedGraphEdgeCountShouldCountLogicalEdges() {
+        final var graph = Graph.<String>undirected()
+            .addEdge("A", "B")
+            .addEdge("B", "C")
+            .build();
+
+        // 2 undirected edges, not 4 directed entries
+        assertThat(graph.edgeCount()).isEqualTo(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Disconnected components
+    // -------------------------------------------------------------------------
+
+    @Test
+    void disconnectedGraphShouldContainIsolatedVertices() {
+        final var graph = Graph.<String>directed()
+            .addVertex("A")
+            .addVertex("B")
+            .addEdge("C", "D")
+            .build();
+
+        assertThat(graph.vertexCount()).isEqualTo(4);
+        assertThat(graph.successors("A")).isEmpty();
+        assertThat(graph.predecessors("B")).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toStringShouldDescribeGraph() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .build();
+
+        assertThat(graph.toString()).contains("directed=true", "vertices=2", "edges=1");
+    }
+}

--- a/base-graph/src/test/java/build/base/graph/GraphsTests.java
+++ b/base-graph/src/test/java/build/base/graph/GraphsTests.java
@@ -1,0 +1,587 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for all graph algorithms in {@link Graphs}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+class GraphsTests {
+
+    // =========================================================================
+    // BFS
+    // =========================================================================
+
+    @Test
+    void bfsShouldVisitVerticesInBreadthFirstOrder() {
+        //     A
+        //    / \
+        //   B   C
+        //  / \
+        // D   E
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("A", "C")
+            .addEdge("B", "D").addEdge("B", "E")
+            .build();
+
+        final var result = Graphs.breadthFirstSearch(graph, "A");
+        // A must come first; B and C before D and E
+        assertThat(result).startsWith("A");
+        assertThat(result.indexOf("B")).isLessThan(result.indexOf("D"));
+        assertThat(result.indexOf("C")).isLessThan(result.indexOf("D"));
+        assertThat(result).containsExactlyInAnyOrder("A", "B", "C", "D", "E");
+    }
+
+    @Test
+    void bfsShouldReturnOnlyReachableVertices() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .addVertex("C")   // isolated
+            .build();
+
+        assertThat(Graphs.breadthFirstSearch(graph, "A")).containsExactlyInAnyOrder("A", "B");
+    }
+
+    @Test
+    void bfsOnSingleNodeShouldReturnThatNode() {
+        final var graph = Graph.<String>directed().addVertex("A").build();
+        assertThat(Graphs.breadthFirstSearch(graph, "A")).containsExactly("A");
+    }
+
+    @Test
+    void bfsShouldHandleSelfLoop() {
+        final var graph = Graph.<String>directed().addEdge("A", "A").build();
+        assertThat(Graphs.breadthFirstSearch(graph, "A")).containsExactly("A");
+    }
+
+    // =========================================================================
+    // DFS
+    // =========================================================================
+
+    @Test
+    void dfsShouldVisitAllReachableVertices() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("A", "C")
+            .addEdge("B", "D")
+            .build();
+
+        final var result = Graphs.depthFirstSearch(graph, "A");
+        assertThat(result).startsWith("A");
+        assertThat(result).containsExactlyInAnyOrder("A", "B", "C", "D");
+        // In DFS, B's subtree should be explored before C
+        assertThat(result.indexOf("D")).isLessThan(result.indexOf("C"));
+    }
+
+    @Test
+    void dfsShouldHandleCyclicGraphWithoutInfiniteLoop() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "A")
+            .build();
+
+        final var result = Graphs.depthFirstSearch(graph, "A");
+        assertThat(result).containsExactlyInAnyOrder("A", "B", "C");
+    }
+
+    // =========================================================================
+    // Reachability
+    // =========================================================================
+
+    @Test
+    void reachableFromShouldReturnAllDownstreamVertices() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("B", "D")
+            .build();
+
+        assertThat(Graphs.reachableFrom(graph, "A")).containsExactlyInAnyOrder("B", "C", "D");
+    }
+
+    @Test
+    void reachableFromIsolatedVertexShouldBeEmpty() {
+        final var graph = Graph.<String>directed().addVertex("A").build();
+        assertThat(Graphs.reachableFrom(graph, "A")).isEmpty();
+    }
+
+    @Test
+    void reachableFromShouldIncludeStartOnCycle() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "A")
+            .build();
+
+        assertThat(Graphs.reachableFrom(graph, "A")).contains("A", "B");
+    }
+
+    @Test
+    void ancestorsShouldReturnUpstreamVertices() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "C").addEdge("B", "C").addEdge("C", "D")
+            .build();
+
+        assertThat(Graphs.ancestors(graph, "D")).containsExactlyInAnyOrder("A", "B", "C");
+        assertThat(Graphs.ancestors(graph, "C")).containsExactlyInAnyOrder("A", "B");
+        assertThat(Graphs.ancestors(graph, "A")).isEmpty();
+    }
+
+    @Test
+    void descendantsShouldReturnDownstreamVertices() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("A", "C").addEdge("B", "D")
+            .build();
+
+        assertThat(Graphs.descendants(graph, "A")).containsExactlyInAnyOrder("B", "C", "D");
+    }
+
+    // =========================================================================
+    // Topological Sort
+    // =========================================================================
+
+    @Test
+    void topologicalSortShouldOrderDependenciesFirst() {
+        // A depends on B and C; B depends on D
+        // Valid order: D, B, C, A  (or D, C, B, A)
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("A", "C").addEdge("B", "D")
+            .build();
+
+        final var sorted = Graphs.topologicalSort(graph);
+        assertThat(sorted).containsExactlyInAnyOrder("A", "B", "C", "D");
+        assertThat(sorted.indexOf("D")).isLessThan(sorted.indexOf("B"));
+        assertThat(sorted.indexOf("B")).isLessThan(sorted.indexOf("A"));
+        assertThat(sorted.indexOf("C")).isLessThan(sorted.indexOf("A"));
+    }
+
+    @Test
+    void topologicalSortOnEmptyGraphShouldReturnEmptyList() {
+        final var graph = Graph.<String>directed().build();
+        assertThat(Graphs.topologicalSort(graph)).isEmpty();
+    }
+
+    @Test
+    void topologicalSortOnSingleVertexShouldReturnIt() {
+        final var graph = Graph.<String>directed().addVertex("A").build();
+        assertThat(Graphs.topologicalSort(graph)).containsExactly("A");
+    }
+
+    @Test
+    void topologicalSortOnGraphWithCycleShouldThrow() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "A")
+            .build();
+
+        assertThatThrownBy(() -> Graphs.topologicalSort(graph))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("cycle");
+    }
+
+    // =========================================================================
+    // Cycle Detection
+    // =========================================================================
+
+    @Test
+    void hasCycleShouldReturnFalseForDag() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C")
+            .build();
+
+        assertThat(Graphs.hasCycle(graph)).isFalse();
+    }
+
+    @Test
+    void hasCycleShouldReturnTrueForCyclicGraph() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "A")
+            .build();
+
+        assertThat(Graphs.hasCycle(graph)).isTrue();
+    }
+
+    @Test
+    void hasCycleOnEmptyGraphShouldReturnFalse() {
+        assertThat(Graphs.hasCycle(Graph.<String>directed().build())).isFalse();
+    }
+
+    @Test
+    void hasCycleOnSingleNodeWithoutSelfLoopShouldReturnFalse() {
+        assertThat(Graphs.hasCycle(Graph.<String>directed().addVertex("A").build())).isFalse();
+    }
+
+    @Test
+    void hasCycleShouldDetectSelfLoop() {
+        final var graph = Graph.<String>directed().addEdge("A", "A").build();
+        assertThat(Graphs.hasCycle(graph)).isTrue();
+    }
+
+    @Test
+    void findCycleShouldReturnEmptyForAcyclicGraph() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C")
+            .build();
+
+        assertThat(Graphs.findCycle(graph)).isEmpty();
+    }
+
+    @Test
+    void findCycleShouldReturnCyclePath() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "A")
+            .build();
+
+        final var cycle = Graphs.findCycle(graph);
+        assertThat(cycle).isPresent();
+
+        final var path = cycle.get();
+        // Cycle should start and end with the same vertex
+        assertThat(path.getFirst()).isEqualTo(path.getLast());
+        // Cycle vertices (excluding duplicate end) should be a subset of graph vertices
+        assertThat(path).hasSize(4); // A->B->C->A or similar rotation
+    }
+
+    @Test
+    void findCycleShouldDetectSelfLoop() {
+        final var graph = Graph.<String>directed().addEdge("A", "A").build();
+        final var cycle = Graphs.findCycle(graph);
+        assertThat(cycle).isPresent();
+        assertThat(cycle.get()).contains("A");
+    }
+
+    // =========================================================================
+    // Shortest Path (unweighted BFS)
+    // =========================================================================
+
+    @Test
+    void shortestPathShouldFindDirectPath() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C")
+            .build();
+
+        final var path = Graphs.shortestPath(graph, "A", "C");
+        assertThat(path).isPresent();
+        assertThat(path.get().vertices()).containsExactly("A", "B", "C");
+        assertThat(path.get().length()).isEqualTo(2);
+    }
+
+    @Test
+    void shortestPathShouldPreferFewerHops() {
+        // A->B->C  and  A->C directly
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("A", "C")
+            .build();
+
+        final var path = Graphs.shortestPath(graph, "A", "C");
+        assertThat(path).isPresent();
+        assertThat(path.get().length()).isEqualTo(1);
+        assertThat(path.get().vertices()).containsExactly("A", "C");
+    }
+
+    @Test
+    void shortestPathToSelfShouldReturnSingleVertexPath() {
+        final var graph = Graph.<String>directed().addEdge("A", "B").build();
+        final var path = Graphs.shortestPath(graph, "A", "A");
+        assertThat(path).isPresent();
+        assertThat(path.get().vertices()).containsExactly("A");
+        assertThat(path.get().length()).isEqualTo(0);
+    }
+
+    @Test
+    void shortestPathShouldReturnEmptyWhenUnreachable() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B")
+            .addVertex("C")
+            .build();
+
+        assertThat(Graphs.shortestPath(graph, "A", "C")).isEmpty();
+    }
+
+    @Test
+    void shortestPathOnEmptyGraphShouldReturnEmptyForDifferentVertices() {
+        final var graph = Graph.<String>directed().addVertex("A").addVertex("B").build();
+        assertThat(Graphs.shortestPath(graph, "A", "B")).isEmpty();
+    }
+
+    // =========================================================================
+    // Dijkstra (weighted shortest path)
+    // =========================================================================
+
+    @Test
+    void dijkstraShouldFindMinimumWeightPath() {
+        // A -1-> B -2-> D   (total 3)
+        // A -4-> C -1-> D   (total 5)
+        // A -1-> B -3-> C -1-> D  (total 5)
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 1)
+            .addEdge("A", "C", 4)
+            .addEdge("B", "D", 2)
+            .addEdge("B", "C", 3)
+            .addEdge("C", "D", 1)
+            .build();
+
+        final var result = Graphs.shortestPath(graph, "A", "D", 0, Integer::sum);
+        assertThat(result).isPresent();
+        assertThat(result.get().totalWeight()).isEqualTo(3);
+        assertThat(result.get().vertices()).containsExactly("A", "B", "D");
+    }
+
+    @Test
+    void dijkstraShouldReturnSingleVertexPathForSameStartAndEnd() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 5)
+            .build();
+
+        final var result = Graphs.shortestPath(graph, "A", "A", 0, Integer::sum);
+        assertThat(result).isPresent();
+        assertThat(result.get().totalWeight()).isEqualTo(0);
+        assertThat(result.get().vertices()).containsExactly("A");
+    }
+
+    @Test
+    void dijkstraShouldReturnEmptyWhenUnreachable() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 1)
+            .addVertex("C")
+            .build();
+
+        assertThat(Graphs.shortestPath(graph, "A", "C", 0, Integer::sum)).isEmpty();
+    }
+
+    @Test
+    void dijkstraShouldWorkWithDoubleWeights() {
+        final var graph = WeightedGraph.<String, Double>directed()
+            .addEdge("A", "B", 1.5)
+            .addEdge("B", "C", 2.5)
+            .build();
+
+        final var result = Graphs.shortestPath(graph, "A", "C", 0.0, Double::sum);
+        assertThat(result).isPresent();
+        assertThat(result.get().totalWeight()).isEqualTo(4.0);
+    }
+
+    // =========================================================================
+    // Parallelizable Groups
+    // =========================================================================
+
+    @Test
+    void parallelizableGroupsShouldLayerDependencies() {
+        // Layer 0: D (no deps)
+        // Layer 1: B, C (depend only on D)
+        // Layer 2: A (depends on B and C)
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("A", "C")
+            .addEdge("B", "D").addEdge("C", "D")
+            .build();
+
+        final var groups = Graphs.parallelizableGroups(graph);
+        assertThat(groups).hasSize(3);
+        assertThat(groups.get(0)).containsExactly("D");
+        assertThat(groups.get(1)).containsExactlyInAnyOrder("B", "C");
+        assertThat(groups.get(2)).containsExactly("A");
+    }
+
+    @Test
+    void parallelizableGroupsOnEmptyGraphShouldReturnEmptyList() {
+        assertThat(Graphs.parallelizableGroups(Graph.<String>directed().build())).isEmpty();
+    }
+
+    @Test
+    void parallelizableGroupsOnCycleShouldThrow() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "A")
+            .build();
+
+        assertThatThrownBy(() -> Graphs.parallelizableGroups(graph))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void parallelizableGroupsOnLinearChainShouldHaveOnePerLayer() {
+        // A -> B -> C -> D: each in its own layer (in reverse: D, C, B, A)
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "D")
+            .build();
+
+        final var groups = Graphs.parallelizableGroups(graph);
+        assertThat(groups).hasSize(4);
+        for (final var group : groups) {
+            assertThat(group).hasSize(1);
+        }
+    }
+
+    // =========================================================================
+    // Strongly Connected Components
+    // =========================================================================
+
+    @Test
+    void sccOnDagShouldReturnOneTrivialComponentPerVertex() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C")
+            .build();
+
+        final var sccs = Graphs.stronglyConnectedComponents(graph);
+        assertThat(sccs).hasSize(3);
+        assertThat(sccs).allSatisfy(c -> assertThat(c.isTrivial()).isTrue());
+    }
+
+    @Test
+    void sccShouldGroupCyclicVerticesTogether() {
+        // A->B->C->A is one SCC; D is separate
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "A")
+            .addEdge("A", "D")
+            .build();
+
+        final var sccs = Graphs.stronglyConnectedComponents(graph);
+        // One SCC of {A,B,C} and one of {D}
+        assertThat(sccs).hasSize(2);
+
+        final var nonTrivial = sccs.stream().filter(Component::isNonTrivial).toList();
+        assertThat(nonTrivial).hasSize(1);
+        assertThat(nonTrivial.getFirst().vertices()).containsExactlyInAnyOrder("A", "B", "C");
+    }
+
+    @Test
+    void sccOnEmptyGraphShouldReturnEmptyList() {
+        final var graph = Graph.<String>directed().build();
+        assertThat(Graphs.stronglyConnectedComponents(graph)).isEmpty();
+    }
+
+    @Test
+    void sccOnSingleVertexShouldReturnOneTrivialComponent() {
+        final var graph = Graph.<String>directed().addVertex("A").build();
+        final var sccs = Graphs.stronglyConnectedComponents(graph);
+        assertThat(sccs).hasSize(1);
+        assertThat(sccs.getFirst().isTrivial()).isTrue();
+    }
+
+    @Test
+    void sccShouldDetectSelfLoopAsNonTrivialComponent() {
+        // A self-loop makes A an SCC, but with a single vertex the isTrivial check is size-based
+        // A -> A: still just {A} but reachable from itself
+        final var graph = Graph.<String>directed().addEdge("A", "A").build();
+        final var sccs = Graphs.stronglyConnectedComponents(graph);
+        assertThat(sccs).hasSize(1);
+        assertThat(sccs.getFirst().contains("A")).isTrue();
+    }
+
+    @Test
+    void sccOnDisconnectedGraphShouldReturnComponentPerVertex() {
+        final var graph = Graph.<String>directed()
+            .addVertex("A").addVertex("B").addVertex("C")
+            .build();
+
+        assertThat(Graphs.stronglyConnectedComponents(graph)).hasSize(3);
+    }
+
+    // =========================================================================
+    // Transitive Reduction
+    // =========================================================================
+
+    @Test
+    void transitiveReductionShouldRemoveRedundantEdges() {
+        // A->B, B->C, A->C (A->C is redundant since A->B->C exists)
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("A", "C")
+            .build();
+
+        final var reduced = Graphs.transitiveReduction(graph);
+        assertThat(reduced.hasEdge("A", "B")).isTrue();
+        assertThat(reduced.hasEdge("B", "C")).isTrue();
+        assertThat(reduced.hasEdge("A", "C")).isFalse();
+        assertThat(reduced.edgeCount()).isEqualTo(2);
+    }
+
+    @Test
+    void transitiveReductionShouldPreserveLinearChain() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("C", "D")
+            .build();
+
+        final var reduced = Graphs.transitiveReduction(graph);
+        assertThat(reduced.edgeCount()).isEqualTo(3);
+    }
+
+    @Test
+    void transitiveReductionOnEmptyGraphShouldReturnEmptyGraph() {
+        final var reduced = Graphs.transitiveReduction(Graph.<String>directed().build());
+        assertThat(reduced.isEmpty()).isTrue();
+    }
+
+    @Test
+    void transitiveReductionShouldPreserveAllVertices() {
+        final var graph = Graph.<String>directed()
+            .addEdge("A", "B").addEdge("B", "C").addEdge("A", "C")
+            .build();
+
+        final var reduced = Graphs.transitiveReduction(graph);
+        assertThat(reduced.vertices()).containsExactlyInAnyOrder("A", "B", "C");
+    }
+
+    // =========================================================================
+    // Null argument guards
+    // =========================================================================
+
+    @Test
+    void algorithmsShouldRejectNullGraph() {
+        assertThatThrownBy(() -> Graphs.breadthFirstSearch(null, "A"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Graphs.depthFirstSearch(null, "A"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Graphs.topologicalSort(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Graphs.hasCycle(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Graphs.findCycle(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Graphs.stronglyConnectedComponents(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Graphs.transitiveReduction(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // =========================================================================
+    // Directed-only guard
+    // =========================================================================
+
+    @Test
+    void directedOnlyAlgorithmsShouldRejectUndirectedGraphs() {
+        final var undirected = Graph.<String>undirected().addEdge("A", "B").build();
+
+        assertThatThrownBy(() -> Graphs.topologicalSort(undirected))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("directed");
+        assertThatThrownBy(() -> Graphs.parallelizableGroups(undirected))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("directed");
+        assertThatThrownBy(() -> Graphs.stronglyConnectedComponents(undirected))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("directed");
+        assertThatThrownBy(() -> Graphs.transitiveReduction(undirected))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("directed");
+    }
+}

--- a/base-graph/src/test/java/build/base/graph/MultigraphTests.java
+++ b/base-graph/src/test/java/build/base/graph/MultigraphTests.java
@@ -1,0 +1,264 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link Multigraph} and {@link MultiEdge}.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+class MultigraphTests {
+
+    // -------------------------------------------------------------------------
+    // Basic structure
+    // -------------------------------------------------------------------------
+
+    @Test
+    void emptyMultigraphShouldBeEmpty() {
+        final var graph = Multigraph.<String>directed().build();
+        assertThat(graph.isEmpty()).isTrue();
+        assertThat(graph.vertices()).isEmpty();
+        assertThat(graph.edges()).isEmpty();
+        assertThat(graph.isDirected()).isTrue();
+    }
+
+    @Test
+    void addedVerticesShouldBePresent() {
+        final var graph = Multigraph.<String>directed()
+            .addVertex("A")
+            .addVertex("B")
+            .build();
+
+        assertThat(graph.vertices()).containsExactly("A", "B");
+        assertThat(graph.contains("A")).isTrue();
+        assertThat(graph.contains("Z")).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Parallel edges — the core multigraph feature
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parallelEdgesShouldBeDistinctObjects() {
+        final var builder = Multigraph.<String>directed();
+        final MultiEdge<String> e1 = builder.addEdge("A", "B");
+        final MultiEdge<String> e2 = builder.addEdge("A", "B");
+        final var graph = builder.build();
+
+        assertThat(e1).isNotSameAs(e2);
+        assertThat(graph.edgeCount()).isEqualTo(2);
+        assertThat(graph.multiplicity("A", "B")).isEqualTo(2);
+        assertThat(graph.edgesConnecting("A", "B")).hasSize(2);
+        assertThat(graph.edgesConnecting("A", "B")).containsExactly(e1, e2);
+    }
+
+    @Test
+    void hasEdgeShouldReturnTrueWhenAnyParallelEdgeExists() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        final var graph = builder.build();
+
+        assertThat(graph.hasEdge("A", "B")).isTrue();
+        assertThat(graph.hasEdge("B", "A")).isFalse();
+    }
+
+    @Test
+    void successorsShouldReturnDistinctVerticesDespiteParallelEdges() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "C");
+        final var graph = builder.build();
+
+        // successors returns distinct vertices, not one per edge
+        assertThat(graph.successors("A")).containsExactlyInAnyOrder("B", "C");
+    }
+
+    @Test
+    void predecessorsShouldReturnDistinctVerticesDespiteParallelEdges() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "C");
+        builder.addEdge("A", "C");
+        builder.addEdge("B", "C");
+        final var graph = builder.build();
+
+        assertThat(graph.predecessors("C")).containsExactlyInAnyOrder("A", "B");
+    }
+
+    @Test
+    void edgeCountShouldCountEachParallelEdgeSeparately() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");
+        final var graph = builder.build();
+
+        assertThat(graph.edgeCount()).isEqualTo(3);
+        assertThat(graph.multiplicity("A", "B")).isEqualTo(3);
+        assertThat(graph.multiplicity("B", "A")).isEqualTo(0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Undirected multigraph
+    // -------------------------------------------------------------------------
+
+    @Test
+    void undirectedParallelEdgeShouldBeNavigableInBothDirections() {
+        final var builder = Multigraph.<String>undirected();
+        builder.addEdge("A", "B");
+        final var graph = builder.build();
+
+        assertThat(graph.hasEdge("A", "B")).isTrue();
+        assertThat(graph.hasEdge("B", "A")).isTrue();
+        assertThat(graph.successors("A")).containsExactly("B");
+        assertThat(graph.successors("B")).containsExactly("A");
+        // undirected: only 1 logical edge in the edges() list
+        assertThat(graph.edgeCount()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // MultiEdge identity
+    // -------------------------------------------------------------------------
+
+    @Test
+    void multiEdgeShouldHaveReferenceIdentity() {
+        final var e1 = new MultiEdge<>("A", "B");
+        final var e2 = new MultiEdge<>("A", "B");
+
+        // Same endpoints, different objects — must NOT be equal
+        assertThat(e1).isNotEqualTo(e2);
+        assertThat(e1).isEqualTo(e1);
+    }
+
+    @Test
+    void multiEdgeSelfLoopShouldBeDetected() {
+        final var e = new MultiEdge<>("A", "A");
+        assertThat(e.isSelfLoop()).isTrue();
+
+        final var e2 = new MultiEdge<>("A", "B");
+        assertThat(e2.isSelfLoop()).isFalse();
+    }
+
+    @Test
+    void toEdgeShouldProduceValueTypeEdge() {
+        final var me = new MultiEdge<>("X", "Y");
+        final var e = me.toEdge();
+
+        assertThat(e.from()).isEqualTo("X");
+        assertThat(e.to()).isEqualTo("Y");
+        assertThat(e).isEqualTo(new Edge<>("X", "Y"));
+    }
+
+    // -------------------------------------------------------------------------
+    // toSimpleGraph
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toSimpleGraphShouldCollapseParallelEdges() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");
+        builder.addEdge("B", "C");
+        final var graph = builder.build();
+
+        final var simple = graph.toSimpleGraph();
+        assertThat(simple.edgeCount()).isEqualTo(2);
+        assertThat(simple.hasEdge("A", "B")).isTrue();
+        assertThat(simple.hasEdge("B", "C")).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Algorithms via VertexGraph — the payoff of the shared interface
+    // -------------------------------------------------------------------------
+
+    @Test
+    void bfsShouldWorkOnMultigraph() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");  // parallel edge — should not affect traversal
+        builder.addEdge("B", "C");
+        final var graph = builder.build();
+
+        final var result = GraphTraversal.breadthFirstSearch(graph, "A");
+        assertThat(result).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    void topologicalSortShouldWorkOnMultigraph() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");  // parallel
+        builder.addEdge("B", "C");
+        final var graph = builder.build();
+
+        final var sorted = GraphOrdering.topologicalSort(graph);
+        assertThat(sorted.indexOf("C")).isLessThan(sorted.indexOf("B"));
+        assertThat(sorted.indexOf("B")).isLessThan(sorted.indexOf("A"));
+    }
+
+    @Test
+    void cycleDetectionShouldWorkOnMultigraph() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("B", "A");  // cycle
+        final var graph = builder.build();
+
+        assertThat(GraphCycles.hasCycle(graph)).isTrue();
+    }
+
+    @Test
+    void sccShouldWorkOnMultigraph() {
+        final var builder = Multigraph.<String>directed();
+        builder.addEdge("A", "B");
+        builder.addEdge("A", "B");  // parallel
+        builder.addEdge("B", "C");
+        builder.addEdge("C", "A");  // cycle: A-B-C-A
+        final var graph = builder.build();
+
+        final var sccs = GraphConnectivity.stronglyConnectedComponents(graph);
+        assertThat(sccs).hasSize(1);
+        assertThat(sccs.getFirst().vertices()).containsExactlyInAnyOrder("A", "B", "C");
+    }
+
+    // -------------------------------------------------------------------------
+    // Null guards
+    // -------------------------------------------------------------------------
+
+    @Test
+    void addVertexShouldRejectNull() {
+        assertThatThrownBy(() -> Multigraph.<String>directed().addVertex(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void addEdgeShouldRejectNullVertices() {
+        assertThatThrownBy(() -> Multigraph.<String>directed().addEdge(null, "B"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Multigraph.<String>directed().addEdge("A", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/base-graph/src/test/java/build/base/graph/WeightedGraphTests.java
+++ b/base-graph/src/test/java/build/base/graph/WeightedGraphTests.java
@@ -1,0 +1,174 @@
+package build.base.graph;
+
+/*-
+ * #%L
+ * base.build Graph
+ * %%
+ * Copyright (C) 2026 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link WeightedGraph} construction and structural queries.
+ *
+ * @author reed.von.redwitz
+ * @since Apr-2026
+ */
+class WeightedGraphTests {
+
+    @Test
+    void emptyWeightedGraphShouldBeEmpty() {
+        final var graph = WeightedGraph.<String, Integer>directed().build();
+        assertThat(graph.isEmpty()).isTrue();
+        assertThat(graph.vertices()).isEmpty();
+        assertThat(graph.edges()).isEmpty();
+        assertThat(graph.vertexCount()).isEqualTo(0);
+        assertThat(graph.edgeCount()).isEqualTo(0);
+    }
+
+    @Test
+    void addedVerticesShouldBePresent() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addVertex("A")
+            .addVertex("B")
+            .build();
+
+        assertThat(graph.vertices()).containsExactly("A", "B");
+        assertThat(graph.contains("A")).isTrue();
+        assertThat(graph.contains("Z")).isFalse();
+    }
+
+    @Test
+    void edgeShouldStoreWeight() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 7)
+            .build();
+
+        assertThat(graph.hasEdge("A", "B")).isTrue();
+        assertThat(graph.weight("A", "B")).hasValue(7);
+        assertThat(graph.edge("A", "B")).hasValueSatisfying(e -> {
+            assertThat(e.from()).isEqualTo("A");
+            assertThat(e.to()).isEqualTo("B");
+            assertThat(e.weight()).isEqualTo(7);
+        });
+    }
+
+    @Test
+    void missingEdgeShouldReturnEmpty() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 5)
+            .build();
+
+        assertThat(graph.weight("B", "A")).isEmpty();
+        assertThat(graph.edge("B", "A")).isEmpty();
+        assertThat(graph.hasEdge("B", "A")).isFalse();
+    }
+
+    @Test
+    void laterWeightShouldOverridePrevious() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 3)
+            .addEdge("A", "B", 99)
+            .build();
+
+        assertThat(graph.weight("A", "B")).hasValue(99);
+        assertThat(graph.edgeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void undirectedWeightedEdgeShouldBeNavigableInBothDirections() {
+        final var graph = WeightedGraph.<String, Integer>undirected()
+            .addEdge("A", "B", 4)
+            .build();
+
+        assertThat(graph.hasEdge("A", "B")).isTrue();
+        assertThat(graph.hasEdge("B", "A")).isTrue();
+        assertThat(graph.weight("A", "B")).hasValue(4);
+        assertThat(graph.weight("B", "A")).hasValue(4);
+    }
+
+    @Test
+    void addEdgeViaWeightedEdgeRecordShouldWork() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge(new WeightedEdge<>("X", "Y", 12))
+            .build();
+
+        assertThat(graph.hasEdge("X", "Y")).isTrue();
+        assertThat(graph.weight("X", "Y")).hasValue(12);
+    }
+
+    @Test
+    void successorsShouldListOutgoingVertices() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 1)
+            .addEdge("A", "C", 2)
+            .build();
+
+        assertThat(graph.successors("A")).containsExactlyInAnyOrder("B", "C");
+        assertThat(graph.successors("B")).isEmpty();
+    }
+
+    @Test
+    void predecessorsShouldListIncomingVertices() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 1)
+            .addEdge("A", "C", 2)
+            .addEdge("B", "C", 3)
+            .build();
+
+        assertThat(graph.predecessors("A")).isEmpty();
+        assertThat(graph.predecessors("B")).containsExactly("A");
+        assertThat(graph.predecessors("C")).containsExactlyInAnyOrder("A", "B");
+    }
+
+    @Test
+    void toUnweightedGraphShouldPreserveStructure() {
+        final var weighted = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 1)
+            .addEdge("B", "C", 2)
+            .build();
+
+        final var unweighted = weighted.toUnweightedGraph();
+        assertThat(unweighted.vertices()).containsExactly("A", "B", "C");
+        assertThat(unweighted.hasEdge("A", "B")).isTrue();
+        assertThat(unweighted.hasEdge("B", "C")).isTrue();
+        assertThat(unweighted.isDirected()).isTrue();
+    }
+
+    @Test
+    void addVertexShouldRejectNull() {
+        assertThatThrownBy(() -> WeightedGraph.<String, Integer>directed().addVertex(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void addEdgeShouldRejectNullWeight() {
+        assertThatThrownBy(() -> WeightedGraph.<String, Integer>directed().addEdge("A", "B", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void toStringShouldDescribeGraph() {
+        final var graph = WeightedGraph.<String, Integer>directed()
+            .addEdge("A", "B", 5)
+            .build();
+        assertThat(graph.toString()).contains("directed=true", "vertices=2", "edges=1");
+    }
+}

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -102,6 +102,21 @@ Three complementary extensibility mechanisms coexist:
 
 ---
 
+## base-graph Integration Roadmap
+
+`base-graph` was added to give the library a shared, well-tested graph abstraction. The intent is for higher-level modules to depend on it rather than rolling their own traversal. Findings per module:
+
+| Module | Integration potential | Blocker |
+|---|---|---|
+| `base-foundation` | None — excluded by design | `base-foundation` is the root of the dependency tree; having it depend on `base-graph` would be architecturally backwards (and likely circular). `Streams.topologicalSort()` stays. |
+| `base-mereology` | **Limited** — additive only (cycle detection guard + `Composites.toGraph()`) | Mereology's iterators are lazy (compute-on-demand); `GraphTraversal` materializes eagerly. The parthood iterators also track `Entity` hierarchy context that base-graph has no model for. Deep replacement would require lazy traversal support in base-graph. |
+| `base-query` | **Promising** — `Scope.DepthFirst`/`BreadthFirst` are unimplemented stubs (`HeapBasedIndex.traverse()` returns empty iterators). A `GraphIndex<V>` class in `base-graph` wrapping a `Graph<V>` and implementing `traverse()` via `GraphTraversal` would make them work. Clean integration — implementing a placeholder, not replacing working code. | None identified. |
+| `base-flow` | **Not viable at the framework level.** The pub/sub topology is implicit and dynamic — each `SubscriberRegistry` only knows its own subscribers, not the full graph. Cycle detection would require the caller to explicitly model the full topology as a `Graph<Publisher>` and validate it before wiring. That's useful application-level advice but there is nothing in base-flow itself to change. | Topology is implicit and dynamic; incompatible with the static immutable `Graph<V>` model. |
+
+**Next step:** `base-query` is the only viable integration. A `GraphIndex<V>` in `base-graph` implementing the existing `traverse()` stubs via `GraphTraversal` would make `Scope.DepthFirst`/`BreadthFirst` actually work. If `base-mereology` is ever revisited, the prerequisite is a lazy/streaming traversal API in `base-graph`.
+
+---
+
 ## Major Enhancements to Existing Modules
 
 ### Bridge the Two Error Models

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <module>base-expression</module>
         <module>base-flow</module>
         <module>base-foundation</module>
+        <module>base-graph</module>
         <module>base-io</module>
         <module>base-logging</module>
         <module>base-marshalling</module>


### PR DESCRIPTION
Introduces base-graph, a new JPMS module providing a well-tested, immutable graph abstraction.

Graph types
- Graph<V> — directed or undirected, unweighted
- WeightedGraph<V, W> — typed edge weights with Comparable constraint
- Multigraph<V> — multiple parallel edges between vertex pairs
- VertexGraph<V> — common interface all three implement, enabling polymorphic algorithms
                                                                                                                                                                                                                                                           
Algorithms (all operate on VertexGraph<V> via the Graphs facade)
- Traversal: BFS, DFS, reachability, ancestors, descendants — O(V+E)
- Ordering: topological sort (Kahn's), parallelizable layer groups — O(V+E)
- Cycles: detection and path reconstruction (iterative DFS, tri-colour) — O(V+E)
- Connectivity: strongly connected components (iterative Tarjan's) — O(V+E)
- Paths: unweighted shortest path (BFS), weighted shortest path (Dijkstra w/ lazy deletion) — O(V+E) / O(E log E)
- Reduction: transitive reduction with precomputed reachability — O(V·(V+E))

Design notes
- GraphCollections factory decouples storage from algorithms; callers can substitute fastutil or other high-performance backends without touching algorithm code
- All traversals are iterative (explicit stack/queue) — no stack overflow risk on large graphs
- Directed-only algorithms (topologicalSort, parallelizableGroups, stronglyConnectedComponents, transitiveReduction) reject undirected graphs with IllegalArgumentException
- All public algorithm methods document time complexity