### PR TITLE
fix(base-template): replace leftCurlyBrace close with atEnd and fix source dir discovery

### DIFF
--- a/base-template-processor/src/main/java/build/base/template/processor/JtParser.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/JtParser.java
@@ -54,7 +54,9 @@ final class JtParser {
                 if (trimmed.startsWith("template ")) {
                     inBody = true;
                 }
-            } else if (!trimmed.equals("}")) {
+            } else if (trimmed.equals("@end")) {
+                break;
+            } else {
                 bodyLines.add(line);
             }
         }

--- a/base-template-processor/src/main/java/build/base/template/processor/TemplateProcessor.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/TemplateProcessor.java
@@ -106,9 +106,17 @@ public final class TemplateProcessor extends AbstractProcessor {
             final URI uri = probe.toUri();
             probe.delete();
 
-            // From target/classes → project root → src/main/jt
-            final Path classOutput = Path.of(uri).getParent();
-            return classOutput.getParent().getParent().resolve("src/main/jt");
+            // Walk up from the class output directory until we find a parent that contains src/main/jt.
+            // This handles both Maven (target/classes) and spin (.build/main/target) layouts.
+            Path dir = Path.of(uri).getParent();
+            while (dir != null) {
+                final Path candidate = dir.resolve("src/main/jt");
+                if (Files.isDirectory(candidate)) {
+                    return candidate;
+                }
+                dir = dir.getParent();
+            }
+            return null;
         } catch (final IOException e) {
             return null;
         }

--- a/base-template-processor/src/test/java/build/base/template/processor/JtParserTests.java
+++ b/base-template-processor/src/test/java/build/base/template/processor/JtParserTests.java
@@ -16,7 +16,7 @@ class JtParserTests {
             "",
             "template HtmlOut HelloTemplate(String name) {",
             "<h1>Hello</h1>",
-            "}"
+            "@end"
         );
         final var result = JtParser.parse(lines, "hello.jt");
 
@@ -35,7 +35,7 @@ class JtParserTests {
             "import com.example.Task;",
             "",
             "template HtmlOut TasksTemplate(List<Task> tasks) {",
-            "}");
+            "@end");
         final var result = JtParser.parse(lines, "tasks.jt");
 
         assertThat(result.imports()).containsExactly("import java.util.List", "import com.example.Task");
@@ -94,7 +94,7 @@ class JtParserTests {
             "@for (var item : items) {",
             "<li>#{item}</li>",
             "@}",
-            "}"
+            "@end"
         );
         final var result = JtParser.parse(lines, "t.jt");
         assertThat(result.body()).contains(new BodyNode.CodeLine("for (var item : items) {"));
@@ -107,7 +107,7 @@ class JtParserTests {
             "package com.example;",
             "template HtmlOut T(Object item) {",
             "@include new ItemTemplate(item)",
-            "}"
+            "@end"
         );
         final var result = JtParser.parse(lines, "t.jt");
         assertThat(result.body()).contains(new BodyNode.Include("new ItemTemplate(item)"));
@@ -119,7 +119,7 @@ class JtParserTests {
             "package com.example;",
             "import java.util.*;",
             "template HtmlOut T() {",
-            "}"
+            "@end"
         );
         final var result = JtParser.parse(lines, "t.jt");
         assertThat(result.imports()).containsExactly("import java.util.*");
@@ -131,7 +131,7 @@ class JtParserTests {
             "package com.example;",
             "import static java.util.List.of;",
             "template HtmlOut T() {",
-            "}"
+            "@end"
         );
         final var result = JtParser.parse(lines, "t.jt");
         assertThat(result.imports()).containsExactly("import static java.util.List.of");
@@ -143,10 +143,36 @@ class JtParserTests {
             "package com.example;",
             "import static java.util.Collections.*;",
             "template HtmlOut T() {",
-            "}"
+            "@end"
         );
         final var result = JtParser.parse(lines, "t.jt");
         assertThat(result.imports()).containsExactly("import static java.util.Collections.*");
+    }
+
+    @Test
+    void shouldPreserveBareClosingBraceInBody() {
+        final var lines = List.of(
+            "package com.example;",
+            "template HtmlOut T() {",
+            "<style>",
+            "body {",
+            "    color: red;",
+            "}",
+            "</style>",
+            "<script>",
+            "function x() {",
+            "    return 1;",
+            "}",
+            "</script>",
+            "@end"
+        );
+        final var result = JtParser.parse(lines, "t.jt");
+
+        assertThat(result.body()).contains(
+            new BodyNode.RawText("body {\n"),
+            new BodyNode.RawText("}\n"),
+            new BodyNode.RawText("function x() {\n"),
+            new BodyNode.RawText("</script>\n"));
     }
 
     @Test

--- a/base-template-processor/src/test/resources/templates/hello.jt
+++ b/base-template-processor/src/test/resources/templates/hello.jt
@@ -7,4 +7,4 @@ template HtmlOut HelloTemplate(String name) {
   <h1>Hello, #{name}!</h1>
 </body>
 </html>
-}
+@end

--- a/base-template-processor/src/test/resources/templates/item.jt
+++ b/base-template-processor/src/test/resources/templates/item.jt
@@ -2,4 +2,4 @@ package build.base.template.processor.generated;
 
 template HtmlOut ItemTemplate(String label, boolean active) {
 <li class="item#{active ? " active" : ""}">#{label}</li>
-}
+@end

--- a/base-template-processor/src/test/resources/templates/tasks.jt
+++ b/base-template-processor/src/test/resources/templates/tasks.jt
@@ -14,4 +14,4 @@ template HtmlOut TasksTemplate(String title, List<String> items) {
   </ul>
 </body>
 </html>
-}
+@end

--- a/base-template-test/src/main/jt/build/base/template/test/HelloTemplate.jt
+++ b/base-template-test/src/main/jt/build/base/template/test/HelloTemplate.jt
@@ -7,4 +7,4 @@ template HtmlOut HelloTemplate(String name) {
   <h1>Hello, #{name}!</h1>
 </body>
 </html>
-}
+@end

--- a/base-template-test/src/main/jt/build/base/template/test/ItemTemplate.jt
+++ b/base-template-test/src/main/jt/build/base/template/test/ItemTemplate.jt
@@ -2,4 +2,4 @@ package build.base.template.test;
 
 template HtmlOut ItemTemplate(String label, boolean active) {
 <li class="item#{active ? " active" : ""}">#{label}</li>
-}
+@end

--- a/base-template-test/src/main/jt/build/base/template/test/TasksTemplate.jt
+++ b/base-template-test/src/main/jt/build/base/template/test/TasksTemplate.jt
@@ -9,4 +9,4 @@ template HtmlOut TasksTemplate(String title, List<String> items) {
   <li>#{item}</li>
 @}
 </ul>
-}
+@end


### PR DESCRIPTION
- Fixes a bug where bare `}` lines in template bodies (CSS rules, JS functions) were silently dropped; replaces the ambiguous trailing `}` close with an explicit `@end` marker                                                                            
- Fixes source directory discovery in `TemplateProcessor` — the previous hardcoded two-level `getParent().getParent()` only worked for Maven's `target/classes` layout; replaced with a walk-up loop that also handles spin's `.build/main/target` layout  
- Updates all `.jt` template files and tests to use `@end`