### PR TITLE
fix(base-marshalling): support enum marshalling via registerEnum

### DIFF
--- a/base-marshalling/src/main/java/build/base/marshalling/ConcurrentSchemaFactory.java
+++ b/base-marshalling/src/main/java/build/base/marshalling/ConcurrentSchemaFactory.java
@@ -9,9 +9,9 @@ package build.base.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -70,12 +70,20 @@ public class ConcurrentSchemaFactory
     private final CopyOnWriteArraySet<Class<?>> unmarshallableClasses;
 
     /**
+     * The {@link Schema}s for explicitly registered enum {@link Class}es.
+     * Enums cannot declare {@link Marshal}/{@link Unmarshal} methods, so they are registered
+     * separately via {@link #registerEnum(Class)} and serialized by their {@link Enum#name()}.
+     */
+    private final ConcurrentHashMap<Class<?>, Schema<?>> enumSchemasByClass;
+
+    /**
      * Constructs the {@link ConcurrentSchemaFactory}.
      */
     public ConcurrentSchemaFactory() {
         this.marshallingSchemasByClass = new ConcurrentHashMap<>();
         this.unmarshallingSchemasByClass = new ConcurrentHashMap<>();
         this.unmarshallableClasses = new CopyOnWriteArraySet<>();
+        this.enumSchemasByClass = new ConcurrentHashMap<>();
     }
 
     /**
@@ -94,8 +102,7 @@ public class ConcurrentSchemaFactory
 
             try {
                 Class.forName(initializableClass.getName());
-            }
-            catch (final ClassNotFoundException e) {
+            } catch (final ClassNotFoundException e) {
                 this.unmarshallableClasses.add(initializableClass);
                 throw new IllegalArgumentException("Failed to load " + initializableClass, e);
             }
@@ -106,21 +113,19 @@ public class ConcurrentSchemaFactory
     public boolean isMarshallable(final Class<?> marshallableClass) {
         if (marshallableClass == null || this.unmarshallableClasses.contains(marshallableClass)) {
             return false;
-        }
-        else {
+        } else if (this.enumSchemasByClass.containsKey(marshallableClass)) {
+            return true;
+        } else {
             ensureInitialized(marshallableClass);
             if (this.unmarshallableClasses.contains(marshallableClass)) {
                 return false;
-            }
-            else if (this.marshallingSchemasByClass.containsKey(marshallableClass)) {
+            } else if (this.marshallingSchemasByClass.containsKey(marshallableClass)) {
                 return true;
-            }
-            else {
+            } else {
                 try {
                     register(marshallableClass);
                     return this.marshallingSchemasByClass.containsKey(marshallableClass);
-                }
-                catch (final RuntimeException e) {
+                } catch (final RuntimeException e) {
                     this.unmarshallableClasses.add(marshallableClass);
                     return false;
                 }
@@ -237,7 +242,7 @@ public class ConcurrentSchemaFactory
             this.unmarshallableClasses.add(marshallableClass);
             throw new IllegalArgumentException("The class " + marshallableClass.getName()
                 + " has @Unmarshal on method(s) " + unmarshalMethods.stream()
-                    .map(Method::getName).toList()
+                .map(Method::getName).toList()
                 + " — @Unmarshal is only supported on constructors");
         }
 
@@ -294,8 +299,7 @@ public class ConcurrentSchemaFactory
                                     });
 
                                     return false;
-                                }
-                                else {
+                                } else {
                                     return true;
                                 }
                             })
@@ -337,10 +341,62 @@ public class ConcurrentSchemaFactory
 
     @Override
     @SuppressWarnings("unchecked")
+    public <E extends Enum<E>> void registerEnum(final Class<E> enumClass) {
+
+        Objects.requireNonNull(enumClass, "The enum class must not be null");
+
+        if (!enumClass.isEnum()) {
+            throw new IllegalArgumentException("Class " + enumClass.getName() + " is not an enum");
+        }
+
+        final Parameter nameParam = new Parameter() {
+            @Override
+            public String name() {
+                return "name";
+            }
+
+            @Override
+            public Type type() {
+                return String.class;
+            }
+        };
+
+        final Schema<E> schema = new Schema<>() {
+            @Override
+            public Class<E> owner() {
+                return enumClass;
+            }
+
+            @Override
+            public Streamable<Parameter> parameters() {
+                return Streamable.of(Stream.of(nameParam));
+            }
+
+            @Override
+            public Optional<Parameter> getParameter(final String n) {
+                return "name".equals(n) ? Optional.of(nameParam) : Optional.empty();
+            }
+
+            @Override
+            public Streamable<Dependency> dependencies() {
+                return Streamable.of(Stream.empty());
+            }
+        };
+
+        this.enumSchemasByClass.putIfAbsent(enumClass, schema);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public <T> Optional<Schema<T>> getMarshallingSchema(final Class<T> marshallableClass) {
 
         if (marshallableClass == null) {
             return Optional.empty();
+        }
+
+        final var enumSchema = (Schema<T>) this.enumSchemasByClass.get(marshallableClass);
+        if (enumSchema != null) {
+            return Optional.of(enumSchema);
         }
 
         ensureInitialized(marshallableClass);
@@ -356,6 +412,11 @@ public class ConcurrentSchemaFactory
             return Stream.empty();
         }
 
+        final var enumSchema = (Schema<T>) this.enumSchemasByClass.get(marshallableClass);
+        if (enumSchema != null) {
+            return Stream.of(enumSchema);
+        }
+
         ensureInitialized(marshallableClass);
 
         final var schemas = this.unmarshallingSchemasByClass.get(marshallableClass);
@@ -363,7 +424,7 @@ public class ConcurrentSchemaFactory
         return schemas == null
             ? Stream.empty()
             : schemas.stream()
-                .map(schema -> (Schema<T>) schema);
+            .map(schema -> (Schema<T>) schema);
     }
 
     @Override
@@ -494,8 +555,7 @@ public class ConcurrentSchemaFactory
                             .map(out -> out.orElse(null)));
                     }
                 };
-            }
-            catch (final IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
+            } catch (final IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
                 throw new RuntimeException("Failed to marshal " + object, e);
             }
         }
@@ -611,8 +671,7 @@ public class ConcurrentSchemaFactory
             try {
                 // invoke the constructor to perform unmarshalling
                 return this.constructor.newInstance(arguments);
-            }
-            catch (final IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            } catch (final IllegalAccessException | InstantiationException | InvocationTargetException e) {
                 throw new RuntimeException("Failed to unmarshal " + marshalled.schema().owner().getCanonicalName(), e);
             }
         }
@@ -658,12 +717,30 @@ public class ConcurrentSchemaFactory
         }
 
         @Override
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "rawtypes"})
         public <T> Marshalled<T> marshal(final T object) {
             Objects.requireNonNull(object, "The object to marshal must not be null");
 
             // obtain the Schema for the Object
             final var marshallableClass = (Class<T>) object.getClass();
+
+            // Check for explicitly registered enums (serialized by name)
+            final var enumSchema = (Schema<T>) ConcurrentSchemaFactory.this.enumSchemasByClass.get(marshallableClass);
+            if (enumSchema != null) {
+                final var enumName = ((Enum) object).name();
+                return new Marshalled<>() {
+                    @Override
+                    public Schema<T> schema() {
+                        return enumSchema;
+                    }
+
+                    @Override
+                    public Streamable<Object> values() {
+                        return Streamable.of(Stream.of(enumName));
+                    }
+                };
+            }
+
             final var schema = (MarshallingSchema<T>) ConcurrentSchemaFactory.this
                 .marshallingSchemasByClass.get(marshallableClass);
 
@@ -677,9 +754,17 @@ public class ConcurrentSchemaFactory
         }
 
         @Override
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "rawtypes"})
         public <T> T unmarshal(final Marshalled<T> marshalled) {
             Objects.requireNonNull(marshalled, "The Marshalled must not be null");
+
+            // Check for explicitly registered enums (deserialized by name via Enum.valueOf)
+            if (ConcurrentSchemaFactory.this.enumSchemasByClass.containsKey(marshalled.schema().owner())) {
+                final var enumName = (String) marshalled.values().stream().findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                        "No name value present for enum " + marshalled.schema().owner()));
+                return (T) Enum.valueOf((Class<Enum>) marshalled.schema().owner(), enumName);
+            }
 
             // obtain the UnmarshallingSchema for the owner of the Marshalled
             final var schemas = ConcurrentSchemaFactory.this

--- a/base-marshalling/src/main/java/build/base/marshalling/Marshalling.java
+++ b/base-marshalling/src/main/java/build/base/marshalling/Marshalling.java
@@ -9,9 +9,9 @@ package build.base.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,6 +63,17 @@ public interface Marshalling {
      */
     static <T> void register(final Class<T> marshallableClass) {
         GLOBAL_SCHEMA_FACTORY.register(marshallableClass);
+    }
+
+    /**
+     * Registers an enum {@link Class} as marshallable, using its {@link Enum#name()} for serialization
+     * and {@link Enum#valueOf(Class, String)} for deserialization.
+     *
+     * @param enumClass the enum {@link Class} to register
+     * @param <E>       the enum type
+     */
+    static <E extends Enum<E>> void registerEnum(final Class<E> enumClass) {
+        GLOBAL_SCHEMA_FACTORY.registerEnum(enumClass);
     }
 
     /**

--- a/base-marshalling/src/main/java/build/base/marshalling/SchemaFactory.java
+++ b/base-marshalling/src/main/java/build/base/marshalling/SchemaFactory.java
@@ -9,9 +9,9 @@ package build.base.marshalling;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,6 +61,20 @@ public interface SchemaFactory {
      * @param <T>               the type of <i>marshallable</i> {@link Class}
      */
     <T> void register(Class<T> marshallableClass, MethodHandles.Lookup lookup);
