### PR TITLE
feat(base-template): compile-time .jt template library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,4 +27,3 @@ For detailed architecture, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md).
 - Configuration: use `ConfigurationBuilder.add(option).build()` → `config.get(MyOption.class)`.
 - Marshalling: annotate with `@Marshal` / `@Unmarshal`; call `Marshalling.register(Class, lookup())` in static initializer.
 - Retryable: throw `EphemeralFailureException` (retry) or `PermanentFailureException` (stop).
-- All JPMS `module-info.java` files are `open` modules to allow marshalling/reflection.

--- a/base-template-processor/pom.xml
+++ b/base-template-processor/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>build.base</groupId>
+        <artifactId>base-project</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>base-template-processor</artifactId>
+
+    <name>base.build Template Processor</name>
+    <description>Annotation processor that compiles .jt template files into Java records at build time.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-parsing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/base-template-processor/src/main/java/build/base/template/processor/BodyNode.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/BodyNode.java
@@ -1,0 +1,35 @@
+package build.base.template.processor;
+
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+sealed interface BodyNode {
+    record RawText(String text) implements BodyNode {
+    }
+
+    record Expression(String code) implements BodyNode {
+    }
+
+    record CodeLine(String code) implements BodyNode {
+    }
+
+    record Include(String expression) implements BodyNode {
+    }
+}

