### PR TITLE
feat(base-parsing): ScannerInput abstraction with backtracking and character-level Scanner API

### DIFF
--- a/base-io/src/main/java/build/base/io/LookaheadReader.java
+++ b/base-io/src/main/java/build/base/io/LookaheadReader.java
@@ -71,6 +71,11 @@ public class LookaheadReader
     private int column;
 
     /**
+     * The zero-based character offset of the current index position in the stream.
+     */
+    private long offset;
+
+    /**
      * Constructs a {@link LookaheadReader} based on the provided {@link Reader} with a desired lookahead character
      * buffer size.
      *
@@ -88,6 +93,7 @@ public class LookaheadReader
 
         this.line = 1;
         this.column = 1;
+        this.offset = 0;
     }
 
     /**
@@ -174,7 +180,7 @@ public class LookaheadReader
      * @return the current {@link Location}
      */
     public Location getLocation() {
-        return Location.of(this.line, this.column);
+        return Location.of(this.line, this.column, this.offset);
     }
 
     /**
@@ -275,6 +281,7 @@ public class LookaheadReader
                 this.column++;
             }
 
+            this.offset++;
             return value;
         }
         else {
@@ -329,6 +336,7 @@ public class LookaheadReader
             }
         }
 
+        this.offset += builder.length();
         return builder.toString();
     }
 
@@ -425,13 +433,23 @@ public class LookaheadReader
         int getColumn();
 
         /**
-         * Creates a {@link Location} given the specified line and column positions.
+         * Obtains the zero-based character offset from the start of the stream.
+         *
+         * @return the character offset
+         */
+        default long getOffset() {
+            return 0;
+        }
+
+        /**
+         * Creates a {@link Location} given the specified line, column, and character offset.
          *
          * @param line   the line
          * @param column the column
+         * @param offset the zero-based character offset
          * @return a new {@link Location}
          */
-        static Location of(final int line, final int column) {
+        static Location of(final int line, final int column, final long offset) {
             return new Location() {
                 @Override
                 public int getLine() {
@@ -441,6 +459,11 @@ public class LookaheadReader
                 @Override
                 public int getColumn() {
                     return column;
+                }
+
+                @Override
+                public long getOffset() {
+                    return offset;
                 }
 
                 @Override
@@ -463,6 +486,17 @@ public class LookaheadReader
                     return "Location " + getLine() + ":" + getColumn();
                 }
             };
+        }
+
+        /**
+         * Creates a {@link Location} given the specified line and column positions.
+         *
+         * @param line   the line
+         * @param column the column
+         * @return a new {@link Location}
+         */
+        static Location of(final int line, final int column) {
+            return of(line, column, 0);
         }
     }
 }

--- a/base-parsing/src/main/java/build/base/parsing/Filter.java
+++ b/base-parsing/src/main/java/build/base/parsing/Filter.java
@@ -9,9 +9,9 @@ package build.base.parsing;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,50 +20,48 @@ package build.base.parsing;
  * #L%
  */
 
-import build.base.io.LookaheadReader;
-
 import java.util.function.Consumer;
 
 /**
- * A {@link Consumer} of a {@link LookaheadReader} that skips content to be ignored while parsing.
+ * A {@link Consumer} of a {@link ScannerInput} that skips content to be ignored while parsing.
  *
  * @author brian.oliver
  * @since Mar-2020
  */
 public interface Filter