+
+    /**
+     * Registers an enum {@link Class} as marshallable, using its {@link Enum#name()} for serialization
+     * and {@link Enum#valueOf(Class, String)} for deserialization.
+     * <p>
+     * Enums cannot declare {@link Marshal}/{@link Unmarshal} methods and must be explicitly opted in
+     * via this method to be marshallable.
+     * <p>
+     * Should the enum already be registered, the request is ignored.
+     *
+     * @param enumClass the enum {@link Class} to register
+     * @param <E>       the enum type
+     */
+    <E extends Enum<E>> void registerEnum(Class<E> enumClass);
 
     /**
      * Obtains the {@link Schema} to <i>marshal</i> the specified {@link Class}.

--- a/base-marshalling/src/test/java/build/base/marshalling/MarshallingTests.java
+++ b/base-marshalling/src/test/java/build/base/marshalling/MarshallingTests.java
@@ -9,7 +9,11 @@ import build.base.marshalling.example.PointWithMarshaller;
 import build.base.marshalling.example.StaticallyRegisteredPoint;
 import build.base.marshalling.example.Wrapper;
 import build.base.marshalling.tutorial.Address;
+import build.base.marshalling.tutorial.Color;
+import build.base.marshalling.tutorial.PersonWithFavoriteColor;
 import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -342,6 +346,113 @@ class MarshallingTests {
         // ensure the Address part of the Person is not the same instance
         assertThat(unmarshalled.address())
             .isNotSameAs(person.address());
+    }
+
+    /**
+     * Ensure an enum {@link Class} can be registered as marshallable and its {@link Schema}s are accessible.
+     */
+    @Test
+    void shouldRegisterEnumAsMarshallable() {
+
+        final var schemaFactory = Marshalling.globalSchemaFactory();
+
+        assertThat(schemaFactory.isMarshallable(Color.class))
+            .isTrue();
+
+        final var marshallingSchema = schemaFactory
+            .getMarshallingSchema(Color.class)
+            .orElseThrow();
+
+        assertThat(marshallingSchema.owner())
+            .isEqualTo(Color.class);
+
+        assertThat(marshallingSchema.parameters().stream().map(Parameter::name))
+            .containsExactly("name");
+
+        assertThat(marshallingSchema.parameters().stream().map(Parameter::type))
+            .containsExactly(String.class);
+
+        final var unmarshallingSchema = schemaFactory
+            .getUnmarshallingSchemas(Color.class)
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(unmarshallingSchema.owner())
+            .isEqualTo(Color.class);
+
+        assertThat(unmarshallingSchema.parameters().stream().map(Parameter::name))
+            .containsExactly("name");
+    }
+
+    /**
+     * Ensure each element of a {@link Stream} of enum values can be marshalled and unmarshalled
+     * directly via the {@link Marshaller} — the scenario that originally exposed this bug.
+     */
+    @Test
+    void shouldMarshalAndUnmarshalStreamOfEnums() {
+
+        final var marshaller = Marshalling.globalSchemaFactory().newMarshaller();
+
+        final var colors = Stream.of(Color.RED, Color.GREEN, Color.BLUE);
+
+        final var roundTripped = colors
+            .map(marshaller::marshal)
+            .map(marshaller::unmarshal)
+            .toList();
+
+        assertThat(roundTripped)
+            .containsExactly(Color.RED, Color.GREEN, Color.BLUE);
+    }
+
+    /**
+     * Ensure a registered enum can be marshalled and unmarshalled directly.
+     */
+    @Test
+    void shouldMarshalAndUnmarshalEnum() {
+
+        final var schemaFactory = Marshalling.globalSchemaFactory();
+
+        final var marshaller = schemaFactory.newMarshaller();
+
+        final var marshalled = marshaller.marshal(Color.BLUE);
+
+        assertThat(marshalled.schema().owner())
+            .isEqualTo(Color.class);
+
+        assertThat(marshalled.values().stream())
+            .containsExactly("BLUE");
+
+        final Color unmarshalled = marshaller.unmarshal(marshalled);
+
+        assertThat(unmarshalled)
+            .isEqualTo(Color.BLUE);
+    }
+
+    /**
+     * Ensure a marshallable {@link Object} containing an enum field can be marshalled and unmarshalled
+     * when the enum is registered via {@link Marshalling#registerEnum(Class)}.
+     */
+    @Test
+    void shouldMarshalAndUnmarshalClassContainingEnum() {
+
+        final var schemaFactory = Marshalling.globalSchemaFactory();
+
+        final var person = new PersonWithFavoriteColor("Ada", "Lovelace", Color.PURPLE);
+
+        final var marshaller = schemaFactory.newMarshaller();
+
+        final var marshalled = marshaller.marshal(person);
+
+        assertThat(marshalled)
+            .isNotNull();
+
+        final PersonWithFavoriteColor unmarshalled = marshaller.unmarshal(marshalled);
+
+        assertThat(unmarshalled)
+            .isNotSameAs(person);
+
+        assertThat(unmarshalled)
+            .isEqualTo(person);
     }
 
     @Test

