### PR TITLE
chore(base-parsing, base-expression, base-template-processor): wire Rule into ExpressionParser/TemplateParser and port ELParser/JtParser to AbstractParser

### DIFF
--- a/base-expression/src/main/java/build/base/expression/parser/ELParser.java
+++ b/base-expression/src/main/java/build/base/expression/parser/ELParser.java
@@ -33,8 +33,9 @@ import build.base.expression.ast.Node;
 import build.base.expression.ast.PropertyAccessNode;
 import build.base.expression.ast.SemicolonNode;
 import build.base.expression.ast.UnaryOpNode;
+import build.base.parsing.AbstractParser;
 import build.base.parsing.Evaluator;
-import build.base.parsing.Filter;
+import build.base.parsing.ParseException;
 import build.base.parsing.Scanner;
 import jakarta.el.ELException;
 
@@ -52,7 +53,8 @@ import java.util.regex.Pattern;
  *   <li>{@link #parseExpression(String)} — parses a raw expression (no {@code ${}} wrapper)</li>
  * </ul>
  */
-public final class ELParser {
+public final class ELParser
+    extends AbstractParser<Node> {
 
     // Evaluators for lexical token recognition
     private static final Evaluator<String> IDENTIFIER =
@@ -73,14 +75,33 @@ public final class ELParser {
         Evaluator.create(Pattern.compile("'(?:[^'\\\\]|\\\\.)*'|\"(?:[^\"\\\\]|\\\\.)*\""),
             s -> unescape(s.substring(1, s.length() - 1), s.charAt(0)), "string literal");
 
-    // Pattern used for keyword word-boundary checks
-    private static final Pattern IDENT_CONTINUE = Pattern.compile("[a-zA-Z0-9_$].*");
+    private enum Mode {EXPRESSION, FULL_WRAPPED}
 
-    private final Scanner scanner;
+    private final String originalInput;
+    private final Mode mode;
 
-    private ELParser(final String input) {
-        this.scanner = new Scanner(input);
-        this.scanner.register(Filter.WHITESPACE);
+    private ELParser(final String input, final Mode mode) {
+        super(input);
+        this.originalInput = input;
+        this.mode = mode;
+    }
+
+    @Override
+    protected Node parse() {
+        return switch (mode) {
+            case FULL_WRAPPED -> {
+                scanner.consume(2);  // ${ or #{
+                final Node node = parseSemicolon();
+                expect("}");
+                yield node;
+            }
+            default -> parseSemicolon();
+        };
+    }
+
+    @Override
+    protected RuntimeException translate(final ParseException cause) {
+        return new ELException("Failed to parse expression: " + originalInput, cause);
     }
 
     // -------------------------------------------------------------------------
@@ -89,31 +110,14 @@ public final class ELParser {
 
     /**
      * Parses a full EL expression string like {@code "${name}"} or {@code "#{name}"}.
-     * Throws {@link ELException} if the expression is malformed.
+     * Returns a {@link LiteralNode} when the input contains no expression delimiters.
+     * Throws {@link ELException} if a wrapped expression is malformed.
      */
     public static Node parseFull(final String expression) {
-        try {
-            final var parser = new ELParser(expression);
-            final var s = parser.scanner;
-            if (s.follows("${") || s.follows("#{")) {
-                s.consume(2);
-                final var node = parser.parseSemicolon();
-                if (!s.follows("}")) {
-                    throw new ELException("Expected '}' at end of expression: " + expression);
-                }
-                s.consume("}");
-                if (s.hasNext()) {
-                    throw new ELException("Unexpected content after expression: " + expression);
-                }
-                return node;
-            }
-            // No expression delimiters — treat as literal text
-            return new LiteralNode(expression);
-        } catch (final ELException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new ELException("Failed to parse expression: " + expression, e);
+        if (expression.startsWith("${") || expression.startsWith("#{")) {
+            return new ELParser(expression, Mode.FULL_WRAPPED).run();
         }
+        return new LiteralNode(expression);
     }
 
     /**
@@ -122,45 +126,28 @@ public final class ELParser {
      */
     public static Node parseComposite(final String template) {
         final var parts = new ArrayList<Node>();
-        var i = 0;
-        final var len = template.length();
-        var textStart = 0;
-
-        while (i < len) {
-            final var isDollar = i + 1 < len && template.charAt(i) == '$' && template.charAt(i + 1) == '{';
-            final var isHash   = i + 1 < len && template.charAt(i) == '#' && template.charAt(i + 1) == '{';
-            if (isDollar || isHash) {
-                if (i > textStart) {
-                    parts.add(new LiteralNode(template.substring(textStart, i)));
-                }
-                final var exprStart = i + 2;
-                var depth = 1;
-                var j = exprStart;
-                while (j < len && depth > 0) {
-                    final var ch = template.charAt(j);
-                    if (ch == '{') {
-                        depth++;
-                    } else if (ch == '}') {
-                        depth--;
+        final var sb = new StringBuilder();
+        try (var s = new Scanner(template)) {
+            // No filters — preserve whitespace in literal text.
+            while (s.hasNext()) {
+                if (s.follows("${") || s.follows("#{")) {
+                    if (sb.length() > 0) {
+                        parts.add(new LiteralNode(sb.toString()));
+                        sb.setLength(0);
                     }
-                    if (depth > 0) {
-                        j++;
-                    } else {
-                        break;
-                    }
+                    s.consume(1);  // $ or #
+                    parts.add(parseExpression(s.consumeBalanced('{', '}')));
+                } else {
+                    sb.append(s.consumeChar());
                 }
-                if (depth != 0) {
-                    throw new ELException("Unclosed expression in template: " + template);
-                }
-                parts.add(parseExpression(template.substring(exprStart, j)));
-                i = j + 1;
-                textStart = i;
-            } else {
-                i++;
             }
+        } catch (final ELException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new ELException("Unclosed expression in template: " + template, e);
         }
-        if (textStart < len) {
-            parts.add(new LiteralNode(template.substring(textStart)));
+        if (sb.length() > 0) {
+            parts.add(new LiteralNode(sb.toString()));
         }
         if (parts.size() == 1) {
             return parts.get(0);
@@ -172,18 +159,7 @@ public final class ELParser {
      * Parses a raw expression string (without {@code ${}} wrapping).
      */
     public static Node parseExpression(final String expression) {
-        try {
-            final var parser = new ELParser(expression);
-            final var node = parser.parseSemicolon();
-            if (parser.scanner.hasNext()) {
-                throw new ELException("Unexpected characters after expression: " + expression);
-            }
-            return node;
-        } catch (final ELException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new ELException("Failed to parse expression: " + expression, e);
-        }
+        return new ELParser(expression, Mode.EXPRESSION).run();
     }
 
     // -------------------------------------------------------------------------
@@ -468,10 +444,10 @@ public final class ELParser {
 
             // Keyword literals
             return switch (ident) {
-                case "true"  -> new LiteralNode(Boolean.TRUE);
+                case "true" -> new LiteralNode(Boolean.TRUE);
                 case "false" -> new LiteralNode(Boolean.FALSE);
-                case "null"  -> new LiteralNode(null);
-                default      -> new IdentifierNode(ident);
+                case "null" -> new LiteralNode(null);
+                default -> new IdentifierNode(ident);
             };
         }
 
@@ -505,23 +481,6 @@ public final class ELParser {
             }
         }
         return List.copyOf(args);
-    }
-
-    /**
-     * Returns true if the scanner starts with the keyword {@code kw} and the next character after
-     * is not an identifier-continue character (i.e. the keyword is a standalone token).
-     */
-    private boolean followsKeyword(final String kw) {
-        if (!scanner.follows(kw)) {
-            return false;
-        }
-        // Peek at what follows the keyword — use a pattern that matches kw + ident-char
-        // If that matches, then kw is part of a larger identifier, not a keyword
-        return !scanner.follows(Pattern.compile(Pattern.quote(kw) + "[a-zA-Z0-9_$]"));
-    }
-
-    private void consumeKeyword(final String kw) {
-        scanner.consume(kw);
     }
 
     private static String unescape(final String raw, final char quote) {

--- a/base-parsing/src/main/java/build/base/parsing/ExpressionParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/ExpressionParser.java
@@ -34,6 +34,7 @@ import build.base.parsing.tokenparsers.UnaryTokenParser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -45,7 +46,8 @@ import java.util.function.Function;
  * @author tim.berston
  * @since Nov-2024
  */
-public class ExpressionParser<N> {
+public class ExpressionParser<N>
+    implements Rule<N> {
 
     private final List<TokenParser<N>> tokenParsers;
 
@@ -110,17 +112,40 @@ public class ExpressionParser<N> {
         if (expression == null || expression.isBlank()) {
             return null;
         }
+        final var scanner = new Scanner(expression);
+        scanner.register(Filter.WHITESPACE);
+        final N result = tryParse(scanner).orElse(null);
+        if (scanner.hasNext()) {
+            throw new ExpressionParserException(
+                "The expression contains an unknown or unexpected token at " + scanner.getLocation());
+        }
+        return result;
+    }
 
-        final var tokenizer = new Tokenizer<>(this.tokenParsers);
-        final var tokens = tokenizer.tokenize(expression);
+    /**
+     * Parses as much of the expression as possible from the current position of the {@link Scanner}, stopping
+     * when no token matches rather than throwing.  Returns {@link Optional#empty()} if no tokens were recognised.
+     * <p>
+     * The scanner is used as-is — filters (e.g. whitespace) must be registered by the caller before invoking.
+     *
+     * @param scanner the scanner to read from
+     * @return the parsed node, or {@link Optional#empty()} if nothing was recognised
+     * @throws ExpressionParserException if tokens were partially parsed but the expression is malformed
+     */
+    @Override
+    public Optional<N> tryParse(final Scanner scanner) {
+        final var tokens = new Tokenizer<>(this.tokenParsers).tokenize(scanner);
+        if (tokens.isEmpty()) {
+            return Optional.empty();
+        }
         final var stackManager = new ExpressionStackManager<N>();
         try {
             for (final var token : tokens) {
                 stackManager.push(token.tokenParser().createNodeResolver(token));
             }
-            return stackManager.getExpressionRoot().resolve();
+            return Optional.of(stackManager.getExpressionRoot().resolve());
         } catch (final ExpressionParserException e) {
-            throw e; // preserve domain exceptions — ExpressionParserException extends RuntimeException
+            throw e;
         } catch (final RuntimeException e) {
             throw new ExpressionParserException("There was an error parsing the expression", e);
         }

--- a/base-parsing/src/main/java/build/base/parsing/TemplateParser.java
+++ b/base-parsing/src/main/java/build/base/parsing/TemplateParser.java
@@ -46,7 +46,8 @@ import java.util.function.Function;
  * @author tim.berston
  * @since Mar-2025
  */
-public class TemplateParser<N> {
+public class TemplateParser<N>
+    implements Rule<List<N>> {
 
     private final List<TokenParser<N>> tokenParsers;
     private final BiFunction<N, N, Optional<N>> tryMerge;
@@ -91,27 +92,53 @@ public class TemplateParser<N> {
         if (expression == null || expression.isBlank()) {
             return List.of();
         }
+        final var scanner = new Scanner(expression);
+        final List<N> result = tryParse(scanner).orElse(List.of());
+        if (scanner.hasNext()) {
+            throw new ExpressionParserException(
+                "The expression contains an unknown or unexpected token at " + scanner.getLocation());
+        }
+        return result;
+    }
 
-        final var tokenizer = new Tokenizer<>(this.tokenParsers, false);
-        final var tokens = tokenizer.tokenize(expression);
+    /**
+     * Parses as much of the template as possible from the current position of the {@link Scanner}, stopping
+     * when no token matches rather than throwing.  Returns {@link Optional#empty()} if no tokens were recognised.
+     * <p>
+     * The scanner is used as-is — no filters are registered on it.
+     *
+     * @param scanner the scanner to read from
+     * @return the parsed node list, or {@link Optional#empty()} if nothing was recognised
+     * @throws ExpressionParserException if the template is malformed
+     */
+    @Override
+    public Optional<List<N>> tryParse(final Scanner scanner) {
+        final var tokens = new Tokenizer<>(this.tokenParsers, false).tokenize(scanner);
+        if (tokens.isEmpty()) {
+            return Optional.empty();
+        }
         try {
-            final var nodes = new ArrayList<N>();
-            for (final var token : tokens) {
-                final var node = token.tokenParser().createNodeResolver(token).resolve();
-                if (this.tryMerge != null && !nodes.isEmpty()) {
-                    final var merged = this.tryMerge.apply(nodes.getLast(), node);
-                    if (merged.isPresent()) {
-                        nodes.set(nodes.size() - 1, merged.get());
-                        continue;
-                    }
-                }
-                nodes.add(node);
-            }
-            return nodes;
+            return Optional.of(resolveNodes(tokens));
         } catch (final ExpressionParserException e) {
-            throw e; // preserve domain exceptions — ExpressionParserException extends RuntimeException
+            throw e;
         } catch (final RuntimeException e) {
             throw new ExpressionParserException("There was an error parsing the expression", e);
         }
+    }
+
+    private List<N> resolveNodes(final List<Token<N>> tokens) {
+        final var nodes = new ArrayList<N>();
+        for (final var token : tokens) {
+            final var node = token.tokenParser().createNodeResolver(token).resolve();
+            if (this.tryMerge != null && !nodes.isEmpty()) {
+                final var merged = this.tryMerge.apply(nodes.getLast(), node);
+                if (merged.isPresent()) {
+                    nodes.set(nodes.size() - 1, merged.get());
+                    continue;
+                }
+            }
+            nodes.add(node);
+        }
+        return nodes;
     }
 }

--- a/base-parsing/src/main/java/build/base/parsing/Tokenizer.java
+++ b/base-parsing/src/main/java/build/base/parsing/Tokenizer.java
@@ -73,6 +73,17 @@ public class Tokenizer<N> {
         return tokenize(scanner, true);
     }
 
+    /**
+     * Tokenizes from an already-positioned {@link Scanner}, stopping when no token parser matches rather than
+     * throwing.  The scanner is used as-is — no filters are registered on it.
+     *
+     * @param scanner the scanner to read from
+     * @return the list of tokens parsed before the first unrecognised position
+     */
+    public List<Token<N>> tokenize(final Scanner scanner) {
+        return tokenize(scanner, false);
+    }
+
     private List<Token<N>> tokenize(final Scanner scanner, final boolean throwOnUnknown) {
         final var tokens = new ArrayList<Token<N>>();
 

--- a/base-parsing/src/test/java/build/base/parsing/ExpressionParserTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/ExpressionParserTests.java
@@ -271,4 +271,29 @@ class ExpressionParserTests {
             Arguments.of("1 2", 3)
         );
     }
+
+    // --- Scanner-based parse(Scanner) overload ---
+
+    @Test
+    void shouldParseExpressionFromScanner() {
+        final var scanner = new Scanner("1 + 2");
+        scanner.register(Filter.WHITESPACE);
+        assertThat(parser.tryParse(scanner)).contains(new Add(new Num("1"), new Num("2")));
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void shouldStopAtUnrecognizedTokenLeavingItUnconsumed() {
+        final var scanner = new Scanner("1 + 2}rest");
+        scanner.register(Filter.WHITESPACE);
+        assertThat(parser.tryParse(scanner)).contains(new Add(new Num("1"), new Num("2")));
+        assertThat(scanner.follows('}')).isTrue();
+    }
+
+    @Test
+    void shouldReturnEmptyFromScannerWhenNoTokensMatch() {
+        final var scanner = new Scanner("}rest");
+        assertThat(parser.tryParse(scanner)).isEmpty();
+        assertThat(scanner.follows('}')).isTrue();
+    }
 }

--- a/base-parsing/src/test/java/build/base/parsing/TemplateParserTests.java
+++ b/base-parsing/src/test/java/build/base/parsing/TemplateParserTests.java
@@ -1,6 +1,7 @@
 package build.base.parsing;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -102,5 +103,20 @@ class TemplateParserTests {
             Arguments.of("[prev]\n[curr]",
                 List.of(new Var("prev"), new Text("\n"), new Var("curr")))
         );
+    }
+
+    // --- Scanner-based parse(Scanner) overload ---
+
+    @Test
+    void shouldParseTemplateFromScanner() {
+        final var scanner = new Scanner("[name] text");
+        assertThat(parser.tryParse(scanner)).contains(List.of(new Var("name"), new Text(" text")));
+        assertThat(scanner.hasNext()).isFalse();
+    }
+
+    @Test
+    void shouldReturnEmptyFromScannerWhenAtEndOfInput() {
+        final var scanner = new Scanner("");
+        assertThat(parser.tryParse(scanner)).isEmpty();
     }
 }

--- a/base-template-processor/src/main/java/build/base/template/processor/JtParser.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/JtParser.java
@@ -20,8 +20,8 @@ package build.base.template.processor;
  * #L%
  */
 
-import build.base.parsing.Filter;
-import build.base.parsing.Scanner;
+import build.base.parsing.AbstractParser;
+import build.base.parsing.ParseException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,94 +39,11 @@ final class JtParser {
     private JtParser() {
     }
 
-    static ParsedTemplate parse(final List<String> lines,
-                                final String sourceFile) {
-        final List<String> headerLines = new ArrayList<>();
-        final List<String> bodyLines = new ArrayList<>();
-        boolean inBody = false;
-
-        for (final String line : lines) {
-            final String trimmed = line.trim();
-            if (!inBody) {
-                if (!trimmed.isEmpty()) {
-                    headerLines.add(trimmed);
-                }
-                if (trimmed.startsWith("template ")) {
-                    inBody = true;
-                }
-            } else if (trimmed.equals("@end")) {
-                break;
-            } else {
-                bodyLines.add(line);
-            }
-        }
-
-        String packageName = "";
-        final List<String> imports = new ArrayList<>();
-        String outType = null;
-        String className = null;
-        String params = null;
-
-        try (var scanner = new Scanner(String.join("\n", headerLines))) {
-            scanner.register(Filter.WHITESPACE);
-            while (scanner.hasNext()) {
-                if (scanner.follows("package")) {
-                    scanner.skip("package");
-                    packageName = scanner.consume(QUALIFIED_NAME);
-                    scanner.skip(";");
-                } else if (scanner.follows("import")) {
-                    scanner.skip("import");
-                    imports.add("import " + scanner.consume(IMPORT_BODY));
-                    scanner.skip(";");
-                } else if (scanner.follows("template")) {
-                    scanner.skip("template");
-                    outType = scanner.consume(QUALIFIED_NAME);
-                    className = scanner.consume(QUALIFIED_NAME);
-                    params = consumeParams(scanner);
-                    break;
-                } else {
-                    break;
-                }
-            }
-        } catch (final Exception e) {
-            throw new JtParseException(sourceFile + ": " + e.getMessage());
-        }
-
-        if (className == null) {
-            throw new JtParseException(sourceFile + ": missing template declaration");
-        }
-
-        final List<BodyNode> body = new ArrayList<>();
-        for (final String line : bodyLines) {
-            parseBodyLine(line, body);
-        }
-
-        return new ParsedTemplate(packageName, imports, outType, className, params, body);
+    static ParsedTemplate parse(final String content, final String sourceFile) {
+        return new JtFileParser(content, sourceFile).run();
     }
 
-    private static String consumeParams(final Scanner scanner) {
-        scanner.consume("(");
-        final var sb = new StringBuilder();
-        int depth = 1;
-        while (depth > 0) {
-            final String ch = scanner.consume(1);
-            if ("(".equals(ch)) {
-                depth++;
-                sb.append(ch);
-            } else if (")".equals(ch)) {
-                depth--;
-                if (depth > 0) {
-                    sb.append(ch);
-                }
-            } else {
-                sb.append(ch);
-            }
-        }
-        return sb.toString();
-    }
-
-    private static void parseBodyLine(final String line,
-                                      final List<BodyNode> body) {
+    private static void parseBodyLine(final String line, final List<BodyNode> body) {
         final String trimmed = line.trim();
         if (trimmed.startsWith("@include ")) {
             body.add(new BodyNode.Include(trimmed.substring("@include ".length()).trim()));
@@ -136,68 +53,146 @@ final class JtParser {
             body.add(new BodyNode.CodeLine(trimmed.substring(1).trim()));
             return;
         }
-        parseTextLine(line + "\n", body);
+        body.addAll(new TextLineParser(line + "\n").run());
     }
 
-    static void parseTextLine(final String line,
-                              final List<BodyNode> body) {
-        try (var scanner = new Scanner(line)) {
+    /** Test-facing entry point: parse a single text line, appending the resulting nodes to {@code body}. */
+    static void parseTextLine(final String line, final List<BodyNode> body) {
+        body.addAll(new TextLineParser(line).run());
+    }
+
+    /**
+     * Parses the full content of a {@code .jt} file.
+     * <p>
+     * No whitespace filter is registered — whitespace is significant in the body and is skipped manually
+     * between header tokens.
+     */
+    private static final class JtFileParser
+        extends AbstractParser<ParsedTemplate> {
+
+        private final String sourceFile;
+
+        JtFileParser(final String content, final String sourceFile) {
+            super(content);
+            this.sourceFile = sourceFile;
+        }
+
+        @Override
+        protected void registerFilters(final build.base.parsing.Scanner s) {
+            // No filters — whitespace is significant in the body.
+        }
+
+        @Override
+        protected ParsedTemplate parse() {
+            String packageName = "";
+            final List<String> imports = new ArrayList<>();
+
+            skip();
+            if (followsKeyword("package")) {
+                consumeKeyword("package");
+                skip();
+                packageName = scanner.consume(QUALIFIED_NAME);
+                skip();
+                expect(";");
+            }
+
+            skip();
+            while (followsKeyword("import")) {
+                consumeKeyword("import");
+                skip();
+                imports.add("import " + scanner.consume(IMPORT_BODY));
+                skip();
+                expect(";");
+                skip();
+            }
+
+            if (!followsKeyword("template")) {
+                throw new JtParseException(sourceFile + ": missing template declaration");
+            }
+            consumeKeyword("template");
+            skip();
+            final String outType = scanner.consume(QUALIFIED_NAME);
+            skip();
+            final String className = scanner.consume(QUALIFIED_NAME);
+            skip();
+            final String params = scanner.consumeBalanced('(', ')');
+
+            // Drain the remainder of the template declaration line (e.g. " {")
+            while (scanner.hasNext() && scanner.peekChar() != '\n') {
+                scanner.consumeChar();
+            }
+            if (scanner.follows('\n')) {
+                scanner.consumeChar();
+            }
+
+            // Parse body lines until @end
+            final List<BodyNode> body = new ArrayList<>();
+            while (scanner.hasNext()) {
+                final String line = scanner.consumeUntil("\n");
+                if (scanner.follows('\n')) {
+                    scanner.consumeChar();
+                }
+                if (line.trim().equals("@end")) {
+                    break;
+                }
+                parseBodyLine(line, body);
+            }
+
+            // Drain any content after @end so AbstractParser's full-consumption check passes
+            while (scanner.hasNext()) {
+                scanner.consumeChar();
+            }
+
+            return new ParsedTemplate(packageName, imports, outType, className, params, body);
+        }
+
+        /** Skips whitespace (including newlines) between header tokens. */
+        private void skip() {
+            scanner.skipWhile(c -> Character.isWhitespace((char) c));
+        }
+
+        @Override
+        protected RuntimeException translate(final ParseException cause) {
+            return new JtParseException(sourceFile + ": " + cause.getMessage());
+        }
+    }
+
+    /**
+     * Parses a single line of the template body, alternating literal text with {@code #{...}} expression
+     * interpolations.
+     */
+    private static final class TextLineParser
+        extends AbstractParser<List<BodyNode>> {
+
+        TextLineParser(final String input) {
+            super(input);
+        }
+
+        @Override
+        protected void registerFilters(final build.base.parsing.Scanner s) {
+            // No filters — whitespace and other characters in literal template text must be preserved verbatim.
+        }
+
+        @Override
+        protected List<BodyNode> parse() {
+            final List<BodyNode> nodes = new ArrayList<>();
             while (scanner.hasNext()) {
                 if (scanner.follows("#{")) {
-                    body.add(new BodyNode.Expression(consumeExpression(scanner)));
+                    scanner.consume("#");
+                    nodes.add(new BodyNode.Expression(scanner.consumeBalanced('{', '}')));
                 } else {
                     final String raw = scanner.consumeUntil("#{");
                     if (!raw.isEmpty()) {
-                        body.add(new BodyNode.RawText(raw));
+                        nodes.add(new BodyNode.RawText(raw));
                     }
                 }
             }
-        } catch (final JtParseException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new JtParseException("Unclosed expression in: " + line.trim());
+            return nodes;
         }
-    }
 
-    private static String consumeExpression(final Scanner scanner) {
-        scanner.consume("#{");
-        final var sb = new StringBuilder();
-        int depth = 1;
-        boolean inString = false;
-        char stringChar = 0;
-        boolean escape = false;
-        while (depth > 0) {
-            final char c = scanner.consume(1).charAt(0);
-            if (escape) {
-                escape = false;
-                sb.append(c);
-                continue;
-            }
-            if (inString) {
-                sb.append(c);
-                if (c == '\\') {
-                    escape = true;
-                } else if (c == stringChar) {
-                    inString = false;
-                }
-                continue;
-            }
-            if (c == '"' || c == '\'') {
-                inString = true;
-                stringChar = c;
-                sb.append(c);
-            } else if (c == '{') {
-                depth++;
-                sb.append(c);
-            } else if (c == '}') {
-                depth--;
-                if (depth > 0) {
-                    sb.append(c);
-                }
-            } else {
-                sb.append(c);
-            }
+        @Override
+        protected RuntimeException translate(final ParseException cause) {
+            return new JtParseException("Unclosed expression: " + cause.getMessage());
         }
-        return sb.toString();
     }
 }

--- a/base-template-processor/src/main/java/build/base/template/processor/TemplateProcessor.java
+++ b/base-template-processor/src/main/java/build/base/template/processor/TemplateProcessor.java
@@ -25,7 +25,6 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.processing.AbstractProcessor;
@@ -77,8 +76,7 @@ public final class TemplateProcessor extends AbstractProcessor {
 
     private void processTemplate(final Path jtFile) {
         try {
-            final List<String> lines = Files.readAllLines(jtFile);
-            final ParsedTemplate parsed = JtParser.parse(lines, jtFile.toString());
+            final ParsedTemplate parsed = JtParser.parse(Files.readString(jtFile), jtFile.toString());
             final String source = CodeGenerator.generate(parsed);
 
             final javax.tools.JavaFileObject output = processingEnv.getFiler()

--- a/base-template-processor/src/test/java/build/base/template/processor/JtParserTests.java
+++ b/base-template-processor/src/test/java/build/base/template/processor/JtParserTests.java
@@ -2,7 +2,7 @@ package build.base.template.processor;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -11,14 +11,13 @@ class JtParserTests {
 
     @Test
     void shouldParseMinimalTemplate() {
-        final var lines = List.of(
-            "package com.example;",
-            "",
-            "template HtmlOut HelloTemplate(String name) {",
-            "<h1>Hello</h1>",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "hello.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+
+            template HtmlOut HelloTemplate(String name) {
+            <h1>Hello</h1>
+            @end
+            """, "hello.jt");
 
         assertThat(result.packageName()).isEqualTo("com.example");
         assertThat(result.outType()).isEqualTo("HtmlOut");
@@ -28,22 +27,22 @@ class JtParserTests {
 
     @Test
     void shouldParseImports() {
-        final var lines = List.of(
-            "package com.example;",
-            "",
-            "import java.util.List;",
-            "import com.example.Task;",
-            "",
-            "template HtmlOut TasksTemplate(List<Task> tasks) {",
-            "@end");
-        final var result = JtParser.parse(lines, "tasks.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+
+            import java.util.List;
+            import com.example.Task;
+
+            template HtmlOut TasksTemplate(List<Task> tasks) {
+            @end
+            """, "tasks.jt");
 
         assertThat(result.imports()).containsExactly("import java.util.List", "import com.example.Task");
     }
 
     @Test
     void shouldParseTextLine() {
-        final var body = new java.util.ArrayList<BodyNode>();
+        final var body = new ArrayList<BodyNode>();
         JtParser.parseTextLine("<h1>Hello</h1>\n", body);
 
         assertThat(body).containsExactly(new BodyNode.RawText("<h1>Hello</h1>\n"));
@@ -51,7 +50,7 @@ class JtParserTests {
 
     @Test
     void shouldParseExpressionInTextLine() {
-        final var body = new java.util.ArrayList<BodyNode>();
+        final var body = new ArrayList<BodyNode>();
         JtParser.parseTextLine("<h1>#{name}</h1>\n", body);
 
         assertThat(body).containsExactly(
@@ -63,7 +62,7 @@ class JtParserTests {
 
     @Test
     void shouldParseMultipleExpressionsOnOneLine() {
-        final var body = new java.util.ArrayList<BodyNode>();
+        final var body = new ArrayList<BodyNode>();
         JtParser.parseTextLine("<li id=\"#{task.id()}\">#{task.title()}</li>\n", body);
 
         assertThat(body).containsExactly(
@@ -77,7 +76,7 @@ class JtParserTests {
 
     @Test
     void shouldParseExpressionWithStringLiteralContainingBrace() {
-        final var body = new java.util.ArrayList<BodyNode>();
+        final var body = new ArrayList<BodyNode>();
         JtParser.parseTextLine("#{task.done() ? \" done\" : \"\"}\n", body);
 
         assertThat(body).containsExactly(
@@ -88,85 +87,79 @@ class JtParserTests {
 
     @Test
     void shouldParseCodeLine() {
-        final var lines = List.of(
-            "package com.example;",
-            "template HtmlOut T(java.util.List<String> items) {",
-            "@for (var item : items) {",
-            "<li>#{item}</li>",
-            "@}",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "t.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+            template HtmlOut T(java.util.List<String> items) {
+            @for (var item : items) {
+            <li>#{item}</li>
+            @}
+            @end
+            """, "t.jt");
         assertThat(result.body()).contains(new BodyNode.CodeLine("for (var item : items) {"));
         assertThat(result.body()).contains(new BodyNode.CodeLine("}"));
     }
 
     @Test
     void shouldParseInclude() {
-        final var lines = List.of(
-            "package com.example;",
-            "template HtmlOut T(Object item) {",
-            "@include new ItemTemplate(item)",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "t.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+            template HtmlOut T(Object item) {
+            @include new ItemTemplate(item)
+            @end
+            """, "t.jt");
         assertThat(result.body()).contains(new BodyNode.Include("new ItemTemplate(item)"));
     }
 
     @Test
     void shouldParseWildcardImport() {
-        final var lines = List.of(
-            "package com.example;",
-            "import java.util.*;",
-            "template HtmlOut T() {",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "t.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+            import java.util.*;
+            template HtmlOut T() {
+            @end
+            """, "t.jt");
         assertThat(result.imports()).containsExactly("import java.util.*");
     }
 
     @Test
     void shouldParseStaticImport() {
-        final var lines = List.of(
-            "package com.example;",
-            "import static java.util.List.of;",
-            "template HtmlOut T() {",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "t.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+            import static java.util.List.of;
+            template HtmlOut T() {
+            @end
+            """, "t.jt");
         assertThat(result.imports()).containsExactly("import static java.util.List.of");
     }
 
     @Test
     void shouldParseStaticWildcardImport() {
-        final var lines = List.of(
-            "package com.example;",
-            "import static java.util.Collections.*;",
-            "template HtmlOut T() {",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "t.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+            import static java.util.Collections.*;
+            template HtmlOut T() {
+            @end
+            """, "t.jt");
         assertThat(result.imports()).containsExactly("import static java.util.Collections.*");
     }
 
     @Test
     void shouldPreserveBareClosingBraceInBody() {
-        final var lines = List.of(
-            "package com.example;",
-            "template HtmlOut T() {",
-            "<style>",
-            "body {",
-            "    color: red;",
-            "}",
-            "</style>",
-            "<script>",
-            "function x() {",
-            "    return 1;",
-            "}",
-            "</script>",
-            "@end"
-        );
-        final var result = JtParser.parse(lines, "t.jt");
+        final var result = JtParser.parse("""
+            package com.example;
+            template HtmlOut T() {
+            <style>
+            body {
+                color: red;
+            }
+            </style>
+            <script>
+            function x() {
+                return 1;
+            }
+            </script>
+            @end
+            """, "t.jt");
 
         assertThat(result.body()).contains(
             new BodyNode.RawText("body {\n"),
@@ -177,8 +170,7 @@ class JtParserTests {
 
     @Test
     void shouldThrowOnMissingDeclaration() {
-        final var lines = List.of("package com.example;");
-        assertThatThrownBy(() -> JtParser.parse(lines, "bad.jt"))
+        assertThatThrownBy(() -> JtParser.parse("package com.example;", "bad.jt"))
             .isInstanceOf(JtParseException.class)
             .hasMessageContaining("missing template declaration");
     }

--- a/base-template-processor/src/test/java/build/base/template/processor/TemplatePipelineTests.java
+++ b/base-template-processor/src/test/java/build/base/template/processor/TemplatePipelineTests.java
@@ -3,23 +3,21 @@ package build.base.template.processor;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TemplatePipelineTests {
 
-    private static List<String> load(final String name) throws IOException {
+    private static String load(final String name) throws IOException {
         final var resource = TemplatePipelineTests.class.getClassLoader()
             .getResourceAsStream("templates/" + name);
         assertThat(resource).as("test resource: " + name).isNotNull();
-        return new String(resource.readAllBytes()).lines().toList();
+        return new String(resource.readAllBytes());
     }
 
     @Test
     void shouldProcessHelloTemplate() throws IOException {
-        final var lines = load("hello.jt");
-        final var parsed = JtParser.parse(lines, "hello.jt");
+        final var parsed = JtParser.parse(load("hello.jt"), "hello.jt");
 
         assertThat(parsed.className()).isEqualTo("HelloTemplate");
         assertThat(parsed.outType()).isEqualTo("HtmlOut");
@@ -35,8 +33,7 @@ class TemplatePipelineTests {
 
     @Test
     void shouldProcessTasksTemplate() throws IOException {
-        final var lines = load("tasks.jt");
-        final var parsed = JtParser.parse(lines, "tasks.jt");
+        final var parsed = JtParser.parse(load("tasks.jt"), "tasks.jt");
 
         assertThat(parsed.className()).isEqualTo("TasksTemplate");
         assertThat(parsed.imports()).contains("import java.util.List");
@@ -50,8 +47,7 @@ class TemplatePipelineTests {
 
     @Test
     void shouldProcessItemTemplateWithConditionalExpression() throws IOException {
-        final var lines = load("item.jt");
-        final var parsed = JtParser.parse(lines, "item.jt");
+        final var parsed = JtParser.parse(load("item.jt"), "item.jt");
 
         assertThat(parsed.className()).isEqualTo("ItemTemplate");
 


### PR DESCRIPTION
- `ExpressionParser<N>` and `TemplateParser<N>` now implement `Rule<N>` / `Rule<List<N>>`, exposing a `tryParse(Scanner)` entry point that stops on unrecognised tokens rather than throwing — backed by the new `Tokenizer.tokenize(Scanner)` overload.  The existing `parse(String)` methods are preserved and delegate to `tryParse`.
- `ELParser` is ported to `AbstractParser<Node>`: the manual `Scanner` field, `followsKeyword`/`consumeKeyword` private methods, and hand-rolled error translation are all removed in favour of inherited infrastructure. `parseComposite` replaces its manual depth-tracking loop with `Scanner#consumeBalanced`.                                                                                                                                                                                                 
- `JtParser.parse` now accepts a `String` (full file content) instead of `List<String>`; the separate `HeaderParser` is removed and replaced by a new `JtFileParser extends AbstractParser<ParsedTemplate>` that handles the entire file in one scanner pass. `TemplateProcessor` uses `Files.readString` at the call site.