### PR TITLE
feat(base-commandline): commands, categories, multi-prefix options, and positional argument builder

### DIFF
--- a/base-commandline/src/main/java/build/base/commandline/Command.java
+++ b/base-commandline/src/main/java/build/base/commandline/Command.java
@@ -144,6 +144,69 @@ public final class Command {
     }
 
     /**
+     * Registers a named command for display in the help output.
+     * <p>
+     * Commands appear under a {@code Commands:} section in {@code --help}, sorted alphabetically by name.
+     * Registration is purely declarative — it does not affect parsing or validation.
+     *
+     * @param name        the command name as the user would type it (e.g. {@code "compile"})
+     * @param description a short description shown alongside the name in help output
+     * @return this {@link Command}
+     */
+    public Command command(final String name, final String description) {
+        this.registrations.add(parser -> parser.registerCommand(name, description));
+
+        return this;
+    }
+
+    /**
+     * Registers a named category for display in the help output.
+     * <p>
+     * Categories are aggregate aliases that match multiple tasks at once (e.g. {@code "build"} runs
+     * compile, test, and package). They appear under a {@code Categories:} section in {@code --help},
+     * sorted alphabetically by name. Registration is purely declarative — it does not affect parsing.
+     *
+     * @param name        the category name as the user would type it (e.g. {@code "build"})
+     * @param description a short description shown alongside the name in help output
+     * @return this {@link Command}
+     */
+    public Command category(final String name, final String description) {
+        this.registrations.add(parser -> parser.registerCategory(name, description));
+
+        return this;
+    }
+
+    /**
+     * Sets the section heading used for the commands block in help output.
+     * <p>
+     * Defaults to {@code "Commands:"}. Use this to override the heading — for example, a build
+     * tool might prefer {@code "Tasks:"}.
+     *
+     * @param name the section heading
+     * @return this {@link Command}
+     */
+    public Command commandsSectionName(final String name) {
+        this.registrations.add(parser -> parser.setCommandsSectionName(name));
+
+        return this;
+    }
+
+    /**
+     * Sets the section heading used for the categories block in help output.
+     * <p>
+     * Defaults to {@code "Categories:"}. Use this to override the heading — for example, a build
+     * tool might prefer {@code "Aliases:"}.
+     *
+     * @param name the section heading
+     * @return this {@link Command}
+     */
+    public Command categoriesSectionName(final String name) {
+        this.registrations.add(parser -> parser.setCategoriesSectionName(name));
+
+        return this;
+    }
+
+    /**
      * Sets the current help section name for subsequently registered {@link Option}s.
      * <p>
      * All options added after this call appear under the specified heading in the help output,
@@ -206,6 +269,41 @@ public final class Command {
     }
 
     /**
+     * Registers an {@link Option} class with multiple prefixes, a factory method, and an explicit description
+     * for help output.
+     * <p>
+     * All prefixes are registered for parsing and appear together on a single help row. Use this when the
+     * {@link Option} class cannot carry {@link CommandLine.Prefix} or {@link CommandLine.Description} annotations
+     * (e.g. because it lives in a module that does not depend on {@code base-commandline}).
+     *
+     * @param prefixes       the command-line prefixes (e.g. {@code List.of("--working-dir", "-w")})
+     * @param optionClass    the {@link Class} of {@link Option}
+     * @param methodName     the name of the {@code static} factory method
+     * @param description    the description shown in help output
+     * @param parameterTypes the parameter types of the factory method
+     * @return this {@link Command}
+     */
+    public Command option(final List<String> prefixes,
+                          final Class<? extends Option> optionClass,
+                          final String methodName,
+                          final String description,
+                          final Class<?>... parameterTypes) {
+
+        this.registrations.add(parser -> {
+            try {
+                parser.add(prefixes, optionClass, methodName, description, parameterTypes);
+            }
+            catch (final NoSuchMethodException e) {
+                throw new IllegalArgumentException(
+                    "No method [" + methodName + "] with the given parameter types on ["
+                        + optionClass.getName() + "]", e);
+            }
+        });
+
+        return this;
+    }
+
+    /**
      * Registers an environment variable fallback for the specified command-line prefix.
      * <p>
      * When the registered environment variable is set and the option has not been provided on the command line,
@@ -236,6 +334,23 @@ public final class Command {
      */
     public Command envVarResolver(final Function<String, Optional<String>> resolver) {
         this.registrations.add(parser -> parser.setEnvironmentVariableResolver(resolver));
+
+        return this;
+    }
+
+    /**
+     * Sets a {@link Consumer} to receive positional (non-option) arguments — arguments that do not begin with
+     * {@code -} and do not match any registered {@link Option} prefix.
+     * <p>
+     * This is the preferred way to declare first-class positional arguments (e.g. task names) rather than relying
+     * on {@link CommandLineParser#CAPTURE_UNKNOWN_OPTIONS_AS_ARGUMENTS}. Hyphen-prefixed unknowns still fall
+     * through to the {@link CommandLineParser.UnknownOptionConsumer}.
+     *
+     * @param consumer the {@link Consumer} to receive each positional argument value, or {@code null} to clear
+     * @return this {@link Command}
+     */
+    public Command positionalArgument(final Consumer<String> consumer) {
+        this.registrations.add(parser -> parser.setPositionalArgumentConsumer(consumer));
 
         return this;
     }