--- a/base-marshalling/src/test/java/build/base/marshalling/tutorial/Color.java
+++ b/base-marshalling/src/test/java/build/base/marshalling/tutorial/Color.java
@@ -9,9 +9,9 @@ package build.base.marshalling.tutorial;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,8 @@ package build.base.marshalling.tutorial;
  * limitations under the License.
  * #L%
  */
+
+import build.base.marshalling.Marshalling;
 
 /**
  * Some colors for testing.
@@ -35,4 +37,8 @@ public enum Color {
     WHITE,
     YELLOW,
     ORANGE;
+
+    static {
+        Marshalling.registerEnum(Color.class);
+    }
 }

--- a/base-transport-json/src/test/java/build/base/transport/json/JsonTransportTests.java
+++ b/base-transport-json/src/test/java/build/base/transport/json/JsonTransportTests.java
@@ -516,6 +516,29 @@ public class JsonTransportTests {
     }
 
     /**
+     * Ensure a registered {@code enum} can be marshalled and unmarshalled directly via the marshaller,
+     * as required when iterating a {@link java.util.stream.Stream} and marshalling each element.
+     */
+    @Test
+    void shouldMarshalAndUnmarshalRegisteredEnumDirectly() {
+
+        final var marshaller = Marshalling.newMarshaller();
+
+        final var marshalled = marshaller.marshal(Country.Australia);
+
+        assertThat(marshalled.schema().owner())
+            .isEqualTo(Country.class);
+
+        assertThat(marshalled.values().stream())
+            .containsExactly("Australia");
+
+        final Country unmarshalled = marshaller.unmarshal(marshalled);
+
+        assertThat(unmarshalled)
+            .isEqualTo(Country.Australia);
+    }
+
+    /**
      * Ensure {@link Marshal}lable with an {@code enum} can be transported.
      *
      * @throws IOException should an exception occur
@@ -655,7 +678,7 @@ public class JsonTransportTests {
         throws IOException {
 
         final var original = new StreamsAndOptionals(null,
-            Arrays.stream(new String[] { "One", "Two" }),
+            Arrays.stream(new String[]{"One", "Two"}),
             null,
             Optional.of("Optional"));
 

--- a/base-transport-json/src/test/java/build/base/transport/json/example/Country.java
+++ b/base-transport-json/src/test/java/build/base/transport/json/example/Country.java
@@ -9,9 +9,9 @@ package build.base.transport.json.example;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,8 @@ package build.base.transport.json.example;
  * limitations under the License.
  * #L%
  */
+
+import build.base.marshalling.Marshalling;
 
 /**
  * An enumeration of a few countries.
@@ -31,5 +33,9 @@ public enum Country {
     Germany,
     UnitedStates,
     UnitedKingdom,
-    Unspecified
+    Unspecified;
+
+    static {
+        Marshalling.registerEnum(Country.class);
+    }
 }


### PR DESCRIPTION
Enums cannot declare `@Marshal`/`@Unmarshal` methods, so there was previously no way to make `isMarshallable` return true for an enum class. This caused `AbstractTraitable.destructor` in `codemodel` to silently drop enum traits — they were filtered out by the `marshaller.isMarshallable(trait.getClass())` guard with no error.
                                                                                                                                                                                                                                                           
Adds `SchemaFactory.registerEnum(Class<E>)` (and `Marshalling.registerEnum`) as an explicit opt-in for enum classes, serializing by `Enum.name()` and deserializing via `Enum.valueOf`. Also fixes `getMarshallingSchema` and `getUnmarshallingSchemas` which were not consulting the enum registry, making them inconsistent with `isMarshallable`.