--- a/base-template-processor/src/main/java/build/base/template/processor/CodeGenerator.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/CodeGenerator.java
@@ -1,0 +1,111 @@
+package build.base.template.processor;
+
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+final class CodeGenerator {
+
+    private CodeGenerator() {
+    }
+
+    static String generate(final ParsedTemplate template) {
+        final StringBuilder sb = new StringBuilder();
+
+        if (!template.packageName().isEmpty()) {
+            sb.append("package ").append(template.packageName()).append(";\n\n");
+        }
+
+        for (final String imp : template.imports()) {
+            sb.append(imp).append(";\n");
+        }
+        if (!template.imports().isEmpty()) {
+            sb.append("\n");
+        }
+
+        sb.append("import build.base.template.").append(template.outType()).append(";\n");
+        sb.append("import build.base.template.Template;\n\n");
+
+        sb.append("public record ").append(template.className())
+            .append("(").append(template.params()).append(")")
+            .append(" implements Template<").append(template.outType()).append("> {\n\n");
+
+        sb.append("    @Override\n");
+        sb.append("    public void render(final ").append(template.outType()).append(" out) {\n");
+
+        generateBody(template.body(), sb);
+
+        sb.append("    }\n");
+        sb.append("}\n");
+
+        return sb.toString();
+    }
+
+    private static void generateBody(final List<BodyNode> body,
+                                     final StringBuilder sb) {
+        final StringBuilder raw = new StringBuilder();
+
+        for (final BodyNode node : body) {
+            switch (node) {
+                case BodyNode.RawText(final String text) -> raw.append(text);
+                case BodyNode.Expression(final String code) -> {
+                    flushRaw(raw, sb);
+                    sb.append("        out.write(").append(code).append(");\n");
+                }
+                case BodyNode.CodeLine(final String code) -> {
+                    flushRaw(raw, sb);
+                    sb.append("        ").append(code).append("\n");
+                }
+                case BodyNode.Include(final String expression) -> {
+                    flushRaw(raw, sb);
+                    sb.append("        ").append(expression).append(".render(out);\n");
+                }
+            }
+        }
+
+        flushRaw(raw, sb);
+    }
+
+    private static void flushRaw(final StringBuilder raw,
+                                 final StringBuilder sb) {
+        if (raw.isEmpty()) {
+            return;
+        }
+        sb.append("        out.raw(\"").append(escapeJava(raw.toString())).append("\");\n");
+        raw.setLength(0);
+    }
+
+    private static String escapeJava(final String s) {
+        final StringBuilder result = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            final char c = s.charAt(i);
+            switch (c) {
+                case '"' -> result.append("\\\"");
+                case '\\' -> result.append("\\\\");
+                case '\n' -> result.append("\\n");
+                case '\r' -> result.append("\\r");
+                case '\t' -> result.append("\\t");
+                default -> result.append(c);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/base-template-processor/src/main/java/build/base/template/processor/JtParseException.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/JtParseException.java
@@ -1,0 +1,27 @@
+package build.base.template.processor;
+
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+final class JtParseException extends RuntimeException {
+    JtParseException(final String message) {
+        super(message);
+    }
+}

--- a/base-template-processor/src/main/java/build/base/template/processor/JtParser.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/JtParser.java
@@ -1,0 +1,201 @@
+package build.base.template.processor;
+
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.parsing.Filter;
+import build.base.parsing.Scanner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+final class JtParser {
+
+    private static final Pattern QUALIFIED_NAME =
+        Pattern.compile("[a-zA-Z_$][\\w$]*(\\.[a-zA-Z_$][\\w$]*)*");
+
+    // Matches the body of an import statement: optional "static", qualified name, optional ".*"
+    private static final Pattern IMPORT_BODY =
+        Pattern.compile("(static\\s+)?[a-zA-Z_$][\\w$]*(\\.[a-zA-Z_$][\\w$]*)*(\\.\\*)?");
+
+    private JtParser() {
+    }
+
+    static ParsedTemplate parse(final List<String> lines,
+                                final String sourceFile) {
+        final List<String> headerLines = new ArrayList<>();
+        final List<String> bodyLines = new ArrayList<>();
+        boolean inBody = false;
+
+        for (final String line : lines) {
+            final String trimmed = line.trim();
+            if (!inBody) {
+                if (!trimmed.isEmpty()) {
+                    headerLines.add(trimmed);
+                }
+                if (trimmed.startsWith("template ")) {
+                    inBody = true;
+                }
+            } else if (!trimmed.equals("}")) {
+                bodyLines.add(line);
+            }
+        }
+
+        String packageName = "";
+        final List<String> imports = new ArrayList<>();
+        String outType = null;
+        String className = null;
+        String params = null;
+
+        try (var scanner = new Scanner(String.join("\n", headerLines))) {
+            scanner.register(Filter.WHITESPACE);
+            while (scanner.hasNext()) {
+                if (scanner.follows("package")) {
+                    scanner.skip("package");
+                    packageName = scanner.consume(QUALIFIED_NAME);
+                    scanner.skip(";");
+                } else if (scanner.follows("import")) {
+                    scanner.skip("import");
+                    imports.add("import " + scanner.consume(IMPORT_BODY));
+                    scanner.skip(";");
+                } else if (scanner.follows("template")) {
+                    scanner.skip("template");
+                    outType = scanner.consume(QUALIFIED_NAME);
+                    className = scanner.consume(QUALIFIED_NAME);
+                    params = consumeParams(scanner);
+                    break;
+                } else {
+                    break;
+                }
+            }
+        } catch (final Exception e) {
+            throw new JtParseException(sourceFile + ": " + e.getMessage());
+        }
+
+        if (className == null) {
+            throw new JtParseException(sourceFile + ": missing template declaration");
+        }
+
+        final List<BodyNode> body = new ArrayList<>();
+        for (final String line : bodyLines) {
+            parseBodyLine(line, body);
+        }
+
+        return new ParsedTemplate(packageName, imports, outType, className, params, body);
+    }
+
+    private static String consumeParams(final Scanner scanner) {
+        scanner.consume("(");
+        final var sb = new StringBuilder();
+        int depth = 1;
+        while (depth > 0) {
+            final String ch = scanner.consume(1);
+            if ("(".equals(ch)) {
+                depth++;
+                sb.append(ch);
+            } else if (")".equals(ch)) {
+                depth--;
+                if (depth > 0) {
+                    sb.append(ch);
+                }
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void parseBodyLine(final String line,
+                                      final List<BodyNode> body) {
+        final String trimmed = line.trim();
+        if (trimmed.startsWith("@include ")) {
+            body.add(new BodyNode.Include(trimmed.substring("@include ".length()).trim()));
+            return;
+        }
+        if (trimmed.startsWith("@")) {
+            body.add(new BodyNode.CodeLine(trimmed.substring(1).trim()));
+            return;
+        }
+        parseTextLine(line + "\n", body);
+    }
+
+    static void parseTextLine(final String line,
+                              final List<BodyNode> body) {
+        try (var scanner = new Scanner(line)) {
+            while (scanner.hasNext()) {
+                if (scanner.follows("#{")) {
+                    body.add(new BodyNode.Expression(consumeExpression(scanner)));
+                } else {
+                    final String raw = scanner.consumeUntil("#{");
+                    if (!raw.isEmpty()) {
+                        body.add(new BodyNode.RawText(raw));
+                    }
+                }
+            }
+        } catch (final JtParseException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new JtParseException("Unclosed expression in: " + line.trim());
+        }
+    }
+
+    private static String consumeExpression(final Scanner scanner) {
+        scanner.consume("#{");
+        final var sb = new StringBuilder();
+        int depth = 1;
+        boolean inString = false;
+        char stringChar = 0;
+        boolean escape = false;
+        while (depth > 0) {
+            final char c = scanner.consume(1).charAt(0);
+            if (escape) {
+                escape = false;
+                sb.append(c);
+                continue;
+            }
+            if (inString) {
+                sb.append(c);
+                if (c == '\\') {
+                    escape = true;
+                } else if (c == stringChar) {
+                    inString = false;
+                }
+                continue;
+            }
+            if (c == '"' || c == '\'') {
+                inString = true;
+                stringChar = c;
+                sb.append(c);
+            } else if (c == '{') {
+                depth++;
+                sb.append(c);
+            } else if (c == '}') {
+                depth--;
+                if (depth > 0) {
+                    sb.append(c);
+                }
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/base-template-processor/src/main/java/build/base/template/processor/ParsedTemplate.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/ParsedTemplate.java
@@ -1,0 +1,35 @@
+package build.base.template.processor;
+
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+record ParsedTemplate(String packageName,
+                      List<String> imports,
+                      String outType,
+                      String className,
+                      String params,
+                      List<BodyNode> body
+) {
+    String qualifiedClassName() {
+        return packageName.isEmpty() ? className : packageName + "." + className;
+    }
+}

--- a/base-template-processor/src/main/java/build/base/template/processor/TemplateProcessor.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/TemplateProcessor.java
@@ -1,0 +1,116 @@
+package build.base.template.processor;
+
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.StandardLocation;
+
+@SupportedAnnotationTypes("build.base.template.ProcessTemplates")
+@SupportedSourceVersion(SourceVersion.RELEASE_25)
+@SupportedOptions("jt.sourceDir")
+public final class TemplateProcessor extends AbstractProcessor {
+
+    private boolean processed = false;
+
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations,
+                           final RoundEnvironment roundEnv) {
+        if (processed || roundEnv.processingOver()) {
+            return false;
+        }
+        processed = true;
+
+        final Path jtSourceDir = resolveJtSourceDir();
+        if (jtSourceDir == null) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
+                "base-template-processor: could not determine jt source directory; "
+                + "set -Ajt.sourceDir=<path> if your layout is non-standard");
+            return false;
+        }
+        if (!Files.isDirectory(jtSourceDir)) {
+            return false;
+        }
+
+        try (Stream<Path> files = Files.walk(jtSourceDir)) {
+            files.filter(p -> p.toString().endsWith(".jt"))
+                .forEach(this::processTemplate);
+        } catch (final IOException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                "base-template-processor: failed to walk " + jtSourceDir + ": " + e.getMessage());
+        }
+
+        return false;
+    }
+
+    private void processTemplate(final Path jtFile) {
+        try {
+            final List<String> lines = Files.readAllLines(jtFile);
+            final ParsedTemplate parsed = JtParser.parse(lines, jtFile.toString());
+            final String source = CodeGenerator.generate(parsed);
+
+            final javax.tools.JavaFileObject output = processingEnv.getFiler()
+                .createSourceFile(parsed.qualifiedClassName());
+
+            try (var writer = output.openWriter()) {
+                writer.write(source);
+            }
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (final JtParseException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                "base-template-processor: " + e.getMessage());
+        }
+    }
+
+    private Path resolveJtSourceDir() {
+        final String explicit = processingEnv.getOptions().get("jt.sourceDir");
+        if (explicit != null) {
+            return Path.of(explicit);
+        }
+        try {
+            final javax.tools.FileObject probe = processingEnv.getFiler()
+                .createResource(StandardLocation.CLASS_OUTPUT, "", ".base-template-probe");
+            final URI uri = probe.toUri();
+            probe.delete();
+
+            // From target/classes → project root → src/main/jt
+            final Path classOutput = Path.of(uri).getParent();
+            return classOutput.getParent().getParent().resolve("src/main/jt");
+        } catch (final IOException e) {
+            return null;
+        }
+    }
+}

--- a/base-template-processor/src/main/java/module-info.java
+++ b/base-template-processor/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*-
+ * #%L
+ * base.build Template Processor
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Annotation processor that compiles .jt template files into Java records.
+ */
+module build.base.template.processor {
+    requires java.compiler;
+    requires build.base.parsing;
+
+    provides javax.annotation.processing.Processor
+        with build.base.template.processor.TemplateProcessor;
+}

--- a/base-template-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/base-template-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+build.base.template.processor.TemplateProcessor

--- a/base-template-processor/src/test/java/build/base/template/processor/CodeGeneratorTests.java
+++ b/base-template-processor/src/test/java/build/base/template/processor/CodeGeneratorTests.java
@@ -1,0 +1,98 @@
+package build.base.template.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CodeGeneratorTests {
+
+    @Test
+    void shouldGenerateRecord() {
+        final var template = new ParsedTemplate(
+            "com.example",
+            List.of("import java.util.List"),
+            "HtmlOut",
+            "HelloTemplate",
+            "String name",
+            List.of(
+                new BodyNode.RawText("<h1>Hello, "),
+                new BodyNode.Expression("name"),
+                new BodyNode.RawText("!</h1>\n")
+            )
+        );
+
+        final var source = CodeGenerator.generate(template);
+
+        assertThat(source).contains("package com.example;");
+        assertThat(source).contains("import java.util.List;");
+        assertThat(source).contains("import build.base.template.HtmlOut;");
+        assertThat(source).contains("import build.base.template.Template;");
+        assertThat(source).contains("public record HelloTemplate(String name) implements Template<HtmlOut>");
+        assertThat(source).contains("out.raw(\"<h1>Hello, \")");
+        assertThat(source).contains("out.write(name)");
+        assertThat(source).contains("out.raw(\"!</h1>\\n\")");
+    }
+
+    @Test
+    void shouldGenerateCodeLine() {
+        final var template = new ParsedTemplate(
+            "com.example", List.of(), "HtmlOut", "T", "java.util.List<String> items",
+            List.of(
+                new BodyNode.CodeLine("for (var item : items) {"),
+                new BodyNode.RawText("<li>"),
+                new BodyNode.Expression("item"),
+                new BodyNode.RawText("</li>\n"),
+                new BodyNode.CodeLine("}")
+            )
+        );
+
+        final var source = CodeGenerator.generate(template);
+
+        assertThat(source).contains("for (var item : items) {");
+        assertThat(source).contains("out.raw(\"<li>\")");
+        assertThat(source).contains("out.write(item)");
+        assertThat(source).contains("out.raw(\"</li>\\n\")");
+    }
+
+    @Test
+    void shouldGenerateInclude() {
+        final var template = new ParsedTemplate(
+            "com.example", List.of(), "HtmlOut", "T", "Object item",
+            List.of(new BodyNode.Include("new ItemTemplate(item)"))
+        );
+
+        final var source = CodeGenerator.generate(template);
+
+        assertThat(source).contains("new ItemTemplate(item).render(out);");
+    }
+
+    @Test
+    void shouldMergeAdjacentRawText() {
+        final var template = new ParsedTemplate(
+            "com.example", List.of(), "HtmlOut", "T", "",
+            List.of(
+                new BodyNode.RawText("<div>"),
+                new BodyNode.RawText("<p>hello</p>"),
+                new BodyNode.RawText("</div>\n")
+            )
+        );
+
+        final var source = CodeGenerator.generate(template);
+
+        assertThat(source).contains("out.raw(\"<div><p>hello</p></div>\\n\")");
+    }
+
+    @Test
+    void shouldEscapeSpecialCharsInRawText() {
+        final var template = new ParsedTemplate(
+            "com.example", List.of(), "TextOut", "T", "",
+            List.of(new BodyNode.RawText("say \"hello\"\n"))
+        );
+
+        final var source = CodeGenerator.generate(template);
+
+        assertThat(source).contains("out.raw(\"say \\\"hello\\\"\\n\")");
+    }
+}

--- a/base-template-processor/src/test/java/build/base/template/processor/JtParserTests.java
+++ b/base-template-processor/src/test/java/build/base/template/processor/JtParserTests.java
@@ -1,0 +1,159 @@
+package build.base.template.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JtParserTests {
+
+    @Test
+    void shouldParseMinimalTemplate() {
+        final var lines = List.of(
+            "package com.example;",
+            "",
+            "template HtmlOut HelloTemplate(String name) {",
+            "<h1>Hello</h1>",
+            "}"
+        );
+        final var result = JtParser.parse(lines, "hello.jt");
+
+        assertThat(result.packageName()).isEqualTo("com.example");
+        assertThat(result.outType()).isEqualTo("HtmlOut");
+        assertThat(result.className()).isEqualTo("HelloTemplate");
+        assertThat(result.params()).isEqualTo("String name");
+    }
+
+    @Test
+    void shouldParseImports() {
+        final var lines = List.of(
+            "package com.example;",
+            "",
+            "import java.util.List;",
+            "import com.example.Task;",
+            "",
+            "template HtmlOut TasksTemplate(List<Task> tasks) {",
+            "}");
+        final var result = JtParser.parse(lines, "tasks.jt");
+
+        assertThat(result.imports()).containsExactly("import java.util.List", "import com.example.Task");
+    }
+
+    @Test
+    void shouldParseTextLine() {
+        final var body = new java.util.ArrayList<BodyNode>();
+        JtParser.parseTextLine("<h1>Hello</h1>\n", body);
+
+        assertThat(body).containsExactly(new BodyNode.RawText("<h1>Hello</h1>\n"));
+    }
+
+    @Test
+    void shouldParseExpressionInTextLine() {
+        final var body = new java.util.ArrayList<BodyNode>();
+        JtParser.parseTextLine("<h1>#{name}</h1>\n", body);
+
+        assertThat(body).containsExactly(
+            new BodyNode.RawText("<h1>"),
+            new BodyNode.Expression("name"),
+            new BodyNode.RawText("</h1>\n")
+        );
+    }
+
+    @Test
+    void shouldParseMultipleExpressionsOnOneLine() {
+        final var body = new java.util.ArrayList<BodyNode>();
+        JtParser.parseTextLine("<li id=\"#{task.id()}\">#{task.title()}</li>\n", body);
+
+        assertThat(body).containsExactly(
+            new BodyNode.RawText("<li id=\""),
+            new BodyNode.Expression("task.id()"),
+            new BodyNode.RawText("\">"),
+            new BodyNode.Expression("task.title()"),
+            new BodyNode.RawText("</li>\n")
+        );
+    }
+
+    @Test
+    void shouldParseExpressionWithStringLiteralContainingBrace() {
+        final var body = new java.util.ArrayList<BodyNode>();
+        JtParser.parseTextLine("#{task.done() ? \" done\" : \"\"}\n", body);
+
+        assertThat(body).containsExactly(
+            new BodyNode.Expression("task.done() ? \" done\" : \"\""),
+            new BodyNode.RawText("\n")
+        );
+    }
+
+    @Test
+    void shouldParseCodeLine() {
+        final var lines = List.of(
+            "package com.example;",
+            "template HtmlOut T(java.util.List<String> items) {",
+            "@for (var item : items) {",
+            "<li>#{item}</li>",
+            "@}",
+            "}"
+        );
+        final var result = JtParser.parse(lines, "t.jt");
+        assertThat(result.body()).contains(new BodyNode.CodeLine("for (var item : items) {"));
+        assertThat(result.body()).contains(new BodyNode.CodeLine("}"));
+    }
+
+    @Test
+    void shouldParseInclude() {
+        final var lines = List.of(
+            "package com.example;",
+            "template HtmlOut T(Object item) {",
+            "@include new ItemTemplate(item)",
+            "}"
+        );
+        final var result = JtParser.parse(lines, "t.jt");
+        assertThat(result.body()).contains(new BodyNode.Include("new ItemTemplate(item)"));
+    }
+
+    @Test
+    void shouldParseWildcardImport() {
+        final var lines = List.of(
+            "package com.example;",
+            "import java.util.*;",
+            "template HtmlOut T() {",
+            "}"
+        );
+        final var result = JtParser.parse(lines, "t.jt");
+        assertThat(result.imports()).containsExactly("import java.util.*");
+    }
+
+    @Test
+    void shouldParseStaticImport() {
+        final var lines = List.of(
+            "package com.example;",
+            "import static java.util.List.of;",
+            "template HtmlOut T() {",
+            "}"
+        );
+        final var result = JtParser.parse(lines, "t.jt");
+        assertThat(result.imports()).containsExactly("import static java.util.List.of");
+    }
+
+    @Test
+    void shouldParseStaticWildcardImport() {
+        final var lines = List.of(
+            "package com.example;",
+            "import static java.util.Collections.*;",
+            "template HtmlOut T() {",
+            "}"
+        );
+        final var result = JtParser.parse(lines, "t.jt");
+        assertThat(result.imports()).containsExactly("import static java.util.Collections.*");
+    }
+
+    @Test
+    void shouldThrowOnMissingDeclaration() {
+        final var lines = List.of("package com.example;");
+        assertThatThrownBy(() -> JtParser.parse(lines, "bad.jt"))
+            .isInstanceOf(JtParseException.class)
+            .hasMessageContaining("missing template declaration");
+    }
+}

--- a/base-template-processor/src/test/java/build/base/template/processor/TemplatePipelineTests.java
+++ b/base-template-processor/src/test/java/build/base/template/processor/TemplatePipelineTests.java
@@ -1,0 +1,63 @@
+package build.base.template.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemplatePipelineTests {
+
+    private static List<String> load(final String name) throws IOException {
+        final var resource = TemplatePipelineTests.class.getClassLoader()
+            .getResourceAsStream("templates/" + name);
+        assertThat(resource).as("test resource: " + name).isNotNull();
+        return new String(resource.readAllBytes()).lines().toList();
+    }
+
+    @Test
+    void shouldProcessHelloTemplate() throws IOException {
+        final var lines = load("hello.jt");
+        final var parsed = JtParser.parse(lines, "hello.jt");
+
+        assertThat(parsed.className()).isEqualTo("HelloTemplate");
+        assertThat(parsed.outType()).isEqualTo("HtmlOut");
+        assertThat(parsed.params()).isEqualTo("String name");
+
+        final var source = CodeGenerator.generate(parsed);
+
+        assertThat(source).contains("public record HelloTemplate(String name) implements Template<HtmlOut>");
+        assertThat(source).contains("out.write(name)");
+        assertThat(source).contains("<h1>Hello, ");
+        assertThat(source).contains("!</h1>\\n");
+    }
+
+    @Test
+    void shouldProcessTasksTemplate() throws IOException {
+        final var lines = load("tasks.jt");
+        final var parsed = JtParser.parse(lines, "tasks.jt");
+
+        assertThat(parsed.className()).isEqualTo("TasksTemplate");
+        assertThat(parsed.imports()).contains("import java.util.List");
+
+        final var source = CodeGenerator.generate(parsed);
+
+        assertThat(source).contains("import java.util.List;");
+        assertThat(source).contains("for (var item : items) {");
+        assertThat(source).contains("out.write(item)");
+    }
+
+    @Test
+    void shouldProcessItemTemplateWithConditionalExpression() throws IOException {
+        final var lines = load("item.jt");
+        final var parsed = JtParser.parse(lines, "item.jt");
+
+        assertThat(parsed.className()).isEqualTo("ItemTemplate");
+
+        final var source = CodeGenerator.generate(parsed);
+
+        assertThat(source).contains("out.write(active ? \" active\" : \"\")");
+        assertThat(source).contains("out.write(label)");
+    }
+}

--- a/base-template-processor/src/test/resources/templates/hello.jt
+++ b/base-template-processor/src/test/resources/templates/hello.jt
@@ -1,0 +1,10 @@
+package build.base.template.processor.generated;
+
+template HtmlOut HelloTemplate(String name) {
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Hello, #{name}!</h1>
+</body>
+</html>
+}

--- a/base-template-processor/src/test/resources/templates/item.jt
+++ b/base-template-processor/src/test/resources/templates/item.jt
@@ -1,0 +1,5 @@
+package build.base.template.processor.generated;
+
+template HtmlOut ItemTemplate(String label, boolean active) {
+<li class="item#{active ? " active" : ""}">#{label}</li>
+}

--- a/base-template-processor/src/test/resources/templates/tasks.jt
+++ b/base-template-processor/src/test/resources/templates/tasks.jt
@@ -1,0 +1,17 @@
+package build.base.template.processor.generated;
+
+import java.util.List;
+
+template HtmlOut TasksTemplate(String title, List<String> items) {
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>#{title}</h1>
+  <ul>
+@for (var item : items) {
+    <li>#{item}</li>
+@}
+  </ul>
+</body>
+</html>
+}

--- a/base-template-test/pom.xml
+++ b/base-template-test/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>build.base</groupId>
+        <artifactId>base-project</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>base-template-test</artifactId>
+
+    <name>base.build Template Integration Tests</name>
+    <description>Integration tests for base-template-processor — verifies that .jt files are compiled to working Java records.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-template</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-template-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <generatedSourcesDirectory>${project.build.directory}/generated-sources/jt</generatedSourcesDirectory>
+                    <!-- Maven compiler plugin does not auto-route JPMS processor modules to processor-module-path.
+                         Required until tooling (spin.build) handles this automatically. -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>build.base</groupId>
+                            <artifactId>base-template-processor</artifactId>
+                            <version>${revision}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredUnusedDeclaredDependencies>
+                        <ignoredUnusedDeclaredDependency>build.base:base-template-processor</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/base-template-test/src/main/java/module-info.java
+++ b/base-template-test/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*-
+ * #%L
+ * base.build Template Integration Tests
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Integration tests for base-template-processor.
+ */
+@build.base.template.ProcessTemplates
+module build.base.template.test {
+    requires build.base.template;
+}

--- a/base-template-test/src/main/jt/build/base/template/test/HelloTemplate.jt
+++ b/base-template-test/src/main/jt/build/base/template/test/HelloTemplate.jt
@@ -1,0 +1,10 @@
+package build.base.template.test;
+
+template HtmlOut HelloTemplate(String name) {
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Hello, #{name}!</h1>
+</body>
+</html>
+}

--- a/base-template-test/src/main/jt/build/base/template/test/ItemTemplate.jt
+++ b/base-template-test/src/main/jt/build/base/template/test/ItemTemplate.jt
@@ -1,0 +1,5 @@
+package build.base.template.test;
+
+template HtmlOut ItemTemplate(String label, boolean active) {
+<li class="item#{active ? " active" : ""}">#{label}</li>
+}

--- a/base-template-test/src/main/jt/build/base/template/test/TasksTemplate.jt
+++ b/base-template-test/src/main/jt/build/base/template/test/TasksTemplate.jt
@@ -1,0 +1,12 @@
+package build.base.template.test;
+
+import java.util.List;
+
+template HtmlOut TasksTemplate(String title, List<String> items) {
+<h1>#{title}</h1>
+<ul>
+@for (var item : items) {
+  <li>#{item}</li>
+@}
+</ul>
+}

--- a/base-template-test/src/test/java/build/base/template/test/HelloTemplateTests.java
+++ b/base-template-test/src/test/java/build/base/template/test/HelloTemplateTests.java
@@ -1,0 +1,28 @@
+package build.base.template.test;
+
+import build.base.template.HtmlOut;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HelloTemplateTests {
+
+    @Test
+    void shouldRenderName() {
+        final var out = new HtmlOut();
+        new HelloTemplate("World").render(out);
+        final var html = out.toString();
+
+        assertThat(html).contains("<h1>Hello, World!</h1>");
+    }
+
+    @Test
+    void shouldEscapeNameInOutput() {
+        final var out = new HtmlOut();
+        new HelloTemplate("<script>alert('xss')</script>").render(out);
+        final var html = out.toString();
+
+        assertThat(html).contains("&lt;script&gt;");
+        assertThat(html).doesNotContain("<script>");
+    }
+}

--- a/base-template-test/src/test/java/build/base/template/test/TasksTemplateTests.java
+++ b/base-template-test/src/test/java/build/base/template/test/TasksTemplateTests.java
@@ -1,0 +1,54 @@
+package build.base.template.test;
+
+import build.base.template.HtmlOut;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TasksTemplateTests {
+
+    @Test
+    void shouldRenderTitleAndItems() {
+        final var out = new HtmlOut();
+        new TasksTemplate("My Tasks", List.of("Buy milk", "Walk dog")).render(out);
+        final var html = out.toString();
+
+        assertThat(html).contains("<h1>My Tasks</h1>");
+        assertThat(html).contains("<li>Buy milk</li>");
+        assertThat(html).contains("<li>Walk dog</li>");
+    }
+
+    @Test
+    void shouldRenderEmptyList() {
+        final var out = new HtmlOut();
+        new TasksTemplate("Empty", List.of()).render(out);
+        final var html = out.toString();
+
+        assertThat(html).contains("<h1>Empty</h1>");
+        assertThat(html).contains("<ul>");
+        assertThat(html).contains("</ul>");
+        assertThat(html).doesNotContain("<li>");
+    }
+
+    @Test
+    void shouldEscapeItemsInOutput() {
+        final var out = new HtmlOut();
+        new TasksTemplate("Tasks", List.of("<b>bold</b>")).render(out);
+        final var html = out.toString();
+
+        assertThat(html).contains("&lt;b&gt;bold&lt;/b&gt;");
+        assertThat(html).doesNotContain("<b>");
+    }
+
+    @Test
+    void shouldComposeWithItemTemplate() {
+        final var out = new HtmlOut();
+        new ItemTemplate("Active item", true).render(out);
+        final var html = out.toString();
+
+        assertThat(html).contains("class=\"item active\"");
+        assertThat(html).contains("Active item");
+    }
+}

--- a/base-template/pom.xml
+++ b/base-template/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>build.base</groupId>
+        <artifactId>base-project</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>base-template</artifactId>
+
+    <name>base.build Template</name>
+    <description>A JPMS-native compile-time template library. Templates are Java records; HtmlOut and TextOut provide context-appropriate output with correct escaping.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/base-template/src/main/java/build/base/template/HtmlOut.java
+++ b/base-template/src/main/java/build/base/template/HtmlOut.java
@@ -1,0 +1,66 @@
+package build.base.template;
+
+/*-
+ * #%L
+ * base.build Template
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.Writer;
+
+public final class HtmlOut extends Out {
+
+    public HtmlOut() {
+        super();
+    }
+
+    public HtmlOut(final Writer writer) {
+        super(writer);
+    }
+
+    @Override
+    public void write(final Object value) {
+        if (value != null) {
+            raw(escape(String.valueOf(value)));
+        }
+    }
+
+    private static String escape(final String s) {
+        StringBuilder result = null;
+        for (int i = 0; i < s.length(); i++) {
+            final char c = s.charAt(i);
+            final String replacement = switch (c) {
+                case '&' -> "&amp;";
+                case '<' -> "&lt;";
+                case '>' -> "&gt;";
+                case '"' -> "&quot;";
+                case '\'' -> "&#39;";
+                default -> null;
+            };
+            if (replacement != null) {
+                if (result == null) {
+                    result = new StringBuilder(s.length() + 8);
+                    result.append(s, 0, i);
+                }
+                result.append(replacement);
+            } else if (result != null) {
+                result.append(c);
+            }
+        }
+        return result != null ? result.toString() : s;
+    }
+}

--- a/base-template/src/main/java/build/base/template/Out.java
+++ b/base-template/src/main/java/build/base/template/Out.java
@@ -1,0 +1,60 @@
+package build.base.template;
+
+/*-
+ * #%L
+ * base.build Template
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+
+public abstract class Out {
+
+    private final StringBuilder buffer;
+    private final Writer writer;
+
+    protected Out() {
+        this.buffer = new StringBuilder();
+        this.writer = null;
+    }
+
+    protected Out(final Writer writer) {
+        this.buffer = null;
+        this.writer = writer;
+    }
+
+    public final void raw(final String s) {
+        if (writer != null) {
+            try {
+                writer.write(s);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        } else {
+            buffer.append(s);
+        }
+    }
+
+    public abstract void write(Object value);
+
+    @Override
+    public final String toString() {
+        return buffer != null ? buffer.toString() : "";
+    }
+}

--- a/base-template/src/main/java/build/base/template/ProcessTemplates.java
+++ b/base-template/src/main/java/build/base/template/ProcessTemplates.java
@@ -1,0 +1,34 @@
+package build.base.template;
+
+/*-
+ * #%L
+ * base.build Template
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a module as containing .jt template files to be compiled by base-template-processor.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.MODULE)
+public @interface ProcessTemplates {
+}

--- a/base-template/src/main/java/build/base/template/Template.java
+++ b/base-template/src/main/java/build/base/template/Template.java
@@ -1,0 +1,26 @@
+package build.base.template;
+
+/*-
+ * #%L
+ * base.build Template
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+@FunctionalInterface
+public interface Template<O extends Out> {
+    void render(O out);
+}

--- a/base-template/src/main/java/build/base/template/TextOut.java
+++ b/base-template/src/main/java/build/base/template/TextOut.java
@@ -1,0 +1,41 @@
+package build.base.template;
+
+/*-
+ * #%L
+ * base.build Template
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.Writer;
+
+public final class TextOut extends Out {
+
+    public TextOut() {
+        super();
+    }
+
+    public TextOut(final Writer writer) {
+        super(writer);
+    }
+
+    @Override
+    public void write(final Object value) {
+        if (value != null) {
+            raw(String.valueOf(value));
+        }
+    }
+}

--- a/base-template/src/main/java/module-info.java
+++ b/base-template/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*-
+ * #%L
+ * base.build Template
+ * %%
+ * Copyright (C) 2026 Workday, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * A JPMS-native compile-time template library.
+ */
+module build.base.template {
+    exports build.base.template;
+}

--- a/base-template/src/test/java/build/base/template/HtmlOutTests.java
+++ b/base-template/src/test/java/build/base/template/HtmlOutTests.java
@@ -1,0 +1,73 @@
+package build.base.template;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HtmlOutTests {
+
+    @Test
+    void shouldEmitRawWithoutEscaping() {
+        final var out = new HtmlOut();
+        out.raw("<h1>Hello</h1>");
+        assertThat(out.toString()).isEqualTo("<h1>Hello</h1>");
+    }
+
+    @Test
+    void shouldEscapeHtmlEntities() {
+        final var out = new HtmlOut();
+        out.write("<script>alert('xss')</script>");
+        assertThat(out.toString()).isEqualTo("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    }
+
+    @Test
+    void shouldEscapeAmpersand() {
+        final var out = new HtmlOut();
+        out.write("cats & dogs");
+        assertThat(out.toString()).isEqualTo("cats &amp; dogs");
+    }
+
+    @Test
+    void shouldEscapeDoubleQuote() {
+        final var out = new HtmlOut();
+        out.write("say \"hello\"");
+        assertThat(out.toString()).isEqualTo("say &quot;hello&quot;");
+    }
+
+    @Test
+    void shouldNotEscapeSafeStrings() {
+        final var out = new HtmlOut();
+        out.write("Hello World 123");
+        assertThat(out.toString()).isEqualTo("Hello World 123");
+    }
+
+    @Test
+    void shouldHandleNullWrite() {
+        final var out = new HtmlOut();
+        out.write(null);
+        assertThat(out.toString()).isEmpty();
+    }
+
+    @Test
+    void shouldInterleavRawAndWrite() {
+        final var out = new HtmlOut();
+        out.raw("<li>");
+        out.write("<b>bold</b>");
+        out.raw("</li>");
+        assertThat(out.toString()).isEqualTo("<li>&lt;b&gt;bold&lt;/b&gt;</li>");
+    }
+
+    @Test
+    void shouldComposeTemplates() {
+        final Template<HtmlOut> inner = out -> {
+            out.raw("<span>");
+            out.write("hello");
+            out.raw("</span>");
+        };
+        final var out = new HtmlOut();
+        out.raw("<div>");
+        inner.render(out);
+        out.raw("</div>");
+        assertThat(out.toString()).isEqualTo("<div><span>hello</span></div>");
+    }
+}

--- a/base-template/src/test/java/build/base/template/TextOutTests.java
+++ b/base-template/src/test/java/build/base/template/TextOutTests.java
@@ -1,0 +1,29 @@
+package build.base.template;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TextOutTests {
+
+    @Test
+    void shouldEmitRawUnchanged() {
+        final var out = new TextOut();
+        out.raw("#!/bin/sh\n");
+        assertThat(out.toString()).isEqualTo("#!/bin/sh\n");
+    }
+
+    @Test
+    void shouldWriteWithoutEscaping() {
+        final var out = new TextOut();
+        out.write("<not escaped>");
+        assertThat(out.toString()).isEqualTo("<not escaped>");
+    }
+
+    @Test
+    void shouldHandleNullWrite() {
+        final var out = new TextOut();
+        out.write(null);
+        assertThat(out.toString()).isEmpty();
+    }
+}

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -53,6 +53,11 @@ graph TB
         TELA[base-telemetry-ansi]
     end
 
+    subgraph "Template"
+        TMPL[base-template]
+        TMPLP[base-template-processor]
+    end
+
     subgraph "Utilities"
         TABLE[base-table]
         NAME[base-naming]
@@ -88,6 +93,8 @@ graph TB
     TAR --> ARCH
     TEL --> TELF
     TELF --> TELA
+    TMPLP --> TMPL
+    TMPLP --> PARSE
     RETRY --> ASSERT
     PARSE --> EXPR
 ```
@@ -127,6 +134,9 @@ base/
 ├── base-telemetry/           # Telemetry type hierarchy API (no implementation)
 ├── base-telemetry-ansi/      # ANSI terminal telemetry recorder with progress bars
 ├── base-telemetry-foundation/# Abstract + concrete TelemetryRecorder impls
+├── base-template/            # Runtime: Template<O>, HtmlOut (escaping), TextOut, @ProcessTemplates
+├── base-template-processor/  # APT: compiles .jt template files into Java records at build time
+├── base-template-test/       # Integration tests for base-template-processor (not published)
 ├── base-transport/           # Transport abstraction + Transformer adapters
 ├── base-transport-json/      # Jackson-based JSON transport + codecs
 ├── base-version/             # Version parsing, comparison, ranges, constraints
@@ -558,6 +568,77 @@ Optional<Path<String>> path = Graphs.shortestPath(g, "A", "C");
 - `WeightedGraph`: if multiple edges are added between the same pair, the last weight wins silently.
 
 **Dependencies:** None (production). JUnit 5 + AssertJ (test only).
+
+---
+
+### base-template
+
+**Purpose:** JPMS-native compile-time template library. Templates are authored as `.jt` files and compiled to Java records by `base-template-processor` at build time. `HtmlOut` HTML-escapes all `write()` calls; `TextOut` passes values through verbatim.
+
+| Type | Role |
+|---|---|
+| `Template<O extends Out>` | `@FunctionalInterface`; one method: `render(O out)` |
+| `Out` | Abstract output sink; `raw(String)` writes unescaped; buffers to `StringBuilder` or streams to `Writer` |
+| `HtmlOut` | Extends `Out`; `write(Object)` HTML-escapes `& < > " '` — safe for user-supplied values in HTML |
+| `TextOut` | Extends `Out`; `write(Object)` writes `String.valueOf(value)` unescaped — for plain-text output |
+| `@ProcessTemplates` | Module-level annotation; marks a module as containing `.jt` files; `RetentionPolicy.SOURCE` |
+
+**Template syntax (`.jt` files):**
+```
+package com.example;
+import java.util.List;
+
+template HtmlOut TasksTemplate(String title, List<String> items) {
+<h1>#{title}</h1>
+<ul>
+@for (var item : items) {
+  <li>#{item}</li>
+@}
+</ul>
+}
+```
+- `#{expr}` — interpolated expression; calls `out.write(expr)`
+- `@<statement>` — raw Java code line emitted into `render()`
+- `@include <expr>` — calls `<expr>.render(out)` for sub-template composition
+- `package` / `import` / `import static` / `import static ... .*` all supported in header
+
+**Usage:**
+```java
+var out = new HtmlOut();
+new TasksTemplate("My Tasks", List.of("Buy milk", "Walk dog")).render(out);
+String html = out.toString();
+```
+
+**Dependencies:** None (runtime). `base-parsing` (processor compile-time only).
+
+---
+
+### base-template-processor
+
+**Purpose:** Annotation processor that walks `src/main/jt/` and compiles each `.jt` file into a Java record implementing `Template<O>`. Activated by `@ProcessTemplates` on the consuming module's `module-info.java`.
+
+| Type | Role |
+|---|---|
+| `TemplateProcessor` | `AbstractProcessor`; triggers on `@ProcessTemplates`; walks `src/main/jt/` |
+| `JtParser` | Parses header (package, imports, template declaration) and body (text, `#{expr}`, `@code`, `@include`) |
+| `CodeGenerator` | Emits the Java record source; merges adjacent `RawText` nodes; escapes Java string literals |
+| `ParsedTemplate` | Record holding package, imports, outType, className, params, and `List<BodyNode>` |
+| `BodyNode` (sealed) | `RawText`, `Expression`, `CodeLine`, `Include` |
+
+**Source root:** defaults to `<classOutput>/../../src/main/jt`; override with `-Ajt.sourceDir=<path>` for non-standard layouts.
+
+**Maven setup:**
+```xml
+<annotationProcessorPaths>
+    <path>
+        <groupId>build.base</groupId>
+        <artifactId>base-template-processor</artifactId>
+        <version>${revision}</version>
+    </path>
+</annotationProcessorPaths>
+```
+
+**Dependencies:** `base-parsing`, `java.compiler`.
 
 ---
 
@@ -1008,6 +1089,13 @@ List<String> order = Graphs.topologicalSort(g);     // [sources, compile, test]
 List<Set<String>> layers = Graphs.parallelizableGroups(g); // concurrent execution layers
 Optional<List<String>> cycle = Graphs.findCycle(g); // empty if DAG
 ```
+
+**To write a compile-time template:**
+- Create a `.jt` file under `src/main/jt/<package>/MyTemplate.jt`
+- Annotate `module-info.java` with `@build.base.template.ProcessTemplates`
+- Add `base-template` as a runtime dependency and `base-template-processor` to `annotationProcessorPaths`
+- Use `#{expr}` for interpolation, `@for`/`@if`/`@}` for control flow, `@include expr` for composition
+- Choose `HtmlOut` for HTML output (auto-escapes user values) or `TextOut` for plain text
 
 **To parse and compare versions:**
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,9 @@
         <module>base-telemetry</module>
         <module>base-telemetry-ansi</module>
         <module>base-telemetry-foundation</module>
+        <module>base-template</module>
+        <module>base-template-processor</module>
+        <module>base-template-test</module>
         <module>base-transport</module>
         <module>base-transport-json</module>
         <module>base-version</module>
@@ -235,6 +238,16 @@
             <dependency>
                 <groupId>build.base</groupId>
                 <artifactId>base-telemetry-foundation</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>build.base</groupId>
+                <artifactId>base-template</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>build.base</groupId>
+                <artifactId>base-template-processor</artifactId>
                 <version>${revision}</version>
             </dependency>
             <dependency>
@@ -537,6 +550,7 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
+                            <excludeArtifacts>base-template-test</excludeArtifacts>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
- Adds `base-template`, a lightweight runtime library providing `Template<O>`, `HtmlOut` (with XSS-safe HTML escaping), and `TextOut`                                                                                                                      
- Adds `base-template-processor`, an annotation processor that compiles `.jt` template files in `src/main/jt/` into Java records at build time
- Adds `base-template-test`, an integration test module that exercises the full parse → generate → compile → render pipeline