--- a/base-commandline/src/main/java/build/base/commandline/CommandLineParser.java
+++ b/base-commandline/src/main/java/build/base/commandline/CommandLineParser.java
@@ -214,6 +214,20 @@ public class CommandLineParser {
     private final LinkedHashMap<String, LinkedHashSet<Method>> sectionedMethods;
 
     /**
+     * All registered prefixes per {@link Method}, used for help rendering.
+     * <p>
+     * Populated by every call to {@link #add(String, Class, Method)} so that both annotation-driven
+     * and explicit-prefix registrations appear correctly in help output.
+     */
+    private final LinkedHashMap<Method, LinkedHashSet<String>> methodPrefixes;
+
+    /**
+     * Explicitly supplied descriptions per {@link Method}, used for help rendering when no
+     * {@link CommandLine.Description} annotation is present on the method.
+     */
+    private final LinkedHashMap<Method, String> methodDescriptions;
+
+    /**
      * The current help section name applied to subsequently registered {@link Option}s.
      * <p>
      * Defaults to {@code ""} (no section header). Changed via {@link #setHelpSection(String)}.
@@ -272,6 +286,26 @@ public class CommandLineParser {
     private final LinkedHashMap<String, String> envVarMappings;
 
     /**
+     * Registered commands: name to description. Insertion order preserved for help output.
+     */
+    private final LinkedHashMap<String, String> commands;
+
+    /**
+     * Registered categories: name to description. Insertion order preserved for help output.
+     */
+    private final LinkedHashMap<String, String> categories;
+
+    /**
+     * The section heading for the commands block in help output. Defaults to {@code "Commands:"}.
+     */
+    private String commandsSectionName;
+
+    /**
+     * The section heading for the categories block in help output. Defaults to {@code "Categories:"}.
+     */
+    private String categoriesSectionName;
+
+    /**
      * Constructs a {@link CommandLineParser}.
      */
     public CommandLineParser() {
@@ -282,11 +316,17 @@ public class CommandLineParser {
             : y.length() - x.length());
 
         this.sectionedMethods = new LinkedHashMap<>();
+        this.methodPrefixes = new LinkedHashMap<>();
+        this.methodDescriptions = new LinkedHashMap<>();
         this.currentHelpSection = "";
         this.unknownOptionConsumer = Capture.empty();
         this.positionalArgumentConsumer = Capture.empty();
         this.envVarResolver = name -> Optional.ofNullable(System.getenv(name));
         this.envVarMappings = new LinkedHashMap<>();
+        this.commands = new LinkedHashMap<>();
+        this.categories = new LinkedHashMap<>();
+        this.commandsSectionName = "Commands:";
+        this.categoriesSectionName = "Categories:";
     }
 
     /**
@@ -472,6 +512,45 @@ public class CommandLineParser {
     }
 
     /**
+     * Adds the specified {@link Class} of {@link Option} to the {@link CommandLineParser} for multiple prefixes,
+     * with an explicit description for help output.
+     * <p>
+     * All prefixes are registered for parsing and appear together on a single help row. The description
+     * is used in help output when no {@link CommandLine.Description} annotation is present on the method.
+     *
+     * @param prefixes       the {@link Option} prefixes (e.g. {@code List.of("--working-dir", "-w")})
+     * @param optionClass    the {@link Class} of {@link Option}
+     * @param methodName     the name of the {@code static} {@link Method} to create the {@link Option}
+     * @param description    the description shown in help output
+     * @param parameterTypes the types of parameters for the {@link Method}
+     * @return this {@link CommandLineParser} to permit fluent-style method invocation
+     * @throws NoSuchMethodException when the specified {@link Method} can't be located on the {@link Class}
+     */
+    public CommandLineParser add(final List<String> prefixes,
+                                 final Class<? extends Option> optionClass,
+                                 final String methodName,
+                                 final String description,
+                                 final Class<?>... parameterTypes)
+        throws NoSuchMethodException {
+
+        Objects.requireNonNull(prefixes, "The prefixes must not be null");
+        Objects.requireNonNull(optionClass, "The class of option must not be null");
+        Objects.requireNonNull(methodName, "The method name must not be null");
+
+        final var method = optionClass.getMethod(methodName, parameterTypes);
+
+        for (final String prefix : prefixes) {
+            add(prefix, optionClass, method);
+        }
+
+        if (description != null && !description.isBlank()) {
+            this.methodDescriptions.put(method, description);
+        }
+
+        return this;
+    }
+
+    /**
      * Adds the specified {@link Class} of {@link Option} to the {@link CommandLineParser} for the provided prefix.
      * <p>
      * Unlike {@link #add(Class)}, the specified {@link Option} {@link Class} does not need a {@link Method} to be
@@ -501,6 +580,9 @@ public class CommandLineParser {
             this.sectionedMethods
                 .computeIfAbsent(this.currentHelpSection, k -> new LinkedHashSet<>())
                 .add(method);
+            this.methodPrefixes
+                .computeIfAbsent(method, k -> new LinkedHashSet<>())
+                .add(prefix);
             this.prefixMethods.compute(prefix, (__, methods) -> {
                 if (methods == null) {
                     return new HashSet<>();
@@ -561,6 +643,69 @@ public class CommandLineParser {
     }
 
     /**
+     * Registers a named command for display in the help output.
+     * <p>
+     * Commands are purely declarative — registration does not affect parsing. They appear under a
+     * {@code Commands:} section in help, sorted alphabetically by name.
+     *
+     * @param name        the command name as the user would type it (e.g. {@code "compile"})
+     * @param description a short description shown alongside the name in help output
+     * @return this {@link CommandLineParser} to permit fluent-style method invocation
+     */
+    public CommandLineParser registerCommand(final String name, final String description) {
+        Objects.requireNonNull(name, "The command name must not be null");
+        Objects.requireNonNull(description, "The command description must not be null");
+
+        this.commands.put(name, description);
+
+        return this;
+    }
+
+    /**
+     * Registers a named category for display in the help output.
+     * <p>
+     * Categories are aggregate aliases that match multiple tasks at once (e.g. {@code "build"} runs
+     * compile, test, and package). Registration is purely declarative and does not affect parsing.
+     * They appear under a {@code Categories:} section in help, sorted alphabetically by name.
+     *
+     * @param name        the category name as the user would type it (e.g. {@code "build"})
+     * @param description a short description shown alongside the name in help output
+     * @return this {@link CommandLineParser} to permit fluent-style method invocation
+     */
+    public CommandLineParser registerCategory(final String name, final String description) {
+        Objects.requireNonNull(name, "The category name must not be null");
+        Objects.requireNonNull(description, "The category description must not be null");
+
+        this.categories.put(name, description);
+
+        return this;
+    }
+
+    /**
+     * Sets the section heading used for the commands block in help output.
+     *
+     * @param name the section heading (e.g. {@code "Tasks:"})
+     * @return this {@link CommandLineParser} to permit fluent-style method invocation
+     */
+    public CommandLineParser setCommandsSectionName(final String name) {
+        this.commandsSectionName = Objects.requireNonNull(name, "The commands section name must not be null");
+
+        return this;
+    }
+
+    /**
+     * Sets the section heading used for the categories block in help output.
+     *
+     * @param name the section heading (e.g. {@code "Aliases:"})
+     * @return this {@link CommandLineParser} to permit fluent-style method invocation
+     */
+    public CommandLineParser setCategoriesSectionName(final String name) {
+        this.categoriesSectionName = Objects.requireNonNull(name, "The categories section name must not be null");
+
+        return this;
+    }
+
+    /**
      * Scans the registered option classes and constructs and throws a {@link HelpException} using reflection on
      * {@link CommandLine} annotations.
      */
@@ -577,6 +722,32 @@ public class CommandLineParser {
                 usageLine.append(" ").append(this.helpUsageArguments);
             }
             helpTable.addRow(usageLine.toString());
+        }
+
+        if (!this.commands.isEmpty()) {
+            helpTable.addRow(this.commandsSectionName);
+
+            final var commandsTable = Table.create();
+            commandsTable.options().add(CellSeparator.of("    "));
+            this.commands.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> commandsTable.addRow(Cell.of(entry.getKey()), Cell.of(entry.getValue())));
+
+            helpTable.addRow(commandsTable.toString());
+            helpTable.addRow("");
+        }
+
+        if (!this.categories.isEmpty()) {
+            helpTable.addRow(this.categoriesSectionName);
+
+            final var categoriesTable = Table.create();
+            categoriesTable.options().add(CellSeparator.of("    "));
+            this.categories.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> categoriesTable.addRow(Cell.of(entry.getKey()), Cell.of(entry.getValue())));
+
+            helpTable.addRow(categoriesTable.toString());
+            helpTable.addRow("");
         }
 
         helpTable.addRow("Options:");
