### PR TITLE
feat(base-parsing): Parser/AbstractParser/Rule combinator framework

### DIFF
--- a/base-parsing/src/main/java/build/base/parsing/AbstractParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/AbstractParser.java
@@ -1,0 +1,195 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.Reader;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Base class for full-grammar parsers — Layer A of base-parsing's two parser styles.
+ * <p>
+ * A subclass implements {@link #parse()} (its imperative grammar, using the inherited {@link #scanner} field and
+ * helper methods) and {@link #translate(ParseException)} (the mapping from {@link ParseException} to its
+ * domain-specific exception type).  Public callers invoke {@link #run()}, which constructs the {@link Scanner},
+ * delegates to {@link #parse()}, asserts that all input was consumed, and translates any {@link ParseException}.
+ * <p>
+ * For composable rule fragments, see {@link Rule}.  An {@link AbstractParser} subclass may use {@link Rule}-style
+ * combinators inside its grammar methods by passing {@code this.scanner} to {@link Rule#tryParse(Scanner)}.
+ *
+ * @param <T> the type of value produced by the grammar
+ * @author reed.vonredwitz
+ * @since Apr-2026
+ */
+public abstract class AbstractParser<T>
+    implements Parser<T> {
+
+    /**
+     * Default identifier-continue character class used by {@link #followsKeyword(String)} to detect that a
+     * keyword stands alone (i.e. is not the prefix of a longer identifier).  Matches the alphabet shared by EL,
+     * the JDK module grammar, ABC, JSON identifiers, and Java in general.
+     */
+    private static final Pattern DEFAULT_IDENT_CONTINUE = Pattern.compile("[a-zA-Z0-9_$]");
+
+    private final String stringInput;
+    private final Reader readerInput;
+
+    /**
+     * The {@link Scanner} for the current parse.  Populated by {@link #run()} immediately before {@link #parse()}
+     * is invoked, and cleared after.  Subclasses should only reference this field from inside grammar methods
+     * called transitively by {@link #parse()}.
+     */
+    protected Scanner scanner;
+
+    /**
+     * Constructs an {@link AbstractParser} that will read from the given {@link String}.
+     *
+     * @param input the input string
+     */
+    protected AbstractParser(final String input) {
+        this.stringInput = Objects.requireNonNull(input, "The input String must not be null");
+        this.readerInput = null;
+    }
+
+    /**
+     * Constructs an {@link AbstractParser} that will read from the given {@link Reader}.
+     *
+     * @param input the input reader
+     */
+    protected AbstractParser(final Reader input) {
+        this.stringInput = null;
+        this.readerInput = Objects.requireNonNull(input, "The input Reader must not be null");
+    }
+
+    /**
+     * Subclass hook: implements the grammar.  Reads from {@link #scanner}, returns the parsed value.  Should not
+     * catch {@link ParseException} — let it propagate; {@link #run()} will translate it via
+     * {@link #translate(ParseException)}.
+     *
+     * @return the parsed value
+     */
+    protected abstract T parse();
+
+    /**
+     * Subclass hook: translates a {@link ParseException} into the subclass's domain-specific exception type.
+     * Has access to the original {@link ParseException} and, via {@code this}, any subclass state (input,
+     * filename, etc.) needed to build a richer message.
+     *
+     * @param cause the {@link ParseException} from the grammar
+     * @return the domain-specific exception to throw
+     */
+    protected abstract RuntimeException translate(ParseException cause);
+
+    /**
+     * Subclass hook: registers {@link Filter}s on the {@link Scanner} before parsing begins.  The default
+     * registers {@link Filter#WHITESPACE}.  Override to register additional filters (e.g. comment filters), or
+     * to register no filters if the grammar is whitespace-significant.
+     *
+     * @param s the {@link Scanner} to configure
+     */
+    protected void registerFilters(final Scanner s) {
+        s.register(Filter.WHITESPACE);
+    }
+
+    /**
+     * Runs the parse to completion.  Constructs a {@link Scanner} over the configured input, applies
+     * {@link #registerFilters(Scanner)}, invokes {@link #parse()}, asserts the entire input was consumed, and
+     * translates any {@link ParseException} via {@link #translate(ParseException)}.
+     *
+     * @return the parsed value
+     * @throws RuntimeException whatever {@link #translate(ParseException)} returns, on parse failure
+     */
+    @Override
+    public final T run() {
+        try (var s = stringInput != null ? new Scanner(stringInput) : new Scanner(readerInput)) {
+            registerFilters(s);
+            this.scanner = s;
+            final T result = parse();
+            if (s.hasNext()) {
+                throw new ParseException(s.getLocation(), "(end of input)", String.valueOf(s.peekChar()));
+            }
+            return result;
+        } catch (final ParseException e) {
+            throw translate(e);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            this.scanner = null;
+        }
+    }
+
+    /**
+     * Helper: consumes the literal {@code expected} or throws.  Equivalent to {@code scanner.consume(expected)}
+     * but reads more directly at call sites.
+     *
+     * @param expected the literal to consume
+     */
+    protected final void expect(final String expected) {
+        scanner.consume(expected);
+    }
+
+    /**
+     * Helper: consumes a match of {@code pattern} and returns the matched text, or throws a {@link ParseException}
+     * whose expected message is {@code description}.
+     *
+     * @param pattern     the pattern to match
+     * @param description the description to use in the {@link ParseException} message
+     * @return the matched text
+     */
+    protected final String expect(final Pattern pattern, final String description) {
+        try {
+            return scanner.consume(pattern);
+        } catch (final ParseException e) {
+            throw new ParseException(e.getLocation().orElse(null), description, e.getFound(), e);
+        }
+    }
+
+    /**
+     * Helper: returns {@code true} if {@code keyword} occurs at the current position and is not immediately
+     * followed by an identifier-continue character ({@code [a-zA-Z0-9_$]}).  This distinguishes the keyword
+     * {@code or} from the start of {@code orange}.
+     *
+     * @param keyword the keyword to test
+     * @return {@code true} if the keyword stands alone at the current position
+     */
+    protected final boolean followsKeyword(final String keyword) {
+        if (!scanner.follows(keyword)) {
+            return false;
+        }
+        return !scanner.follows(Pattern.compile(Pattern.quote(keyword) + DEFAULT_IDENT_CONTINUE.pattern()));
+    }
+
+    /**
+     * Helper: consumes {@code keyword} (with the same word-boundary check as {@link #followsKeyword(String)}),
+     * or throws.
+     *
+     * @param keyword the keyword to consume
+     */
+    protected final void consumeKeyword(final String keyword) {
+        if (!followsKeyword(keyword)) {
+            throw new ParseException(scanner.getLocation(), keyword,
+                scanner.hasNext() ? String.valueOf(scanner.peekChar()) : "(end of input)");
+        }
+        scanner.consume(keyword);
+    }
+}

--- a/base-parsing/src/main/java/build/base/parsing/Parser.java
+++ b/base-parsing/src/main/java/build/base/parsing/Parser.java
@@ -1,0 +1,48 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * A full-grammar parser — Layer A of base-parsing's two parser styles.
+ * <p>
+ * A {@code Parser<T>} consumes its entire input and produces a {@code T}, or throws a domain-specific
+ * exception.  Used by full grammars such as ELParser, JtParser, ModuleInfoParser, AbcParser, and JsonParser.
+ * The standard implementation extends {@link AbstractParser}, which provides {@link Scanner} construction,
+ * full-input-consumption assertion, exception translation, and grammar helpers.
+ * <p>
+ * For composable fragments (combinator-style, soft no-match via {@link java.util.Optional#empty()}), see
+ * {@link Rule} (Layer B).
+ *
+ * @param <T> the type of value produced
+ * @author reed.vonredwitz
+ * @since Apr-2026
+ */
+@FunctionalInterface
+public interface Parser<T> {
+
+    /**
+     * Parses the configured input in full and returns the resulting value, throwing a domain-specific
+     * exception on failure.
+     *
+     * @return the parsed value
+     */
+    T run();
+}

--- a/base-parsing/src/main/java/build/base/parsing/Rule.java
+++ b/base-parsing/src/main/java/build/base/parsing/Rule.java
@@ -1,0 +1,443 @@
+package build.base.parsing;
+
+/*-
+ * #%L
+ * base.build Parsing
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A composable parser fragment — Layer B of base-parsing's two parser styles.
+ * <p>
+ * A {@code Rule<T>} attempts to parse a value of type {@code T} from a {@link Scanner}, returning
+ * {@link Optional#empty()} when the input does not match (without consuming input) and a present {@link Optional}
+ * when it does.  Throws {@link ParseException} for hard failures where input was partially consumed but could not
+ * be completed.  Combinator methods ({@link #or}, {@link #map}, {@link #repeated}, {@link #separatedBy}, …) compose
+ * rules into larger rules.
+ * <p>
+ * Used by {@link ExpressionParser}, {@link TemplateParser}, and any {@link AbstractParser} subclass that wants to
+ * factor a sub-rule out of its imperative grammar methods.
+ * <p>
+ * For full grammars with domain-specific exception types and full-input consumption, see {@link Parser} and
+ * {@link AbstractParser} (Layer A).
+ * <p>
+ * Combinators that try alternatives ({@link #or}, {@link #not}) use {@link Scanner#save()} and
+ * {@link Scanner#restore(int)} and therefore require a backtracking-capable {@link Scanner} (constructed from a
+ * {@link String}).
+ *
+ * @param <T> the type of value produced
+ * @author reed.vonredwitz
+ * @since Apr-2026
+ */
+@FunctionalInterface
+public interface Rule<T> {
+
+    /**
+     * Attempts to parse a value of type {@code T} from the current position of the {@link Scanner}.
+     *
+     * @param scanner the {@link Scanner}
+     * @return the parsed value, or {@link Optional#empty()} if the input does not match
+     * @throws ParseException on a hard parse failure
+     */
+    Optional<T> tryParse(Scanner scanner) throws ParseException;
+
+    /**
+     * Returns a {@link Rule} that maps the result of this rule using the given function.
+     *
+     * @param <U> the result type
+     * @param fn  the mapping function
+     * @return a mapped rule
+     */
+    default <U> Rule<U> map(final Function<T, U> fn) {
+        return scanner -> tryParse(scanner).map(fn);
+    }
+
+    /**
+     * Returns a {@link Rule} that tries this rule first and, if it returns empty, tries {@code other}.
+     * <p>
+     * Requires a backtracking-capable {@link Scanner}.
+     *
+     * @param other the alternative rule
+     * @return a choice rule
+     * @throws UnsupportedOperationException at parse time if the scanner does not support backtracking
+     */
+    default Rule<T> or(final Rule<T> other) {
+        return scanner -> {
+            if (!scanner.supportsBacktracking()) {
+                throw new UnsupportedOperationException("Rule.or() requires a backtracking-capable Scanner");
+            }
+            final int checkpoint = scanner.save();
+            try {
+                final Optional<T> result = tryParse(scanner);
+                if (result.isPresent()) {
+                    return result;
+                }
+            } catch (final ParseException ignored) {
+                // first alternative failed — try the other
+            }
+            scanner.restore(checkpoint);
+            return other.tryParse(scanner);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that runs this rule for its side-effects and then returns the result of {@code next}.
+     *
+     * @param <U>  the result type of the next rule
+     * @param next the rule to run after this one
+     * @return a sequence rule
+     */
+    default <U> Rule<U> then(final Rule<U> next) {
+        return scanner -> {
+            tryParse(scanner);
+            return next.tryParse(scanner);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that applies this rule zero or more times, collecting results into a {@link List}.
+     * <p>
+     * Stops when this rule returns {@link Optional#empty()}.  Always succeeds (returns an empty list when there
+     * are no matches).
+     *
+     * @return a repeated rule
+     */
+    default Rule<List<T>> repeated() {
+        return scanner -> {
+            final List<T> results = new ArrayList<>();
+            Optional<T> item;
+            while ((item = tryParse(scanner)).isPresent()) {
+                results.add(item.get());
+            }
+            return Optional.of(results);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that parses a separated list: one or more occurrences of this rule
+     * interleaved with the separator rule.  Returns an empty list when not even a first element matches.
+     *
+     * @param sep the separator rule
+     * @return a separated-list rule
+     */
+    default Rule<List<T>> separatedBy(final Rule<?> sep) {
+        return scanner -> {
+            final Optional<T> first = tryParse(scanner);
+            if (first.isEmpty()) {
+                return Optional.of(List.of());
+            }
+            final List<T> results = new ArrayList<>();
+            results.add(first.get());
+            while (sep.tryParse(scanner).isPresent()) {
+                final Optional<T> next = tryParse(scanner);
+                if (next.isEmpty()) {
+                    break;
+                }
+                results.add(next.get());
+            }
+            return Optional.of(results);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that applies this rule and then filters the result by the given predicate.
+     * Returns {@link Optional#empty()} when the predicate is not satisfied.
+     *
+     * @param predicate the predicate
+     * @return a filtered rule
+     */
+    default Rule<T> filter(final Predicate<T> predicate) {
+        return scanner -> tryParse(scanner).filter(predicate);
+    }
+
+    /**
+     * Returns a {@link Rule} that runs this rule and {@code other} in sequence, combining their results with
+     * {@code fn}.
+     * <p>
+     * Returns {@link Optional#empty()} if either rule returns empty.  Note that if this rule succeeds but
+     * {@code other} returns empty, any input consumed by this rule is not restored — use {@link #or} with a
+     * checkpoint if you need that guarantee.
+     *
+     * @param <U>   the result type of the second rule
+     * @param <R>   the combined result type
+     * @param other the second rule
+     * @param fn    the combining function
+     * @return a zip rule
+     */
+    default <U, R> Rule<R> zip(final Rule<U> other, final BiFunction<T, U, R> fn) {
+        return scanner -> {
+            final Optional<T> left = tryParse(scanner);
+            if (left.isEmpty()) {
+                return Optional.empty();
+            }
+            final Optional<U> right = other.tryParse(scanner);
+            if (right.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(fn.apply(left.get(), right.get()));
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that always succeeds, wrapping the result of this rule in an {@link Optional}.
+     * Returns {@link Optional#of}{@code (Optional.empty())} when this rule does not match.
+     *
+     * @return an optional rule
+     */
+    default Rule<Optional<T>> optional() {
+        return scanner -> Optional.of(tryParse(scanner));
+    }
+
+    /**
+     * Returns a {@link Rule} that applies this rule one or more times, collecting results into a {@link List}.
+     * Returns {@link Optional#empty()} when there are no matches.
+     *
+     * @return a one-or-more repeated rule
+     */
+    default Rule<List<T>> repeated1() {
+        return scanner -> {
+            final Optional<T> first = tryParse(scanner);
+            if (first.isEmpty()) {
+                return Optional.empty();
+            }
+            final List<T> results = new ArrayList<>();
+            results.add(first.get());
+            Optional<T> item;
+            while ((item = tryParse(scanner)).isPresent()) {
+                results.add(item.get());
+            }
+            return Optional.of(results);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that parses {@code open}, then this rule, then {@code close}, returning only
+     * this rule's result.
+     * <p>
+     * Returns {@link Optional#empty()} if {@code open} does not match.  The {@code close} rule is always
+     * attempted when the content rule succeeds; its result is discarded.
+     *
+     * @param open  the opening delimiter rule
+     * @param close the closing delimiter rule
+     * @return a between rule
+     */
+    default Rule<T> between(final Rule<?> open, final Rule<?> close) {
+        return scanner -> {
+            if (open.tryParse(scanner).isEmpty()) {
+                return Optional.empty();
+            }
+            final Optional<T> result = tryParse(scanner);
+            close.tryParse(scanner);
+            return result;
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that applies this rule exactly {@code n} times, collecting results into a
+     * {@link List}.  Returns {@link Optional#empty()} if the first application does not match.
+     * <p>
+     * Note that if one or more (but fewer than {@code n}) applications match, any consumed input is not restored.
+     *
+     * @param n the exact number of times to apply this rule
+     * @return a fixed-count rule
+     * @throws IllegalArgumentException if {@code n} is negative
+     */
+    default Rule<List<T>> times(final int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("times() count must not be negative");
+        }
+        return scanner -> {
+            final List<T> results = new ArrayList<>(n);
+            for (int i = 0; i < n; i++) {
+                final Optional<T> item = tryParse(scanner);
+                if (item.isEmpty()) {
+                    return i == 0 ? Optional.empty() : Optional.of(results);
+                }
+                results.add(item.get());
+            }
+            return Optional.of(results);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that applies this rule at least {@code min} times, collecting results into a
+     * {@link List}.  Returns {@link Optional#empty()} if fewer than {@code min} matches are found.
+     * <p>
+     * Continues matching beyond {@code min} until the rule returns empty.
+     *
+     * @param min the minimum number of matches required
+     * @return an at-least rule
+     * @throws IllegalArgumentException if {@code min} is negative
+     */
+    default Rule<List<T>> atLeast(final int min) {
+        if (min < 0) {
+            throw new IllegalArgumentException("atLeast() min must not be negative");
+        }
+        return scanner -> {
+            final List<T> results = new ArrayList<>();
+            Optional<T> item;
+            while ((item = tryParse(scanner)).isPresent()) {
+                results.add(item.get());
+            }
+            return results.size() >= min ? Optional.of(results) : Optional.empty();
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that applies this rule at most {@code max} times, collecting results into a
+     * {@link List}.  Always succeeds (returns an empty list when there are no matches).
+     *
+     * @param max the maximum number of matches to collect
+     * @return an at-most rule
+     * @throws IllegalArgumentException if {@code max} is negative
+     */
+    default Rule<List<T>> atMost(final int max) {
+        if (max < 0) {
+            throw new IllegalArgumentException("atMost() max must not be negative");
+        }
+        return scanner -> {
+            final List<T> results = new ArrayList<>();
+            while (results.size() < max) {
+                final Optional<T> item = tryParse(scanner);
+                if (item.isEmpty()) {
+                    break;
+                }
+                results.add(item.get());
+            }
+            return Optional.of(results);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that succeeds (returning {@code true}) when this rule does <em>not</em> match at the
+     * current position, and fails when it does.  The scanner position is never advanced.
+     * <p>
+     * Requires a backtracking-capable {@link Scanner} so the attempted parse can be undone.
+     *
+     * @return a negative-lookahead rule
+     * @throws UnsupportedOperationException at parse time if the scanner does not support backtracking
+     */
+    default Rule<Boolean> not() {
+        return scanner -> {
+            if (!scanner.supportsBacktracking()) {
+                throw new UnsupportedOperationException("Rule.not() requires a backtracking-capable Scanner");
+            }
+            final int checkpoint = scanner.save();
+            final boolean matched;
+            try {
+                matched = tryParse(scanner).isPresent();
+            } catch (final ParseException ignored) {
+                scanner.restore(checkpoint);
+                return Optional.of(true);
+            }
+            scanner.restore(checkpoint);
+            return matched ? Optional.empty() : Optional.of(true);
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that succeeds (returning {@code true}) only when the scanner has no remaining input,
+     * and fails otherwise.
+     *
+     * @return an end-of-input rule
+     */
+    static Rule<Boolean> endOfInput() {
+        return scanner -> scanner.hasNext() ? Optional.empty() : Optional.of(true);
+    }
+
+    /**
+     * Defines a recursive {@link Rule} by providing a self-reference placeholder.
+     * <p>
+     * The {@code definition} function receives a placeholder that forwards all parse calls to the
+     * fully-constructed rule.  This enables rules that reference themselves, such as nested structures and
+     * recursive grammars.
+     * <p>
+     * Direct left recursion (a rule whose first action is to call itself) will cause a {@link StackOverflowError}
+     * at parse time, as with any recursive-descent parser.  Use iteration ({@link #repeated},
+     * {@link #separatedBy}) for left-recursive patterns instead.
+     *
+     * <pre>{@code
+     * // Nested parentheses: '(' (word | nested)* ')'
+     * Rule<String> nested = Rule.define(self ->
+     *     self.or(WORD).repeated().map(parts -> String.join("", parts))
+     *         .between(OPEN_PAREN, CLOSE_PAREN));
+     * }</pre>
+     *
+     * @param <T>        the result type
+     * @param definition a function that receives a self-reference and returns the rule definition
+     * @return the recursive rule
+     */
+    static <T> Rule<T> define(final Function<Rule<T>, Rule<T>> definition) {
+        final var ref = new AtomicReference<Rule<T>>();
+        final Rule<T> placeholder = scanner -> ref.get().tryParse(scanner);
+        ref.set(definition.apply(placeholder));
+        return placeholder;
+    }
+
+    /**
+     * Returns a {@link Rule} that behaves identically to this rule but relabels any {@link ParseException} it
+     * throws, replacing the expected description with {@code description}.  Soft failures
+     * ({@link Optional#empty()} returns) are passed through unchanged.
+     *
+     * @param description the description to use in place of the original expected text
+     * @return a labelled rule
+     */
+    default Rule<T> label(final String description) {
+        return scanner -> {
+            try {
+                return tryParse(scanner);
+            } catch (final ParseException e) {
+                throw new ParseException(e.getLocation().orElse(null), description, e.getFound(), e);
+            }
+        };
+    }
+
+    /**
+     * Returns a {@link Rule} that throws a {@link ParseException} with the given description when this rule
+     * returns {@link Optional#empty()}, converting a soft failure into a hard one.  If this rule throws a
+     * {@link ParseException}, it is relabelled with {@code description}.
+     *
+     * @param description the description of what was expected
+     * @return a requiring rule
+     */
+    default Rule<T> require(final String description) {
+        return scanner -> {
+            try {
+                final Optional<T> result = tryParse(scanner);
+                if (result.isEmpty()) {
+                    throw new ParseException(scanner.getLocation(), description, scanner.hasNext()
+                        ? scanner.peekChar() + ""
+                        : "(end of input)");
+                }
+                return result;
+            } catch (final ParseException e) {
+                if (e.getExpected().equals(description)) {
+                    throw e;
+                }
+                throw new ParseException(e.getLocation().orElse(null), description, e.getFound(), e);
+            }
+        };
+    }
+}

--- a/base-parsing/src/test/java/build/base/parsing/AbstractParserTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/AbstractParserTests.java
@@ -1,0 +1,170 @@
+package build.base.parsing;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AbstractParserTests {
+
+    private static final class DemoException extends RuntimeException {
+        DemoException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * Parses {@code <ident> = <ident>} and returns the pair.
+     */
+    private static final class AssignmentParser extends AbstractParser<String> {
+
+        private static final Pattern IDENT = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+
+        AssignmentParser(final String input) {
+            super(input);
+        }
+
+        AssignmentParser(final Reader input) {
+            super(input);
+        }
+
+        @Override
+        protected String parse() {
+            final var lhs = expect(IDENT, "identifier");
+            expect("=");
+            final var rhs = expect(IDENT, "identifier");
+            return lhs + "=" + rhs;
+        }
+
+        @Override
+        protected RuntimeException translate(final ParseException cause) {
+            return new DemoException("parse failed: " + cause.getMessage(), cause);
+        }
+    }
+
+    /**
+     * Exercises followsKeyword/consumeKeyword.
+     */
+    private static final class KeywordParser extends AbstractParser<String> {
+
+        KeywordParser(final String input) {
+            super(input);
+        }
+
+        @Override
+        protected String parse() {
+            if (followsKeyword("yes")) {
+                consumeKeyword("yes");
+                return "Y";
+            }
+            consumeKeyword("no");
+            return "N";
+        }
+
+        @Override
+        protected RuntimeException translate(final ParseException cause) {
+            return new DemoException("kw fail", cause);
+        }
+    }
+
+    @Test
+    void parsesStringInput() {
+        assertThat(new AssignmentParser("a=b").run()).isEqualTo("a=b");
+    }
+
+    @Test
+    void parsesReaderInput() {
+        assertThat(new AssignmentParser((Reader) new StringReader("foo = bar")).run()).isEqualTo("foo=bar");
+    }
+
+    @Test
+    void translatesParseException() {
+        assertThatThrownBy(() -> new AssignmentParser("a + b").run())
+            .isInstanceOf(DemoException.class)
+            .hasMessageContaining("parse failed")
+            .hasCauseInstanceOf(ParseException.class);
+    }
+
+    @Test
+    void requiresFullInputConsumption() {
+        // The grammar parses "a=b" successfully but extra "; trailing" remains.
+        assertThatThrownBy(() -> new AssignmentParser("a=b; trailing").run())
+            .isInstanceOf(DemoException.class)
+            .hasCauseInstanceOf(ParseException.class);
+    }
+
+    @Test
+    void followsKeywordRespectsWordBoundary() {
+        assertThat(new KeywordParser("yes").run()).isEqualTo("Y");
+        assertThat(new KeywordParser("no").run()).isEqualTo("N");
+        // "yesterday" starts with "yes" but is not the keyword
+        assertThatThrownBy(() -> new KeywordParser("yesterday").run())
+            .isInstanceOf(DemoException.class);
+    }
+
+    @Test
+    void consumeKeywordFailsOnNonKeyword() {
+        assertThatThrownBy(() -> new KeywordParser("yesno").run())
+            .isInstanceOf(DemoException.class);
+    }
+
+    @Test
+    void scannerFieldClearedAfterRun() throws Exception {
+        final var p = new AssignmentParser("a=b");
+        p.run();
+        // package-private field; null after run() returns
+        final var f = AbstractParser.class.getDeclaredField("scanner");
+        f.setAccessible(true);
+        assertThat(f.get(p)).isNull();
+    }
+
+    @Test
+    void consumeBalancedReturnsBody() throws Exception {
+        try (var s = new Scanner("{a + b}")) {
+            assertThat(s.consumeBalanced('{', '}')).isEqualTo("a + b");
+            assertThat(s.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void consumeBalancedHandlesNesting() throws Exception {
+        try (var s = new Scanner("{outer {inner} more}rest")) {
+            assertThat(s.consumeBalanced('{', '}')).isEqualTo("outer {inner} more");
+            assertThat(s.consumeChar()).isEqualTo('r');
+        }
+    }
+
+    @Test
+    void consumeBalancedSkipsQuotedDelimiters() throws Exception {
+        try (var s = new Scanner("{\"}}}\" + 'x}'}")) {
+            assertThat(s.consumeBalanced('{', '}')).isEqualTo("\"}}}\" + 'x}'");
+        }
+    }
+
+    @Test
+    void consumeBalancedHandlesEscapedQuotes() throws Exception {
+        try (var s = new Scanner("{\"a\\\"b\"}")) {
+            assertThat(s.consumeBalanced('{', '}')).isEqualTo("\"a\\\"b\"");
+        }
+    }
+
+    @Test
+    void consumeBalancedThrowsOnEofBeforeClose() throws Exception {
+        try (var s = new Scanner("{unclosed")) {
+            assertThatThrownBy(() -> s.consumeBalanced('{', '}'))
+                .isInstanceOf(ParseException.class);
+        }
+    }
+
+    @Test
+    void consumeBalancedThrowsWhenNotPositionedOnOpen() throws Exception {
+        try (var s = new Scanner("not-a-brace")) {
+            assertThatThrownBy(() -> s.consumeBalanced('{', '}'))
+                .isInstanceOf(ParseException.class);
+        }
+    }
+}

--- a/base-parsing/src/test/java/build/base/parsing/RuleTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/RuleTests.java
@@ -1,0 +1,582 @@
+package build.base.parsing;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link Rule} combinators.
+ */
+class RuleTests {
+
+    private static final Rule<String> WORD = scanner -> {
+        if (!scanner.follows(c -> Character.isLetter(c))) {
+            return Optional.empty();
+        }
+        return Optional.of(scanner.consumeWhile(c -> Character.isLetter(c)));
+    };
+
+    private static final Rule<String> DIGITS = scanner -> {
+        if (!scanner.follows(c -> Character.isDigit(c))) {
+            return Optional.empty();
+        }
+        return Optional.of(scanner.consumeWhile(c -> Character.isDigit(c)));
+    };
+
+    private static final Rule<String> COMMA = scanner ->
+        scanner.optionallyConsume(",").isPresent() ? Optional.of(",") : Optional.empty();
+
+    // ---- tryParse basics ----------------------------------------------------
+
+    @Test
+    void returnsValueWhenInputMatches() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.tryParse(scanner)).contains("hello");
+    }
+
+    @Test
+    void returnsEmptyWhenInputDoesNotMatch() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.tryParse(scanner)).isEmpty();
+    }
+
+    @Test
+    void doesNotConsumeInputOnEmptyResult() throws ParseException {
+        final var scanner = new Scanner("123");
+        WORD.tryParse(scanner);
+        assertThat(scanner.follows("123")).isTrue();
+    }
+
+    // ---- map ----------------------------------------------------------------
+
+    @Test
+    void mapTransformsResult() throws ParseException {
+        final var scanner = new Scanner("hello");
+        final Rule<Integer> length = WORD.map(String::length);
+        assertThat(length.tryParse(scanner)).contains(5);
+    }
+
+    @Test
+    void mapPropagatesEmpty() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.map(String::length).tryParse(scanner)).isEmpty();
+    }
+
+    // ---- filter -------------------------------------------------------------
+
+    @Test
+    void filterPassesMatchingResult() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.filter(w -> w.length() > 3).tryParse(scanner)).contains("hello");
+    }
+
+    @Test
+    void filterRejectsNonMatchingResult() throws ParseException {
+        final var scanner = new Scanner("hi");
+        assertThat(WORD.filter(w -> w.length() > 3).tryParse(scanner)).isEmpty();
+    }
+
+    // ---- or -----------------------------------------------------------------
+
+    @Test
+    void orReturnsFirstAlternativeWhenItMatches() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.or(DIGITS).tryParse(scanner)).contains("hello");
+    }
+
+    @Test
+    void orFallsBackToSecondAlternative() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.or(DIGITS).tryParse(scanner)).contains("123");
+    }
+
+    @Test
+    void orRestoresPositionBeforeTryingSecond() throws ParseException {
+        final Rule<String> failAfterConsuming = scanner -> {
+            if (!scanner.follows("ab")) return Optional.empty();
+            scanner.consume("ab");
+            return Optional.empty(); // consumed but returns empty
+        };
+        final var scanner = new Scanner("abcd");
+        final var result = failAfterConsuming.or(WORD).tryParse(scanner);
+        assertThat(result).contains("abcd");
+    }
+
+    @Test
+    void orThrowsOnNonBacktrackingScanner() {
+        final var scanner = new Scanner(new java.io.StringReader("hello"));
+        assertThatThrownBy(() -> WORD.or(DIGITS).tryParse(scanner))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void orReturnsEmptyWhenBothAlternativesFail() throws ParseException {
+        final var scanner = new Scanner("!!");
+        assertThat(WORD.or(DIGITS).tryParse(scanner)).isEmpty();
+    }
+
+    // ---- then ---------------------------------------------------------------
+
+    @Test
+    void thenReturnsSecondResult() throws ParseException {
+        final var scanner = new Scanner("hello123");
+        assertThat(WORD.then(DIGITS).tryParse(scanner)).contains("123");
+    }
+
+    @Test
+    void thenConsumesFirstParserInput() throws ParseException {
+        final var scanner = new Scanner("hello123");
+        WORD.then(DIGITS).tryParse(scanner);
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    // ---- repeated -----------------------------------------------------------
+
+    @Test
+    void repeatedCollectsAllMatches() throws ParseException {
+        final var scanner = new Scanner("abc");
+        final Rule<String> singleChar = s -> {
+            if (!s.follows(c -> Character.isLetter(c))) return Optional.empty();
+            return Optional.of(String.valueOf(s.consumeChar()));
+        };
+        assertThat(singleChar.repeated().tryParse(scanner)).contains(List.of("a", "b", "c"));
+    }
+
+    @Test
+    void repeatedReturnsEmptyListWhenNothingMatches() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.repeated().tryParse(scanner)).contains(List.of());
+    }
+
+    @Test
+    void repeatedAlwaysSucceeds() throws ParseException {
+        final var scanner = new Scanner("");
+        assertThat(WORD.repeated().tryParse(scanner)).isPresent();
+    }
+
+    // ---- separatedBy --------------------------------------------------------
+
+    @Test
+    void separatedByCollectsItems() throws ParseException {
+        final var scanner = new Scanner("a,b,c");
+        final Rule<String> letter = s -> {
+            if (!s.follows(c -> Character.isLetter(c))) return Optional.empty();
+            return Optional.of(String.valueOf(s.consumeChar()));
+        };
+        assertThat(letter.separatedBy(COMMA).tryParse(scanner)).contains(List.of("a", "b", "c"));
+    }
+
+    @Test
+    void separatedByReturnsSingleItemWithNoSeparator() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.separatedBy(COMMA).tryParse(scanner)).contains(List.of("hello"));
+    }
+
+    @Test
+    void separatedByReturnsEmptyListWhenFirstItemDoesNotMatch() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.separatedBy(COMMA).tryParse(scanner)).contains(List.of());
+    }
+
+    // ---- zip ----------------------------------------------------------------
+
+    @Test
+    void zipCombinesBothResults() throws ParseException {
+        final var scanner = new Scanner("hello123");
+        assertThat(WORD.zip(DIGITS, (w, d) -> w + ":" + d).tryParse(scanner)).contains("hello:123");
+    }
+
+    @Test
+    void zipReturnsEmptyWhenFirstParserFails() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.zip(DIGITS, (w, d) -> w + d).tryParse(scanner)).isEmpty();
+        assertThat(scanner.follows("123")).isTrue();
+    }
+
+    @Test
+    void zipReturnsEmptyWhenSecondParserFails() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.zip(DIGITS, (w, d) -> w + d).tryParse(scanner)).isEmpty();
+    }
+
+    @Test
+    void zipConsumesInputFromBothParsers() throws ParseException {
+        final var scanner = new Scanner("hello123");
+        WORD.zip(DIGITS, (w, d) -> w + d).tryParse(scanner);
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    // ---- optional -----------------------------------------------------------
+
+    @Test
+    void optionalReturnsPresentValueWhenParserMatches() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.optional().tryParse(scanner)).contains(Optional.of("hello"));
+    }
+
+    @Test
+    void optionalReturnsEmptyOptionalWhenParserDoesNotMatch() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.optional().tryParse(scanner)).contains(Optional.empty());
+    }
+
+    @Test
+    void optionalAlwaysSucceeds() throws ParseException {
+        final var scanner = new Scanner("");
+        assertThat(WORD.optional().tryParse(scanner)).isPresent();
+    }
+
+    @Test
+    void optionalDoesNotConsumeInputOnNoMatch() throws ParseException {
+        final var scanner = new Scanner("123");
+        WORD.optional().tryParse(scanner);
+        assertThat(scanner.follows("123")).isTrue();
+    }
+
+    // ---- repeated1 ----------------------------------------------------------
+
+    @Test
+    void repeated1CollectsAllMatches() throws ParseException {
+        final var scanner = new Scanner("abc");
+        final Rule<String> singleChar = s -> {
+            if (!s.follows(c -> Character.isLetter(c))) return Optional.empty();
+            return Optional.of(String.valueOf(s.consumeChar()));
+        };
+        assertThat(singleChar.repeated1().tryParse(scanner)).contains(List.of("a", "b", "c"));
+    }
+
+    @Test
+    void repeated1ReturnsSingleElementList() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.repeated1().tryParse(scanner)).contains(List.of("hello"));
+    }
+
+    @Test
+    void repeated1ReturnsEmptyWhenNothingMatches() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.repeated1().tryParse(scanner)).isEmpty();
+    }
+
+    @Test
+    void repeated1DoesNotConsumeInputOnNoMatch() throws ParseException {
+        final var scanner = new Scanner("123");
+        WORD.repeated1().tryParse(scanner);
+        assertThat(scanner.follows("123")).isTrue();
+    }
+
+    // ---- between ------------------------------------------------------------
+
+    private static final Rule<String> OPEN_PAREN = scanner ->
+        scanner.optionallyConsume("(").isPresent() ? Optional.of("(") : Optional.empty();
+
+    private static final Rule<String> CLOSE_PAREN = scanner ->
+        scanner.optionallyConsume(")").isPresent() ? Optional.of(")") : Optional.empty();
+
+    @Test
+    void betweenExtractsContentBetweenDelimiters() throws ParseException {
+        final var scanner = new Scanner("(hello)");
+        assertThat(WORD.between(OPEN_PAREN, CLOSE_PAREN).tryParse(scanner)).contains("hello");
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void betweenReturnsEmptyWhenOpenFails() throws ParseException {
+        final var scanner = new Scanner("hello)");
+        assertThat(WORD.between(OPEN_PAREN, CLOSE_PAREN).tryParse(scanner)).isEmpty();
+        assertThat(scanner.follows("hello)")).isTrue();
+    }
+
+    @Test
+    void betweenConsumesMissingCloseGracefully() throws ParseException {
+        final var scanner = new Scanner("(hello");
+        assertThat(WORD.between(OPEN_PAREN, CLOSE_PAREN).tryParse(scanner)).contains("hello");
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void betweenWorksWithNestedContent() throws ParseException {
+        final var scanner = new Scanner("(hello world)");
+        final Rule<String> untilClose = s -> Optional.of(s.consumeUntil(")"));
+        assertThat(untilClose.between(OPEN_PAREN, CLOSE_PAREN).tryParse(scanner)).contains("hello world");
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    // ---- times --------------------------------------------------------------
+
+    @Test
+    void timesMatchesExactCount() throws ParseException {
+        final var scanner = new Scanner("aaa");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.times(3).tryParse(scanner)).contains(List.of("a", "a", "a"));
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void timesReturnsEmptyWhenFirstMatchFails() throws ParseException {
+        final var scanner = new Scanner("bbb");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.times(3).tryParse(scanner)).isEmpty();
+        assertThat(scanner.follows("bbb")).isTrue();
+    }
+
+    @Test
+    void timesZeroAlwaysSucceedsWithEmptyList() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.times(0).tryParse(scanner)).contains(List.of());
+    }
+
+    @Test
+    void timesNegativeThrows() {
+        assertThatThrownBy(() -> WORD.times(-1))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---- atLeast ------------------------------------------------------------
+
+    @Test
+    void atLeastSucceedsWhenMinMet() throws ParseException {
+        final var scanner = new Scanner("aaa");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.atLeast(2).tryParse(scanner)).contains(List.of("a", "a", "a"));
+    }
+
+    @Test
+    void atLeastReturnsEmptyWhenBelowMin() throws ParseException {
+        final var scanner = new Scanner("a");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.atLeast(2).tryParse(scanner)).isEmpty();
+    }
+
+    @Test
+    void atLeastZeroIsSameAsRepeated() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.atLeast(0).tryParse(scanner)).contains(List.of());
+    }
+
+    @Test
+    void atLeastNegativeThrows() {
+        assertThatThrownBy(() -> WORD.atLeast(-1))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---- atMost -------------------------------------------------------------
+
+    @Test
+    void atMostCollectsUpToMax() throws ParseException {
+        final var scanner = new Scanner("aaaaa");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.atMost(3).tryParse(scanner)).contains(List.of("a", "a", "a"));
+        assertThat(scanner.follows("aa")).isTrue();
+    }
+
+    @Test
+    void atMostSucceedsWithFewerThanMax() throws ParseException {
+        final var scanner = new Scanner("a");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.atMost(3).tryParse(scanner)).contains(List.of("a"));
+    }
+
+    @Test
+    void atMostAlwaysSucceedsOnNoMatch() throws ParseException {
+        final var scanner = new Scanner("bbb");
+        final Rule<String> a = s -> s.follows('a') ? Optional.of(String.valueOf(s.consumeChar())) : Optional.empty();
+        assertThat(a.atMost(3).tryParse(scanner)).contains(List.of());
+    }
+
+    @Test
+    void atMostNegativeThrows() {
+        assertThatThrownBy(() -> WORD.atMost(-1))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---- not ----------------------------------------------------------------
+
+    @Test
+    void notSucceedsWhenParserFails() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.not().tryParse(scanner)).contains(true);
+        assertThat(scanner.follows("123")).isTrue();
+    }
+
+    @Test
+    void notFailsWhenParserSucceeds() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.not().tryParse(scanner)).isEmpty();
+        assertThat(scanner.follows("hello")).isTrue();
+    }
+
+    @Test
+    void notNeverAdvancesScanner() throws ParseException {
+        final var scanner = new Scanner("hello");
+        WORD.not().tryParse(scanner);
+        assertThat(scanner.follows("hello")).isTrue();
+    }
+
+    @Test
+    void notThrowsOnNonBacktrackingScanner() {
+        final var scanner = new Scanner(new java.io.StringReader("hello"));
+        assertThatThrownBy(() -> WORD.not().tryParse(scanner))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // ---- endOfInput ---------------------------------------------------------
+
+    @Test
+    void endOfInputSucceedsAtEnd() throws ParseException {
+        final var scanner = new Scanner("");
+        assertThat(Rule.endOfInput().tryParse(scanner)).contains(true);
+    }
+
+    @Test
+    void endOfInputFailsWhenInputRemains() throws ParseException {
+        final var scanner = new Scanner("x");
+        assertThat(Rule.endOfInput().tryParse(scanner)).isEmpty();
+    }
+
+    @Test
+    void endOfInputSucceedsAfterConsumingAll() throws ParseException {
+        final var scanner = new Scanner("hi");
+        WORD.tryParse(scanner);
+        assertThat(Rule.endOfInput().tryParse(scanner)).contains(true);
+    }
+
+    // ---- label --------------------------------------------------------------
+
+    @Test
+    void labelRelabelsParseException() {
+        final Rule<String> alwaysThrows = scanner -> {
+            throw new ParseException(scanner.getLocation(), "original", "x");
+        };
+        final var scanner = new Scanner("x");
+        assertThatThrownBy(() -> alwaysThrows.label("relabelled").tryParse(scanner))
+            .isInstanceOf(ParseException.class)
+            .satisfies(e -> assertThat(((ParseException) e).getExpected()).isEqualTo("relabelled"));
+    }
+
+    @Test
+    void labelPassesThroughEmptyResult() throws ParseException {
+        final var scanner = new Scanner("123");
+        assertThat(WORD.label("word").tryParse(scanner)).isEmpty();
+    }
+
+    @Test
+    void labelPassesThroughSuccessResult() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.label("word").tryParse(scanner)).contains("hello");
+    }
+
+    // ---- require ------------------------------------------------------------
+
+    @Test
+    void requireThrowsWhenParserReturnsEmpty() {
+        final var scanner = new Scanner("123");
+        assertThatThrownBy(() -> WORD.require("identifier").tryParse(scanner))
+            .isInstanceOf(ParseException.class)
+            .satisfies(e -> assertThat(((ParseException) e).getExpected()).isEqualTo("identifier"));
+    }
+
+    @Test
+    void requirePassesThroughSuccessResult() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(WORD.require("identifier").tryParse(scanner)).contains("hello");
+    }
+
+    @Test
+    void requireRelabelsParseException() {
+        final Rule<String> alwaysThrows = scanner -> {
+            throw new ParseException(scanner.getLocation(), "original", "x");
+        };
+        final var scanner = new Scanner("x");
+        assertThatThrownBy(() -> alwaysThrows.require("identifier").tryParse(scanner))
+            .isInstanceOf(ParseException.class)
+            .satisfies(e -> assertThat(((ParseException) e).getExpected()).isEqualTo("identifier"));
+    }
+
+    // ---- define (recursive grammars) ----------------------------------------
+
+    // Parses a word or a parenthesised group containing more of the same, e.g. "(hello (world))"
+    private static final Rule<String> NESTED_PARENS = Rule.define(self -> {
+        final Rule<String> open = scanner ->
+            scanner.optionallyConsume("(").isPresent() ? Optional.of("(") : Optional.empty();
+        final Rule<String> close = scanner ->
+            scanner.optionallyConsume(")").isPresent() ? Optional.of(")") : Optional.empty();
+        return WORD.or(self).repeated1()
+            .map(parts -> String.join(" ", parts))
+            .between(open, close);
+    });
+
+    @Test
+    void defineHandlesFlatContent() throws ParseException {
+        final var scanner = new Scanner("(hello world)");
+        scanner.register(Filter.WHITESPACE);
+        assertThat(NESTED_PARENS.tryParse(scanner)).isPresent();
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void defineHandlesOneNestedLevel() throws ParseException {
+        final var scanner = new Scanner("(hello (world))");
+        scanner.register(Filter.WHITESPACE);
+        assertThat(NESTED_PARENS.tryParse(scanner)).isPresent();
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void defineHandlesDeeplyNested() throws ParseException {
+        final var scanner = new Scanner("(a (b (c (d))))");
+        scanner.register(Filter.WHITESPACE);
+        assertThat(NESTED_PARENS.tryParse(scanner)).isPresent();
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void defineReturnsEmptyWhenNoOpenParen() throws ParseException {
+        final var scanner = new Scanner("hello");
+        assertThat(NESTED_PARENS.tryParse(scanner)).isEmpty();
+        assertThat(scanner.follows("hello")).isTrue();
+    }
+
+    // Parses nested block comments: /* ... /* ... */ ... */
+    private static Rule<String> nestedBlockComment() {
+        final Rule<String> notDelimiter = scanner -> {
+            if (scanner.follows("/*") || scanner.follows("*/") || !scanner.hasNext()) {
+                return Optional.empty();
+            }
+            return Optional.of(String.valueOf(scanner.consumeChar()));
+        };
+        return Rule.define(self -> {
+            final Rule<String> open = s ->
+                s.optionallyConsume("/*").isPresent() ? Optional.of("/*") : Optional.empty();
+            final Rule<String> close = s ->
+                s.optionallyConsume("*/").isPresent() ? Optional.of("*/") : Optional.empty();
+            return notDelimiter.or(self).repeated()
+                .map(parts -> String.join("", parts))
+                .between(open, close);
+        });
+    }
+
+    @Test
+    void defineHandlesFlatBlockComment() throws ParseException {
+        final var scanner = new Scanner("/* hello */");
+        assertThat(nestedBlockComment().tryParse(scanner)).contains(" hello ");
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void defineHandlesNestedBlockComment() throws ParseException {
+        final var scanner = new Scanner("/* outer /* inner */ outer */");
+        assertThat(nestedBlockComment().tryParse(scanner)).isPresent();
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void defineHandlesDeeplyNestedBlockComment() throws ParseException {
+        final var scanner = new Scanner("/* a /* b /* c */ b */ a */");
+        assertThat(nestedBlockComment().tryParse(scanner)).isPresent();
+        assertThat(scanner.hasNext()).isFalse();
+    }
+}


### PR DESCRIPTION
- Adds `Parser<T>`, a functional interface for full-grammar parsers that consume their entire input and produce a value or throw a domain-specific exception.
- Adds `AbstractParser<T>`, the standard implementation base: subclasses implement `parse()` (the grammar) and `translate(ParseException)` (domain exception mapping); `run()` handles scanner construction, filter registration, full-input-consumption assertion, and scanner lifecycle.
- Adds `Rule<T>`, a functional interface for composable parser fragments that return `Optional<T>` (soft no-match) or throw `ParseException` (hard failure), with a full combinator set: `map`, `filter`, `or`, `then`, `zip`, `optional`, `repeated`, `repeated1`, `separatedBy`, `between`, `times`, `atLeast`, `atMost`, `not`, `label`, `require`, `endOfInput`, and `define` for recursive grammars.
- `Rule.or` and `Rule.not` use `Scanner#save()`/`restore()` for backtracking and require a backtracking-capable scanner (i.e. one constructed from a `String`).