-    extends Consumer<LookaheadReader> {
+    extends Consumer<ScannerInput> {
 
     /**
      * A {@link Filter} for characters that satisfy {@link Character#isWhitespace(char)}.
      */
-    Filter WHITESPACE = (reader) -> {
-        while (reader.follows(Character::isWhitespace)) {
-            reader.skip(1);
+    Filter WHITESPACE = (input) -> {
+        while (input.follows(Character::isWhitespace)) {
+            input.skip(1);
         }
     };
 
     /**
      * A {@link Filter} for Java Single Line Comments.
      */
-    Filter JAVA_SINGLE_LINE_COMMENT = (reader) -> {
-        if (reader.follows("//")) {
-            reader.skipWhile(c -> c != '\n');
+    Filter JAVA_SINGLE_LINE_COMMENT = (input) -> {
+        if (input.follows("//")) {
+            input.skipWhile(c -> c != '\n');
         }
     };
 
     /**
      * A {@link Filter} for Java Multiline Comments.
      */
-    Filter JAVA_MULTILINE_COMMENT = (reader) -> {
-        if (reader.follows("/*")) {
-            reader.consume(2);
+    Filter JAVA_MULTILINE_COMMENT = (input) -> {
+        if (input.follows("/*")) {
+            input.consume(2);
 
-            while (!reader.follows("*/")) {
-                reader.skip(1);
+            while (!input.follows("*/")) {
+                input.skip(1);
             }
 
-            if (reader.consume(2).length() != 2) {
-                throw new ParseException(reader.getLocation(), "*/", reader.peekMaximum());
+            if (input.consume(2).length() != 2) {
+                throw new ParseException(input.getLocation(), "*/", input.peekMaximum());
             }
         }
     };

--- a/base-parsing/src/main/java/build/base/parsing/LookaheadReaderInput.java
+++ b/base-parsing/src/main/java/build/base/parsing/LookaheadReaderInput.java
@@ -1,0 +1,87 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.io.LookaheadReader;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * A {@link ScannerInput} backed by a {@link LookaheadReader}.  Does not support backtracking.
+ *
+ * @author reed.vonredwitz
+ * @since Apr-2026
+ */
+public final class LookaheadReaderInput
+    implements ScannerInput {
+
+    private final LookaheadReader reader;
+
+    /**
+     * Constructs a {@link LookaheadReaderInput} for the given {@link Reader}.
+     *
+     * @param reader the reader
+     */
+    public LookaheadReaderInput(final Reader reader) {
+        this.reader = reader instanceof LookaheadReader lr ? lr : new LookaheadReader(reader);
+    }
+
+    @Override
+    public boolean available() {
+        return reader.available();
+    }
+
+    @Override
+    public int peek() {
+        return reader.peek();
+    }
+
+    @Override
+    public CharSequence peek(final int size) {
+        return reader.peek(size);
+    }
+
+    @Override
+    public CharSequence peekMaximum() {
+        return reader.peekMaximum();
+    }
+
+    @Override
+    public int consume() {
+        return reader.consume();
+    }
+
+    @Override
+    public String consume(final int size) {
+        return reader.consume(size);
+    }
+
+    @Override
+    public LookaheadReader.Location getLocation() {
+        return reader.getLocation();
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/Scanner.java
+++ b/base-parsing/src/main/java/build/base/parsing/Scanner.java
@@ -24,11 +24,11 @@ import build.base.foundation.stream.Streamable;
 import build.base.io.LookaheadReader;
 
 import java.io.Reader;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.IntPredicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -62,12 +62,12 @@ public class Scanner
     implements AutoCloseable {
 
     /**
-     * The {@link LookaheadReader} from which content will be read for parsing.
+     * The {@link ScannerInput} from which content will be read for parsing.
      */
-    private final LookaheadReader reader;
+    private final ScannerInput input;
 
     /**
-     * The {@link Filter}s for skipping {@link LookaheadReader} content to ignore and not parse.
+     * The {@link Filter}s for skipping {@link ScannerInput} content to ignore and not parse.
      */
     private final ArrayList<Filter> filters;
 
@@ -84,7 +84,7 @@ public class Scanner
     public Scanner(final Reader reader) {
         Objects.requireNonNull(reader, "The Reader must not be null");
 
-        this.reader = reader instanceof LookaheadReader ? (LookaheadReader) reader : new LookaheadReader(reader);
+        this.input = new LookaheadReaderInput(reader);
         this.filters = new ArrayList<>();
         this.evaluators = new HashMap<>();
     }
@@ -95,13 +95,17 @@ public class Scanner
      * @param string the {@link String}
      */
     public Scanner(final String string) {
-        this(new StringReader(string));
+        Objects.requireNonNull(string, "The String must not be null");
+
+        this.input = new StringInput(string);
+        this.filters = new ArrayList<>();
+        this.evaluators = new HashMap<>();
     }
 
     @Override
     public void close()
         throws Exception {
-        this.reader.close();
+        this.input.close();
     }
 
     /**
@@ -138,25 +142,51 @@ public class Scanner
      * @return the {@link LookaheadReader.Location}
      */
     public LookaheadReader.Location getLocation() {
-        return this.reader.getLocation();
+        return this.input.getLocation();
     }
 
     /**
-     * Normalizes a {@link Pattern} for matching with the {@link String}.
+     * Returns {@code true} if this {@link Scanner} supports backtracking via {@link #save()} and
+     * {@link #restore(int)}.
+     *
+     * @return {@code true} if backtracking is supported
+     */
+    public boolean supportsBacktracking() {
+        return this.input.supportsBacktracking();
+    }
+
+    /**
+     * Saves the current scanner position and returns a checkpoint.
+     *
+     * @return an opaque checkpoint value
+     * @throws UnsupportedOperationException if backtracking is not supported
+     */
+    public int save() {
+        return this.input.save();
+    }
+
+    /**
+     * Restores the scanner to the position recorded by {@link #save()}.
+     *
+     * @param checkpoint a value previously returned by {@link #save()}
+     * @throws UnsupportedOperationException if backtracking is not supported
+     */
+    public void restore(final int checkpoint) {
+        this.input.restore(checkpoint);
+    }
+
+    /**
+     * Normalizes a {@link Pattern} for matching at the current position in the input.
      * <p>
-     * By default, all {@link Pattern}s are designed to match anywhere in a {@link String}, unless they are explicitly
-     * bounded, say to commence matching at the start (^) or end ($) of a {@link String}.  When using a {@link Pattern}
-     * for parsing, we need to take this into account, namely if a specified {@link Pattern} is bounded to commence
-     * matching at the start of a {@link String}, the current position in the {@link String} being parsed
-     * <strong>must be</strong> at the start of the said {@link String}.  Similarly, if the {@link Pattern} is not
-     * bound to commence matching at the start of a {@link String}, we must automatically include the bound to
-     * commence matching at the start of a {@link String}, because we must match from the <i>start of the current
-     * position</i> in the {@link String}.
+     * If the provided {@link Pattern} does not start with {@code ^}, one is prepended so that matching is
+     * anchored to the current scanner position.
      * <p>
-     * This method performs this transformation, if necessary, to return a {@link Pattern} that is suitable for
-     * matching at the current position in the {@link String}.  Should it not be possible to produce a
-     * normalized {@link Pattern} or it is determined that the provided {@link Pattern} would never match, an
-     * {@link Optional#empty()} is returned.
+     * A leading {@code ^} in the caller's pattern is treated as a line-start assertion: the pattern will only
+     * match when the scanner is at column 1 (the start of a line). To match from the current position regardless
+     * of column, omit the {@code ^} — the scanner adds it automatically.
+     * <p>
+     * Returns {@link Optional#empty()} when {@code pattern} is {@code null} or when a line-anchored pattern
+     * is used outside column 1.
      *
      * @param pattern the {@link Pattern}
      * @return the {@link Optional}ly normalized {@link Pattern}
@@ -166,10 +196,9 @@ public class Scanner
             return Optional.empty();
         }
 
-        // normalize the pattern
         final String regex = pattern.pattern();
 
-        if (regex.startsWith("^") && this.reader.getLocation().getColumn() != 1) {
+        if (regex.startsWith("^") && this.input.getLocation().getColumn() != 1) {
             return Optional.empty();
         }
 
@@ -187,18 +216,18 @@ public class Scanner
      * @return the {@link Optional}ly matched {@link String} or {@link Optional#empty()} if the match was unsuccessful
      */
     private Optional<String> match(final Pattern pattern) {
-        if (pattern != null && this.reader.available()) {
+        if (pattern != null && this.input.available()) {
             final Optional<Pattern> normalized = normalize(pattern);
 
             if (normalized.isPresent()) {
-                final Matcher matcher = normalized.get().matcher(this.reader.peekMaximum());
+                final Matcher matcher = normalized.get().matcher(this.input.peekMaximum());
 
                 if (matcher.find()) {
                     // obtain the match
                     final String match = matcher.group();
 
                     // skip the matched length
-                    this.reader.consume(match.length());
+                    this.input.consume(match.length());
 
                     return Optional.of(match);
                 }
@@ -217,11 +246,11 @@ public class Scanner
      * @return the {@link Optional}ly matched {@link String} or {@link Optional#empty()} if the match was unsuccessful
      */
     private Optional<String> match(final String string) {
-        if (string != null && !string.isEmpty() && this.reader.available()) {
-            if (this.reader.peek(string.length()).equals(string)) {
+        if (string != null && !string.isEmpty() && this.input.available()) {
+            if (this.input.peek(string.length()).equals(string)) {
 
                 // move the column past the match
-                this.reader.consume(string.length());
+                this.input.consume(string.length());
 
                 return Optional.of(string);
             }
@@ -240,15 +269,15 @@ public class Scanner
         if (!this.filters.isEmpty()) {
             int index = 0;
 
-            while (this.reader.available() && index < this.filters.size()) {
+            while (this.input.available() && index < this.filters.size()) {
 
                 final Filter filter = this.filters.get(index);
-                final LookaheadReader.Location location = this.reader.getLocation();
+                final LookaheadReader.Location location = this.input.getLocation();
 
-                filter.accept(this.reader);
+                filter.accept(this.input);
 
                 // did the filter consume any content?
-                if (location.equals(this.reader.getLocation())) {
+                if (location.equals(this.input.getLocation())) {
                     // the location wasn't changed, so we can proceed to the next filter
                     index++;
                 } else {
@@ -258,7 +287,7 @@ public class Scanner
             }
         }
 
-        return this.reader.available();
+        return this.input.available();
     }
 
     /**
@@ -316,7 +345,7 @@ public class Scanner
      */
     public String consume(final int count)
         throws ParseException {
-        final String consumed = this.reader.consume(count);
+        final String consumed = this.input.consume(count);
 
         if (consumed.length() != count) {
             throw new ParseException(getLocation(),
@@ -342,9 +371,9 @@ public class Scanner
             final Optional<String> match = match(pattern);
 
             return match.orElseThrow(
-                () -> new ParseException(this.reader.getLocation(), pattern.toString(), this.reader.peekMaximum()));
+                () -> new ParseException(this.input.getLocation(), pattern.toString(), this.input.peekMaximum()));
         } else {
-            throw new ParseException(this.reader.getLocation(), pattern.toString(), "(end of input)");
+            throw new ParseException(this.input.getLocation(), pattern.toString(), "(end of input)");
         }
     }
 
@@ -363,9 +392,9 @@ public class Scanner
             final Optional<String> match = match(string);
 
             return match.orElseThrow(
-                () -> new ParseException(this.reader.getLocation(), string, this.reader.peekMaximum()));
+                () -> new ParseException(this.input.getLocation(), string, this.input.peekMaximum()));
         } else {
-            throw new ParseException(this.reader.getLocation(), string, "(end of input)");
+            throw new ParseException(this.input.getLocation(), string, "(end of input)");
         }
     }
 
@@ -391,7 +420,7 @@ public class Scanner
                 try {
                     return evaluator.apply(this);
                 } catch (final ParseException e) {
-                    throw new ParseException(getLocation(), evaluator.getDescription(), this.reader.peekMaximum());
+                    throw new ParseException(getLocation(), evaluator.getDescription(), this.input.peekMaximum());
                 } catch (final Exception e) {
                     throw new ParseException(
                         getLocation(),
@@ -401,12 +430,12 @@ public class Scanner
                 }
             } else {
                 throw new ParseException(
-                    this.reader.getLocation(),
+                    this.input.getLocation(),
                     evaluator.getDescription(),
-                    this.reader.peekMaximum());
+                    this.input.peekMaximum());
             }
         } else {
-            throw new ParseException(this.reader.getLocation(), evaluator.getDescription(), "(end of input)");
+            throw new ParseException(this.input.getLocation(), evaluator.getDescription(), "(end of input)");
         }
     }
 
@@ -429,9 +458,9 @@ public class Scanner
         }
 
         throw new ParseException(
-            this.reader.getLocation(),
+            this.input.getLocation(),
             "Unable to determine Evaluator for " + valueClass,
-            this.reader.peekMaximum());
+            this.input.peekMaximum());
     }
 
     /**
@@ -443,7 +472,7 @@ public class Scanner
     public boolean follows(final Pattern pattern) {
         final Optional<Pattern> normalized = normalize(pattern);
 
-        return normalized.isPresent() && available() && normalized.get().matcher(this.reader.peekMaximum()).find();
+        return normalized.isPresent() && available() && normalized.get().matcher(this.input.peekMaximum()).find();
     }
 
     /**
@@ -455,7 +484,7 @@ public class Scanner
      * @return {@code true} if the pattern matches, {@code false} otherwise
      */
     public boolean follows(final String string) {
-        return string != null && available() && this.reader.follows(string);
+        return string != null && available() && this.input.follows(string);
     }
 
     /**
@@ -535,7 +564,7 @@ public class Scanner
      */
     public void skipUntil(final Pattern pattern) {
         while (available() && !follows(pattern)) {
-            this.reader.consume();
+            this.input.consume();
         }
     }
 
@@ -550,7 +579,7 @@ public class Scanner
      */
     public void skipUntil(final String string) {
         while (available() && !follows(string)) {
-            this.reader.consume();
+            this.input.consume();
         }
     }
 
@@ -563,7 +592,7 @@ public class Scanner
      */
     public void skipUntil(final Evaluator<?> evaluator) {
         while (available() && !follows(evaluator)) {
-            this.reader.consume();
+            this.input.consume();
         }
     }
 
@@ -577,7 +606,7 @@ public class Scanner
      */
     public void skipUntil(final Class<?> valueClass) {
         while (available() && !follows(valueClass)) {
-            this.reader.consume();
+            this.input.consume();
         }
     }
 
@@ -643,7 +672,7 @@ public class Scanner
         final var builder = new StringBuilder();
 
         while (available() && !follows(pattern)) {
-            builder.append((char) this.reader.consume());
+            builder.append((char) this.input.consume());
         }
 
         return builder.toString();
@@ -662,7 +691,7 @@ public class Scanner
         final var builder = new StringBuilder();
 
         while (available() && !follows(string)) {
-            builder.append((char) this.reader.consume());
+            builder.append((char) this.input.consume());
         }
 
         return builder.toString();
@@ -679,7 +708,7 @@ public class Scanner
         final var builder = new StringBuilder();
 
         while (available() && !follows(evaluator)) {
-            builder.append((char) this.reader.consume());
+            builder.append((char) this.input.consume());
         }
 
         return builder.toString();
@@ -697,7 +726,7 @@ public class Scanner
         final var builder = new StringBuilder();
 
         while (available() && !follows(valueClass)) {
-            builder.append((char) this.reader.consume());
+            builder.append((char) this.input.consume());
         }
 
         return builder.toString();
@@ -764,5 +793,171 @@ public class Scanner
      */
     public boolean hasNext() {
         return available();
+    }
+
+    /**
+     * Determines if the next character (after applying filters) matches the specified character.
+     *
+     * @param c the character to check
+     * @return {@code true} if the next character matches, {@code false} otherwise
+     */
+    public boolean follows(final char c) {
+        return available() && this.input.peek() == c;
+    }
+
+    /**
+     * Peeks at the next character without consuming it, after applying any registered {@link Filter}s.
+     * Returns {@code '\0'} if there is no further content.
+     *
+     * @return the next character, or {@code '\0'} if there is no further content
+     */
+    public char peekChar() {
+        if (!available()) {
+            return '\0';
+        }
+        final int peeked = this.input.peek();
+        return peeked == -1 ? '\0' : (char) peeked;
+    }
+
+    /**
+     * Consumes and returns the next character, after applying any registered {@link Filter}s.
+     *
+     * @return the consumed character
+     * @throws ParseException if there is no further content
+     */
+    public char consumeChar()
+        throws ParseException {
+        if (!available()) {
+            throw new ParseException(this.input.getLocation(), "any character", "(end of input)");
+        }
+        final int consumed = this.input.consume();
+        if (consumed == -1) {
+            throw new ParseException(this.input.getLocation(), "any character", "(end of input)");
+        }
+        return (char) consumed;
+    }
+
+    /**
+     * Consumes balanced delimiters and returns the body (excluding both outer delimiters).
+     * <p>
+     * Precondition: the scanner is positioned on the opening delimiter character (after any registered filters
+     * have skipped whitespace/comments).  After verifying that opening character, the body is read at the raw
+     * character level — filters do <em>not</em> apply inside the body, so whitespace and comment characters are
+     * preserved verbatim.
+     * <p>
+     * Nested {@code open}/{@code close} pairs increment and decrement an internal depth counter.  Quoted strings
+     * inside the body are skipped intact — single and double quotes are both supported, with backslash escape —
+     * so quote-enclosed delimiters do not affect the depth.
+     *
+     * @param open  the opening delimiter character
+     * @param close the closing delimiter character (must differ from {@code open})
+     * @return the body, excluding both outer delimiters
+     * @throws ParseException if not positioned on {@code open}, or if EOF is reached before the matching close
+     */
+    public String consumeBalanced(final char open, final char close)
+        throws ParseException {
+        if (!follows(open)) {
+            throw new ParseException(getLocation(), String.valueOf(open),
+                hasNext() ? String.valueOf(peekChar()) : "(end of input)");
+        }
+        consumeChar();
+        final var body = new StringBuilder();
+        int depth = 1;
+        boolean inString = false;
+        char stringChar = 0;
+        boolean escape = false;
+        while (depth > 0) {
+            final int next = this.input.consume();
+            if (next == -1) {
+                throw new ParseException(this.input.getLocation(), String.valueOf(close), "(end of input)");
+            }
+            final char c = (char) next;
+            if (escape) {
+                escape = false;
+                body.append(c);
+                continue;
+            }
+            if (inString) {
+                body.append(c);
+                if (c == '\\') {
+                    escape = true;
+                } else if (c == stringChar) {
+                    inString = false;
+                }
+                continue;
+            }
+            if (c == '"' || c == '\'') {
+                inString = true;
+                stringChar = c;
+                body.append(c);
+            } else if (c == open) {
+                depth++;
+                body.append(c);
+            } else if (c == close) {
+                depth--;
+                if (depth > 0) {
+                    body.append(c);
+                }
+            } else {
+                body.append(c);
+            }
+        }
+        return body.toString();
+    }
+
+    /**
+     * Determines if the next character (after applying filters) satisfies the specified {@link IntPredicate}.
+     *
+     * @param predicate the {@link IntPredicate}
+     * @return {@code true} if the next character satisfies the predicate, {@code false} otherwise
+     */
+    public boolean follows(final IntPredicate predicate) {
+        return predicate != null && available() && predicate.test(this.input.peek());
+    }
+
+    /**
+     * Attempts to {@link Optional}ly consume the next character if it satisfies the specified {@link IntPredicate},
+     * returning it as an {@link Optional} or {@link Optional#empty()} if it does not.
+     *
+     * @param predicate the {@link IntPredicate}
+     * @return the {@link Optional}ly consumed character
+     */
+    public Optional<Character> optionallyConsume(final IntPredicate predicate) {
+        if (!follows(predicate)) {
+            return Optional.empty();
+        }
+        final int consumed = this.input.consume();
+        return consumed == -1 ? Optional.empty() : Optional.of((char) consumed);
+    }
+
+    /**
+     * Repeatedly skips characters while they satisfy the specified {@link IntPredicate}.
+     * Should no character satisfy the predicate, nothing happens.
+     *
+     * @param predicate the {@link IntPredicate}
+     */
+    public void skipWhile(final IntPredicate predicate) {
+        while (follows(predicate)) {
+            this.input.consume();
+        }
+    }
+
+    /**
+     * Repeatedly consumes characters while they satisfy the specified {@link IntPredicate},
+     * returning all consumed characters as a {@link String}.
+     *
+     * @param predicate the {@link IntPredicate}
+     * @return the consumed characters
+     */
+    public String consumeWhile(final IntPredicate predicate) {
+        final var sb = new StringBuilder();
+        while (follows(predicate)) {
+            final int c = this.input.consume();
+            if (c == -1) {
+                break;
+            }
+            sb.append((char) c);
+        }
+        return sb.toString();
     }
 }

--- a/base-parsing/src/main/java/build/base/parsing/ScannerInput.java
+++ b/base-parsing/src/main/java/build/base/parsing/ScannerInput.java
@@ -1,0 +1,164 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.io.LookaheadReader;
+
+import java.util.function.Predicate;
+
+/**
+ * The character-level input abstraction used by {@link Scanner}.
+ * <p>
+ * Implementations that hold a fixed char buffer (e.g. {@link StringInput}) may support backtracking via
+ * {@link #save()} and {@link #restore(int)}; stream-backed implementations (e.g. {@link LookaheadReaderInput})
+ * typically do not.
+ *
+ * @author reed.vonredwitz
+ * @since Apr-2026
+ */
+public interface ScannerInput
+    extends AutoCloseable {
+
+    /**
+     * Returns {@code true} if there are characters remaining in the input.
+     *
+     * @return {@code true} if input is available
+     */
+    boolean available();
+
+    /**
+     * Returns the next character without consuming it, or {@code -1} at end-of-input.
+     *
+     * @return the next character as an {@code int}, or {@code -1}
+     */
+    int peek();
+
+    /**
+     * Returns up to {@code size} next characters without consuming them.
+     *
+     * @param size the maximum number of characters to peek
+     * @return the peeked characters
+     */
+    CharSequence peek(int size);
+
+    /**
+     * Returns all currently buffered characters without consuming them.
+     *
+     * @return the peeked characters
+     */
+    CharSequence peekMaximum();
+
+    /**
+     * Consumes and returns the next character, or {@code -1} at end-of-input.
+     *
+     * @return the consumed character as an {@code int}, or {@code -1}
+     */
+    int consume();
+
+    /**
+     * Consumes and returns up to {@code size} characters.
+     *
+     * @param size the number of characters to consume
+     * @return the consumed characters
+     */
+    String consume(int size);
+
+    /**
+     * Returns the current location in the input stream.
+     *
+     * @return the current {@link LookaheadReader.Location}
+     */
+    LookaheadReader.Location getLocation();
+
+    @Override
+    void close() throws Exception;
+
+    /**
+     * Returns {@code true} if the specified string occurs next in the input.
+     *
+     * @param string the string to check
+     * @return {@code true} if the string follows
+     */
+    default boolean follows(final String string) {
+        return string != null && peek(string.length()).equals(string);
+    }
+
+    /**
+     * Returns {@code true} if the next character satisfies the predicate.
+     *
+     * @param predicate the predicate to test
+     * @return {@code true} if the predicate is satisfied
+     */
+    default boolean follows(final Predicate<? super Integer> predicate) {
+        return predicate != null && available() && predicate.test(peek());
+    }
+
+    /**
+     * Skips {@code count} characters.
+     *
+     * @param count the number of characters to skip
+     */
+    default void skip(final int count) {
+        consume(count);
+    }
+
+    /**
+     * Skips characters while the predicate is satisfied.
+     *
+     * @param predicate the predicate
+     */
+    default void skipWhile(final Predicate<? super Character> predicate) {
+        if (predicate != null) {
+            while (available() && predicate.test((char) peek())) {
+                consume();
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if this input supports backtracking via {@link #save()} and {@link #restore(int)}.
+     *
+     * @return {@code true} if backtracking is supported
+     */
+    default boolean supportsBacktracking() {
+        return false;
+    }
+
+    /**
+     * Saves the current position and returns a checkpoint that can be passed to {@link #restore(int)}.
+     *
+     * @return an opaque checkpoint value
+     * @throws UnsupportedOperationException if backtracking is not supported
+     */
+    default int save() {
+        throw new UnsupportedOperationException("This ScannerInput does not support backtracking");
+    }
+
+    /**
+     * Restores the input position to the given checkpoint.
+     *
+     * @param checkpoint a value previously returned by {@link #save()}
+     * @throws UnsupportedOperationException if backtracking is not supported
+     */
+    default void restore(final int checkpoint) {
+        throw new UnsupportedOperationException("This ScannerInput does not support backtracking");
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/StringInput.java
+++ b/base-parsing/src/main/java/build/base/parsing/StringInput.java
@@ -1,0 +1,139 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.io.LookaheadReader;
+
+import java.util.ArrayList;
+
+/**
+ * A {@link ScannerInput} backed by a {@link String}.  Supports full backtracking via {@link #save()} and
+ * {@link #restore(int)}.
+ *
+ * @author reed.vonredwitz
+ * @since Apr-2026
+ */
+public final class StringInput
+    implements ScannerInput {
+
+    private record Snapshot(int index, int line, int column, long offset) {
+    }
+
+    private final char[] chars;
+    private final ArrayList<Snapshot> snapshots = new ArrayList<>();
+    private int index;
+    private int line;
+    private int column;
+    private long offset;
+
+    /**
+     * Constructs a {@link StringInput} for the given string.
+     *
+     * @param string the input string
+     */
+    public StringInput(final String string) {
+        this.chars = string.toCharArray();
+        this.index = 0;
+        this.line = 1;
+        this.column = 1;
+        this.offset = 0;
+    }
+
+    @Override
+    public boolean available() {
+        return index < chars.length;
+    }
+
+    @Override
+    public int peek() {
+        return available() ? chars[index] : -1;
+    }
+
+    @Override
+    public CharSequence peek(final int size) {
+        if (!available()) {
+            return "";
+        }
+        return new String(chars, index, Math.min(size, chars.length - index));
+    }
+
+    @Override
+    public CharSequence peekMaximum() {
+        return available() ? new String(chars, index, chars.length - index) : "";
+    }
+
+    @Override
+    public int consume() {
+        if (!available()) {
+            return -1;
+        }
+        final int c = chars[index++];
+        if ((c == '\r' && (index >= chars.length || chars[index] != '\n')) || c == '\n') {
+            line++;
+            column = 1;
+        } else {
+            column++;
+        }
+        offset++;
+        return c;
+    }
+
+    @Override
+    public String consume(final int size) {
+        final var sb = new StringBuilder(size);
+        for (int i = 0; i < size && available(); i++) {
+            sb.append((char) consume());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public LookaheadReader.Location getLocation() {
+        return LookaheadReader.Location.of(line, column, offset);
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+
+    @Override
+    public boolean supportsBacktracking() {
+        return true;
+    }
+
+    @Override
+    public int save() {
+        final int id = snapshots.size();
+        snapshots.add(new Snapshot(index, line, column, offset));
+        return id;
+    }
+
+    @Override
+    public void restore(final int checkpoint) {
+        final Snapshot snap = snapshots.get(checkpoint);
+        this.index = snap.index();
+        this.line = snap.line();
+        this.column = snap.column();
+        this.offset = snap.offset();
+        snapshots.subList(checkpoint + 1, snapshots.size()).clear();
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/Tokenizer.java
+++ b/base-parsing/src/main/java/build/base/parsing/Tokenizer.java
@@ -70,7 +70,10 @@ public class Tokenizer<N> {
         if (this.ignoreWhitespace) {
             scanner.register(Filter.WHITESPACE);
         }
+        return tokenize(scanner, true);
+    }
 
+    private List<Token<N>> tokenize(final Scanner scanner, final boolean throwOnUnknown) {
         final var tokens = new ArrayList<Token<N>>();
 
         while (scanner.hasNext()) {
@@ -84,8 +87,11 @@ public class Tokenizer<N> {
                 }
             }
             if (!tokenProcessed) {
-                throw new ExpressionParserException(
-                    "The expression contains an unknown or unexpected token at " + scanner.getLocation());
+                if (throwOnUnknown) {
+                    throw new ExpressionParserException(
+                        "The expression contains an unknown or unexpected token at " + scanner.getLocation());
+                }
+                break;
             }
         }
 

--- a/base-parsing/src/test/java/build/base/parsing/ScannerBacktrackingTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/ScannerBacktrackingTests.java
@@ -1,0 +1,67 @@
+package build.base.parsing;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link Scanner} backtracking support via {@link ScannerInput}.
+ */
+class ScannerBacktrackingTests {
+
+    @Test
+    void scannerFromStringSupportsBacktracking() {
+        assertThat(new Scanner("abc").supportsBacktracking()).isTrue();
+    }
+
+    @Test
+    void scannerFromReaderDoesNotSupportBacktracking() {
+        assertThat(new Scanner(new StringReader("abc")).supportsBacktracking()).isFalse();
+    }
+
+    @Test
+    void saveAndRestoreReturnsToPriorPosition() {
+        final var scanner = new Scanner("hello world");
+
+        final int checkpoint = scanner.save();
+        scanner.consume("hello");
+
+        assertThat(scanner.follows(" world")).isTrue();
+
+        scanner.restore(checkpoint);
+
+        assertThat(scanner.follows("hello")).isTrue();
+    }
+
+    @Test
+    void saveOnNonBacktrackingScannerThrows() {
+        final var scanner = new Scanner(new StringReader("x"));
+        assertThatThrownBy(scanner::save)
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void restoreOnNonBacktrackingScannerThrows() {
+        final var scanner = new Scanner(new StringReader("x"));
+        assertThatThrownBy(() -> scanner.restore(0))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void saveAndRestoreWorksWithFilters() {
+        final var scanner = new Scanner("  hello  world")
+            .register(Filter.WHITESPACE);
+
+        final int checkpoint = scanner.save();
+        scanner.consume("hello");
+
+        assertThat(scanner.follows("world")).isTrue();
+
+        scanner.restore(checkpoint);
+
+        assertThat(scanner.follows("hello")).isTrue();
+    }
+}

--- a/base-parsing/src/test/java/build/base/parsing/ScannerTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/ScannerTests.java
@@ -386,4 +386,100 @@ class ScannerTests {
         assertThat(scanner.follows("rest"))
             .isTrue();
     }
+
+    /**
+     * Ensure {@link Scanner#follows(char)} detects the next character.
+     */
+    @Test
+    void shouldFollowsChar() {
+        final var scanner = new Scanner("abc");
+
+        assertThat(scanner.follows('a')).isTrue();
+        assertThat(scanner.follows('b')).isFalse();
+
+        scanner.consume("a");
+
+        assertThat(scanner.follows('b')).isTrue();
+    }
+
+    /**
+     * Ensure {@link Scanner#follows(char)} respects registered filters.
+     */
+    @Test
+    void shouldFollowsCharWithFilter() {
+        final var scanner = new Scanner("  x")
+            .register(Filter.WHITESPACE);
+
+        assertThat(scanner.follows('x')).isTrue();
+    }
+
+    /**
+     * Ensure {@link Scanner#peekChar()} returns the next character without consuming it.
+     */
+    @Test
+    void shouldPeekChar() {
+        final var scanner = new Scanner("ab");
+
+        assertThat(scanner.peekChar()).isEqualTo('a');
+        assertThat(scanner.peekChar()).isEqualTo('a');
+
+        scanner.consume("a");
+
+        assertThat(scanner.peekChar()).isEqualTo('b');
+    }
+
+    /**
+     * Ensure {@link Scanner#peekChar()} returns {@code '\0'} on empty input.
+     */
+    @Test
+    void shouldPeekCharOnEmpty() {
+        final var scanner = new Scanner("");
+
+        assertThat(scanner.peekChar()).isEqualTo('\0');
+    }
+
+    /**
+     * Ensure {@link Scanner#peekChar()} respects registered filters.
+     */
+    @Test
+    void shouldPeekCharWithFilter() {
+        final var scanner = new Scanner("  z")
+            .register(Filter.WHITESPACE);
+
+        assertThat(scanner.peekChar()).isEqualTo('z');
+    }
+
+    /**
+     * Ensure {@link Scanner#consumeChar()} consumes and returns the next character.
+     */
+    @Test
+    void shouldConsumeChar() {
+        final var scanner = new Scanner("xy");
+
+        assertThat(scanner.consumeChar()).isEqualTo('x');
+        assertThat(scanner.consumeChar()).isEqualTo('y');
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    /**
+     * Ensure {@link Scanner#consumeChar()} respects registered filters.
+     */
+    @Test
+    void shouldConsumeCharWithFilter() {
+        final var scanner = new Scanner("  q")
+            .register(Filter.WHITESPACE);
+
+        assertThat(scanner.consumeChar()).isEqualTo('q');
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    /**
+     * Ensure {@link Scanner#consumeChar()} throws on empty input.
+     */
+    @Test
+    void shouldConsumeCharThrowsOnEmpty() {
+        final var scanner = new Scanner("");
+
+        org.junit.jupiter.api.Assertions.assertThrows(ParseException.class, scanner::consumeChar);
+    }
 }


### PR DESCRIPTION
- Introduces `ScannerInput` interface to decouple `Scanner` from `LookaheadReader`, with two implementations: `StringInput` (backtracking-capable, char-array backed) and `LookaheadReaderInput` (stream-backed, no backtracking). `Filter` is updated to accept `ScannerInput` accordingly.                       
- `Scanner` constructed from a `String` now uses `StringInput` directly, enabling `save()`/`restore()` checkpointing without the `StringReader → LookaheadReader` round-trip. Checkpoints are O(1) save and restore via an internal snapshot list.       
- Adds character-level methods to `Scanner`: `follows(char)`, `follows(IntPredicate)`, `peekChar()`, `consumeChar()`, `consumeBalanced(char, char)`, `skipWhile(IntPredicate)`, `consumeWhile(IntPredicate)`, and `optionallyConsume(IntPredicate)`.     
- `LookaheadReader.Location` gains `getOffset()` (zero-based character offset from stream start), tracked through both single-char and bulk `consume` paths; the two-arg `Location.of(line, column)` overload is preserved for compatibility.