@@ -601,20 +772,19 @@ public class CommandLineParser {
 
                 // add the prefixes to the option table
                 optionTable.addRow(String.join(", ",
-                    Arrays.stream(method.getAnnotationsByType(CommandLine.Prefix.class))
-                        .map(CommandLine.Prefix::value)
+                    Optional.ofNullable(this.methodPrefixes.get(method))
+                        .orElseGet(LinkedHashSet::new)
+                        .stream()
                         .collect(Collectors.toCollection(() -> new TreeSet<>(PREFIX_COMPARATOR)))));
 
-                // create a new table for the class/description
+                // create a new table for the description
                 final var infoTable = Table.create();
                 infoTable.options().add(CellSeparator.of("    "));
 
-                // add the option class as a new row
-                infoTable.addRow(Cell.create(), Cell.of("(" + method.getDeclaringClass().getName() + ")"));
-
-                // add the description if it exists
+                // add the description if it exists (annotation takes precedence over explicit)
                 Optional.ofNullable(method.getAnnotation(CommandLine.Description.class))
                     .map(CommandLine.Description::value)
+                    .or(() -> Optional.ofNullable(this.methodDescriptions.get(method)))
                     .ifPresent(description -> infoTable.addRow(Cell.create(), Cell.of(description)));
 
                 // add the info table to the optionTable

--- a/base-commandline/src/test/java/build/base/commandline/CommandLineParserTests.java
+++ b/base-commandline/src/test/java/build/base/commandline/CommandLineParserTests.java
@@ -644,6 +644,141 @@ class CommandLineParserTests {
     }
 
     /**
+     * Ensure {@link CommandLineParser#add(java.util.List, Class, String, String, Class[])} registers all provided
+     * prefixes so the option can be parsed via any of them.
+     */
+    @Test
+    void shouldRegisterAllExplicitPrefixes()
+        throws NoSuchMethodException {
+
+        final var parser = new CommandLineParser()
+            .add(List.of("--zero", "-z"), ZeroArgumentOption.class, "autodetect", null);
+
+        assertThat(parser.parse("--zero").build().get(ZeroArgumentOption.class)).isNotNull();
+        assertThat(parser.parse("-z").build().get(ZeroArgumentOption.class)).isNotNull();
+    }
+
+    /**
+     * Ensure an explicit description supplied to
+     * {@link CommandLineParser#add(java.util.List, Class, String, String, Class[])} appears in help output
+     * when the factory method carries no {@link CommandLine.Description} annotation.
+     */
+    @Test
+    void shouldUseExplicitDescriptionInHelpWhenNoAnnotation()
+        throws NoSuchMethodException {
+
+        final List<String> helpOutput = new ArrayList<>();
+
+        new CommandLineParser()
+            .setHelpHandler(helpOutput::add)
+            .add(List.of("--zero"), ZeroArgumentOption.class, "autodetect", "An explicit description");
+
+        // ZeroArgumentOption has no @Description — the explicit one must appear
+        // Trigger help
+        new CommandLineParser()
+            .setHelpHandler(helpOutput::add)
+            .add(List.of("--zero"), ZeroArgumentOption.class, "autodetect", "An explicit description")
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        assertThat(helpOutput.getFirst()).contains("An explicit description");
+    }
+
+    /**
+     * Ensure a {@link CommandLine.Description} annotation takes precedence over an explicit description
+     * passed to {@link CommandLineParser#add(java.util.List, Class, String, String, Class[])}.
+     */
+    @Test
+    void shouldPreferAnnotationDescriptionOverExplicitDescription()
+        throws NoSuchMethodException {
+
+        final List<String> helpOutput = new ArrayList<>();
+
+        new CommandLineParser()
+            .setHelpHandler(helpOutput::add)
+            .add(List.of("--add"), TwoArgumentOption.class, "of", "Explicit ignored", int.class, int.class)
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        assertThat(helpOutput.getFirst()).contains("Adds two ints");
+        assertThat(helpOutput.getFirst()).doesNotContain("Explicit ignored");
+    }
+
+    /**
+     * Ensure {@link CommandLineParser#registerCommand(String, String)} and
+     * {@link CommandLineParser#registerCategory(String, String)} cause their entries to appear under
+     * {@code Commands:} and {@code Categories:} sections in help output.
+     */
+    @Test
+    void shouldRenderCommandsAndCategoriesInHelp() {
+        final List<String> helpOutput = new ArrayList<>();
+
+        new CommandLineParser()
+            .setHelpHandler(helpOutput::add)
+            .add(ZeroArgumentOption.class)
+            .registerCommand("compile", "Compiles sources")
+            .registerCommand("test", "Runs tests")
+            .registerCategory("build", "Runs compile + test")
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        final var help = helpOutput.getFirst();
+        assertThat(help).contains("Commands:");
+        assertThat(help).contains("compile");
+        assertThat(help).contains("Compiles sources");
+        assertThat(help).contains("Categories:");
+        assertThat(help).contains("build");
+        assertThat(help).contains("Runs compile + test");
+    }
+
+    /**
+     * Ensure {@link CommandLineParser#setCommandsSectionName(String)} and
+     * {@link CommandLineParser#setCategoriesSectionName(String)} replace the default headings in help output.
+     */
+    @Test
+    void shouldUseCustomSectionNamesForCommandsAndCategories() {
+        final List<String> helpOutput = new ArrayList<>();
+
+        new CommandLineParser()
+            .setHelpHandler(helpOutput::add)
+            .add(ZeroArgumentOption.class)
+            .registerCommand("compile", "Compiles sources")
+            .registerCategory("build", "Runs everything")
+            .setCommandsSectionName("Tasks:")
+            .setCategoriesSectionName("Aliases:")
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        final var help = helpOutput.getFirst();
+        assertThat(help).contains("Tasks:");
+        assertThat(help).doesNotContain("Commands:");
+        assertThat(help).contains("Aliases:");
+        assertThat(help).doesNotContain("Categories:");
+    }
+
+    /**
+     * Ensure commands and categories are sorted alphabetically in help output regardless of registration order.
+     */
+    @Test
+    void shouldSortCommandsAndCategoriesAlphabeticallyInHelp() {
+        final List<String> helpOutput = new ArrayList<>();
+
+        new CommandLineParser()
+            .setHelpHandler(helpOutput::add)
+            .add(ZeroArgumentOption.class)
+            .registerCommand("zebra", "Z task")
+            .registerCommand("alpha", "A task")
+            .registerCategory("zoo", "Z cat")
+            .registerCategory("ant", "A cat")
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        final var help = helpOutput.getFirst();
+        assertThat(help).containsSubsequence("alpha", "zebra");
+        assertThat(help).containsSubsequence("ant", "zoo");
+    }
+
+    /**
      * Ensure {@link CommandLineParser#setPositionalArgumentConsumer(java.util.function.Consumer)} receives
      * non-hyphen-prefixed arguments.
      */

--- a/base-commandline/src/test/java/build/base/commandline/CommandTests.java
+++ b/base-commandline/src/test/java/build/base/commandline/CommandTests.java
@@ -132,6 +132,133 @@ class CommandTests {
     }
 
     /**
+     * Ensure {@link Command#command(String, String)} causes the command to appear under a {@code Commands:}
+     * section in help output.
+     */
+    @Test
+    void commandBuilderShouldRegisterCommandsInHelp() {
+        final List<String> helpOutput = new ArrayList<>();
+
+        Command.create("spin")
+            .helpHandler(helpOutput::add)
+            .option(CommandLineParserTests.ZeroArgumentOption.class)
+            .command("compile", "Compiles sources")
+            .command("test", "Runs tests")
+            .build()
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        final var help = helpOutput.getFirst();
+        assertThat(help).contains("Commands:");
+        assertThat(help).contains("compile");
+        assertThat(help).contains("Compiles sources");
+        assertThat(help).contains("test");
+    }
+
+    /**
+     * Ensure {@link Command#category(String, String)} causes the category to appear under a {@code Categories:}
+     * section in help output.
+     */
+    @Test
+    void commandBuilderShouldRegisterCategoriesInHelp() {
+        final List<String> helpOutput = new ArrayList<>();
+
+        Command.create("spin")
+            .helpHandler(helpOutput::add)
+            .option(CommandLineParserTests.ZeroArgumentOption.class)
+            .category("build", "Runs compile + test + package")
+            .build()
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        final var help = helpOutput.getFirst();
+        assertThat(help).contains("Categories:");
+        assertThat(help).contains("build");
+        assertThat(help).contains("Runs compile + test + package");
+    }
+
+    /**
+     * Ensure {@link Command#option(List, Class, String, String, Class[])} registers all prefixes so the option
+     * can be parsed via any of them.
+     */
+    @Test
+    void commandBuilderShouldRegisterMultiPrefixOption() {
+        final var parser = Command.create("test")
+            .option(List.of("--working-dir", "-w"),
+                CommandLineParserTests.OneArgumentOption.class,
+                "of",
+                "Working directory",
+                boolean.class)
+            .build();
+
+        assertThat(parser.parse("--working-dir", "true").build()
+            .get(CommandLineParserTests.OneArgumentOption.class))
+            .isEqualTo(CommandLineParserTests.OneArgumentOption.of(true));
+
+        assertThat(parser.parse("-w", "false").build()
+            .get(CommandLineParserTests.OneArgumentOption.class))
+            .isEqualTo(CommandLineParserTests.OneArgumentOption.of(false));
+    }
+
+    /**
+     * Ensure {@link Command#option(List, Class, String, String, Class[])} wraps {@link NoSuchMethodException} as
+     * {@link IllegalArgumentException} when the method does not exist.
+     */
+    @Test
+    void commandBuilderShouldWrapNoSuchMethodExceptionForMultiPrefixOption() {
+        final var command = Command.create("test")
+            .option(List.of("--working-dir", "-w"),
+                CommandLineParserTests.OneArgumentOption.class,
+                "nonExistentMethod",
+                "desc",
+                boolean.class);
+
+        assertThrows(IllegalArgumentException.class, command::build);
+    }
+
+    /**
+     * Ensure {@link Command#commandsSectionName(String)} and {@link Command#categoriesSectionName(String)}
+     * replace the default headings in help output.
+     */
+    @Test
+    void commandBuilderShouldUseCustomSectionNames() {
+        final List<String> helpOutput = new ArrayList<>();
+
+        Command.create("spin")
+            .helpHandler(helpOutput::add)
+            .option(CommandLineParserTests.ZeroArgumentOption.class)
+            .command("compile", "Compiles sources")
+            .commandsSectionName("Tasks:")
+            .category("build", "Runs everything")
+            .categoriesSectionName("Aliases:")
+            .build()
+            .parse("--help");
+
+        assertThat(helpOutput).hasSize(1);
+        final var help = helpOutput.getFirst();
+        assertThat(help).contains("Tasks:");
+        assertThat(help).doesNotContain("Commands:");
+        assertThat(help).contains("Aliases:");
+        assertThat(help).doesNotContain("Categories:");
+    }
+
+    /**
+     * Ensure {@link Command#positionalArgument(java.util.function.Consumer)} routes non-hyphen args to the consumer.
+     */
+    @Test
+    void commandBuilderShouldForwardPositionalArgumentConsumer() {
+        final List<String> positionals = new ArrayList<>();
+
+        Command.create("spin")
+            .option(CommandLineParserTests.ZeroArgumentOption.class)
+            .positionalArgument(positionals::add)
+            .build()
+            .parse("-default", "compile", "test");
+
+        assertThat(positionals).containsExactly("compile", "test");
+    }
+
+    /**
      * Ensure command-line arg overrides env var when wired through the {@link Command} builder.
      */
     @Test


### PR DESCRIPTION
Extends `CommandLineParser` and the `Command` fluent builder with four additions that close the remaining gap between base-commandline and a full flat-CLI framework:                                                                                      

- **Declarative commands and categories** — `registerCommand` / `registerCategory` (and `Command.command` / `Command.category`) add `Commands:` and `Categories:` sections to help output, sorted alphabetically. Section headings are overridable via     
`setCommandsSectionName` / `setCategoriesSectionName` (e.g. spin can render `Tasks:` / `Aliases:`).                                                                                                                                                        
- **Multi-prefix options without annotations** — `CommandLineParser.add(List<String>, Class, methodName, description, paramTypes...)` and the matching `Command.option(List<String>, ...)` overload register an option under multiple prefixes with an     
explicit description, no `@CommandLine.Prefix` or `@CommandLine.Description` required.                                                                                                                                                                     
- **`Command.positionalArgument(Consumer<String>)`** — fluent wrapper for `setPositionalArgumentConsumer`, completing the builder API.
- **Help rendering fix** — prefixes are now tracked in `methodPrefixes` at registration time, so explicitly-registered options appear correctly in help (previously only annotation-driven options rendered their prefixes).