### PR TITLE
feat(base-transport-json): replace Jackson with base-json

### DIFF
--- a/base-transport-json/pom.xml
+++ b/base-transport-json/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>base-transport-json</artifactId>
 
     <name>base.build Transport (JSON)</name>
-    <description>JSON transport implementation using Jackson Core for encoding and decoding.</description>
+    <description>JSON transport implementation using base-json for encoding and decoding.</description>
 
     <dependencies>
         <dependency>
@@ -33,8 +33,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>build.base</groupId>
+            <artifactId>base-json</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/base-transport-json/src/main/java/build/base/transport/json/Codec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/Codec.java
@@ -9,9 +9,9 @@ package build.base.transport.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,9 @@ package build.base.transport.json;
  * #L%
  */
 
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-
-import java.io.IOException;
 
 /**
  * A JSON <a href="https://en.wikipedia.org/wiki/Codec">Codec</a> for a specific type of value.
@@ -44,35 +41,30 @@ public interface Codec<T> {
     Class<?> codecClass();
 
     /**
-     * Writes the specified {@link Parameter} value using the provided {@link JsonGenerator}.
+     * Encodes the specified value as a {@link JsonValue}.
      *
      * @param transport  the {@link JsonTransport}
      * @param parameter  the {@link Parameter}
-     * @param value      the value to write
-     * @param generator  the {@link JsonGenerator}
+     * @param value      the value to encode
      * @param marshaller the {@link Marshaller}
-     * @throws IOException should writing fail
+     * @return the encoded {@link JsonValue}
      */
-    void write(JsonTransport transport,
-               Parameter parameter,
-               T value,
-               JsonGenerator generator,
-               Marshaller marshaller)
-        throws IOException;
+    JsonValue encode(JsonTransport transport,
+                     Parameter parameter,
+                     T value,
+                     Marshaller marshaller);
 
     /**
-     * Reads the specified {@link Parameter} value using the provided the {@link JsonParser}.
+     * Decodes a value of type {@code T} from the provided {@link JsonValue}.
      *
      * @param transport  the {@link JsonTransport}
      * @param parameter  the {@link Parameter}
-     * @param parser     the {@link JsonParser}
+     * @param value      the {@link JsonValue} to decode (never absent; may be {@link build.base.json.JsonNull})
      * @param marshaller the {@link Marshaller}
-     * @return the value
-     * @throws IOException should reading fail
+     * @return the decoded value
      */
-    T read(JsonTransport transport,
-           Parameter parameter,
-           JsonParser parser,
-           Marshaller marshaller)
-        throws IOException;
+    T decode(JsonTransport transport,
+             Parameter parameter,
+             JsonValue value,
+             Marshaller marshaller);
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/JsonTransport.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/JsonTransport.java
@@ -9,9 +9,9 @@ package build.base.transport.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,11 @@ import build.base.foundation.Introspection;
 import build.base.foundation.stream.Streamable;
 import build.base.foundation.stream.Streams;
 import build.base.foundation.tuple.Pair;
-import build.base.foundation.tuple.Triple;
+import build.base.json.Json;
+import build.base.json.JsonNull;
+import build.base.json.JsonObject;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshalled;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Marshalling;
@@ -55,14 +59,16 @@ import build.base.transport.json.codec.StreamableCodec;
 import build.base.transport.json.codec.StringCodec;
 import build.base.transport.json.codec.TimestampCodec;
 import build.base.transport.json.codec.ZonedDateTimeCodec;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,23 +83,14 @@ import java.util.stream.Collectors;
 public class JsonTransport
     extends AbstractTransport<JsonTransport> {
 
-    /**
-     * The JSON field name to capture the {@link Class} name for {@link Marshalled}.
-     */
-    private static final String TYPE_FIELD_NAME = "type";
+    private static final String TYPE_FIELD = "@type";
+    private static final String VALUE_FIELD = "value";
 
-    /**
-     * The {@link SchemaFactory} used by the {@link JsonTransport} for unmarshalling.
-     */
     private final SchemaFactory schemaFactory;
-
-    /**
-     * The {@link Codec}s by {@link Class} supported by the {@link JsonTransport}.
-     */
     private final ConcurrentHashMap<Class<?>, Codec<?>> codecs;
 
     /**
-     * Constructs a default {@link JsonTransport} using the specified {@link SchemaFactory}.
+     * Constructs a {@link JsonTransport} using the specified {@link SchemaFactory}.
      *
      * @param schemaFactory the {@link SchemaFactory}
      */
@@ -144,7 +141,6 @@ public class JsonTransport
         if (codec != null) {
             this.codecs.put(codec.codecClass(), codec);
         }
-
         return this;
     }
 
@@ -162,283 +158,267 @@ public class JsonTransport
     }
 
     /**
-     * Write the specified {@link Marshalled} {@link Object} using the provided {@link JsonGenerator}.
+     * Encodes a {@link Marshalled} object as a {@link JsonObject} and writes it to the provided {@link Writer}.
      *
-     * @param marshalled the {@link Marshalled}
-     * @param generator  the {@link JsonGenerator}
-     * @throws IOException should writing fail
+     * @param marshalled the {@link Marshalled} object
+     * @param writer     the destination
+     */
+    public void write(final Marshalled<?> marshalled, final Writer writer) {
+        Objects.requireNonNull(marshalled, "marshalled");
+        Objects.requireNonNull(writer, "writer");
+        try {
+            writer.write(encodeMarshalled(marshalled, this.schemaFactory.newMarshaller()).toJsonString());
+        }
+        catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Parses JSON from the provided {@link Reader} and decodes it as a {@link Marshalled} object.
+     *
+     * @param reader the source of JSON text
+     * @param <T>    the type of the marshalled object
+     * @return the decoded {@link Marshalled}
+     */
+    public <T> Marshalled<T> read(final Reader reader) {
+        Objects.requireNonNull(reader, "reader");
+        return decodeMarshalled(Json.parse(reader).asObject(), this.schemaFactory.newMarshaller());
+    }
+
+    /**
+     * Parses JSON from the provided {@link Reader} and decodes it as a {@link Marshalled} object,
+     * using the given {@link Marshaller} (e.g. one with bound values).
+     *
+     * @param reader     the source of JSON text
+     * @param marshaller the {@link Marshaller} to use
+     * @param <T>        the type of the marshalled object
+     * @return the decoded {@link Marshalled}
+     */
+    public <T> Marshalled<T> read(final Reader reader, final Marshaller marshaller) {
+        Objects.requireNonNull(reader, "reader");
+        Objects.requireNonNull(marshaller, "marshaller");
+        return decodeMarshalled(Json.parse(reader).asObject(), marshaller);
+    }
+
+    /**
+     * Encodes a value of the given type as a {@link JsonValue}, used by codecs for recursive encoding.
+     *
+     * @param parameter  the {@link Parameter}
+     * @param valueType  the {@link Type} of the value
+     * @param value      the value
+     * @param marshaller the {@link Marshaller}
+     * @return the encoded {@link JsonValue}
      */
     @SuppressWarnings("unchecked")
-    public void write(final Marshalled<?> marshalled,
-                      final JsonGenerator generator)
-        throws IOException {
+    public JsonValue encode(final Parameter parameter,
+                            final Type valueType,
+                            final Object value,
+                            final Marshaller marshaller) {
 
-        Objects.requireNonNull(marshalled, "The Marshalled object must not be null");
-        Objects.requireNonNull(generator, "The JsonGenerator must not be null");
+        if (value == null) {
+            return JsonNull.INSTANCE;
+        }
 
-        generator.writeStartObject();
-        generator.writeStringField(TYPE_FIELD_NAME, marshalled.schema().owner().getName());
+        if (value instanceof Marshalled<?> marshalledValue) {
+            return encodeMarshalled(marshalledValue, marshaller);
+        }
 
-        final Iterable<Pair<Parameter, Object>> iterable = () -> Streams.zip(
+        final var valueClass = Introspection.getClassFromType(valueType)
+            .orElseThrow(() -> new IllegalStateException(
+                "Failed to determine class of [" + valueType + "] for parameter [" + parameter.name() + "]"));
+
+        final var optionalTransformer = getTransformer(valueClass);
+        if (optionalTransformer.isPresent()) {
+            final var transformer = optionalTransformer.orElseThrow();
+            final var transformed = transformer.transform(marshaller, value);
+            if (Objects.equals(transformed, value)) {
+                throw new IllegalStateException("Transformer produced no change for parameter ["
+                    + parameter.name() + "] of type [" + valueClass + "]");
+            }
+            return encode(parameter, transformer.targetClass(), transformed, marshaller);
+        }
+
+        final var optionalCodec = getCodec(valueType);
+        if (optionalCodec.isPresent()) {
+            return optionalCodec.orElseThrow().encode(this, parameter, value, marshaller);
+        }
+
+        if (this.schemaFactory.isMarshallable(valueClass)) {
+            return encodeMarshalled(marshaller.marshal(value), marshaller);
+        }
+
+        if (valueClass == Object.class
+            || valueClass.isInterface()
+            || Modifier.isAbstract(valueClass.getModifiers())) {
+
+            return JsonObject.of(Map.of(
+                TYPE_FIELD,  JsonString.of(value.getClass().getName()),
+                VALUE_FIELD, encode(parameter, value.getClass(), value, marshaller)));
+        }
+
+        throw new IllegalStateException("No Transformer, Codec, or @Marshal-able found for parameter ["
+            + parameter.name() + "] of type [" + valueClass + "]");
+    }
+
+    /**
+     * Decodes a value of the given type from a {@link JsonValue}, used by codecs for recursive decoding.
+     *
+     * @param parameter  the {@link Parameter}
+     * @param type       the {@link Type} of the expected value
+     * @param value      the {@link JsonValue} to decode
+     * @param marshaller the {@link Marshaller}
+     * @param <T>        the type of the decoded value
+     * @return the decoded value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T decode(final Parameter parameter,
+                        final Type type,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
+
+        if (value instanceof JsonNull) {
+            return null;
+        }
+
+        final var optionalTransformer = getTransformer(type);
+        if (optionalTransformer.isPresent()) {
+            final var transformer = optionalTransformer.orElseThrow();
+            final var read = decode(parameter, transformer.targetClass(), value, marshaller);
+            final var reformed = transformer.reform(marshaller, type, read);
+            if (Objects.equals(reformed, read)) {
+                throw new IllegalStateException("Transformer reform produced no change for parameter ["
+                    + parameter.name() + "] of type [" + type + "]");
+            }
+            return (T) reformed;
+        }
+
+        final var readableClass = Introspection.getClassFromType(type)
+            .orElseThrow(() -> new IllegalStateException(
+                "Failed to determine class for parameter [" + parameter.name() + "] of type [" + type + "]"));
+
+        final var optionalCodec = getCodec(type);
+        if (optionalCodec.isPresent()) {
+            return (T) optionalCodec.orElseThrow().decode(this, parameter, value, marshaller);
+        }
+
+        if (Marshalled.class.isAssignableFrom(readableClass)) {
+            return (T) decodeMarshalled(value.asObject(), marshaller);
+        }
+
+        if (marshaller.isMarshallable(readableClass)) {
+            return (T) marshaller.unmarshal(decodeMarshalled(value.asObject(), marshaller));
+        }
+
+        if (readableClass == Object.class
+            || readableClass.isInterface()
+            || Modifier.isAbstract(readableClass.getModifiers())) {
+
+            final var wrapper = value.asObject();
+            final var typeName = wrapper.get(TYPE_FIELD).asString().value();
+            final var concreteType = loadClass(typeName, parameter);
+            return (T) decode(parameter, concreteType, wrapper.get(VALUE_FIELD), marshaller);
+        }
+
+        throw new IllegalStateException("No Transformer, Codec, or @Marshal-able found for parameter ["
+            + parameter.name() + "] of type [" + readableClass + "]");
+    }
+
+    @SuppressWarnings("unchecked")
+    private JsonObject encodeMarshalled(final Marshalled<?> marshalled, final Marshaller marshaller) {
+        final var members = new LinkedHashMap<String, JsonValue>();
+        members.put(TYPE_FIELD, JsonString.of(marshalled.schema().owner().getName()));
+
+        final Iterable<Pair<Parameter, Object>> pairs = () -> Streams.zip(
                 marshalled.schema().parameters().stream(),
                 marshalled.values().stream())
             .iterator();
 
-        final var marshaller = this.schemaFactory.newMarshaller();
-
-        for (Pair<Parameter, Object> pair : iterable) {
+        for (final var pair : pairs) {
             final var parameter = pair.first();
             final var value = pair.second();
 
             final var codec = getCodec(parameter.type());
 
-            // when there is a Codec for the type, determine if the value should be ignored
             if (codec.filter(ConditionalCodec.class::isInstance)
                 .map(ConditionalCodec.class::cast)
-                .filter(conditionalCodec -> conditionalCodec.ignore(value))
+                .filter(cc -> cc.ignore(value))
                 .isPresent()) {
-
                 continue;
             }
 
-            generator.writeFieldName(parameter.name());
-
-            write(parameter, parameter.type(), value, generator, marshaller);
+            members.put(parameter.name(), encode(parameter, parameter.type(), value, marshaller));
         }
 
-        generator.writeEndObject();
-        generator.flush();
+        return JsonObject.of(members);
     }
 
-    /**
-     * Write the specified {@link Parameter} value, of the specified {@link Type}, which may be different from
-     * the {@link Parameter#type()} due to transformation, using the {@link Codec}s known to the {@link Transport}
-     * with the provided {@link JsonGenerator}, further transforming the value as needed.
-     *
-     * @param parameter  the {@link Parameter}
-     * @param valueType  the {@link Type} of value
-     * @param value      the value
-     * @param generator  the {@link JsonGenerator}
-     * @param marshaller the {@link Marshaller}
-     * @throws IOException should writing fail
-     */
-    public void write(final Parameter parameter,
-                      final Type valueType,
-                      final Object value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else if (value instanceof Marshalled<?> marshalledValue) {
-            write(marshalledValue, generator);
-        }
-        else {
-            final var valueClass = Introspection.getClassFromType(valueType)
-                .orElseThrow(() -> new IOException("Failed to determine Class of [" + valueType + "]"
-                    + " to write parameter [" + parameter.name() + "]"));
-
-            // attempt to locate a Transformer for the value
-            final var optionalTransformer = getTransformer(valueClass);
-
-            if (optionalTransformer.isPresent()) {
-                final var transformer = optionalTransformer.orElseThrow();
-
-                final var transformedValue = transformer.transform(marshaller, value);
-
-                if (Objects.equals(transformedValue, value)) {
-                    // as no transformation occurred, we can't write the value (we couldn't before this!)
-                    throw new IOException("Failed to transform parameter [" + parameter.name() + "]"
-                        + " with value [" + value + "]"
-                        + " of type [" + value.getClass() + "]"
-                        + " into a different value that can be written");
-                }
-                write(parameter, transformer.targetClass(), transformedValue, generator, marshaller);
-            }
-            else {
-                // attempt to use a Codec
-                final var optionalCodec = getCodec(valueType);
-
-                if (optionalCodec.isPresent()) {
-                    optionalCodec.orElseThrow()
-                        .write(this, parameter, value, generator, marshaller);
-                }
-                else if (this.schemaFactory.isMarshallable(valueClass)) {
-                    final var marshalledValue = marshaller.marshal(value);
-                    write(marshalledValue, generator);
-                }
-                else {
-                    // when the type is Object, an Interface or Abstract, attempt to use the concrete value type
-                    if (valueClass == Object.class
-                        || valueClass.isInterface()
-                        || Modifier.isAbstract(valueClass.getModifiers())) {
-
-                        // write out the concrete value so the reader can read it
-                        generator.writeStartObject();
-                        try {
-                            generator.writeFieldName("type");
-                            generator.writeString(value.getClass().getName());
-                            generator.writeFieldName("value");
-                            write(parameter, value.getClass(), value, generator, marshaller);
-                        }
-                        finally {
-                            generator.writeEndObject();
-                        }
-                    }
-                    else {
-                        // TODO: it may be possible there is a transformer or codec for value.getClass()
-                        // in which case we should try that too?
-
-                        throw new IOException("Failed to write parameter [" + parameter.name() + "]"
-                            + " with value [" + value + "]"
-                            + " of type [" + valueClass + "]"
-                            + " as no suitable Transformer, Codec or @Marshal-able type was found");
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Reads a {@link Marshalled} {@link Object} using the provided {@link JsonParser} and {@link Marshaller}.
-     *
-     * @param parser     the {@link JsonParser}
-     * @param marshaller the {@link Marshaller}
-     * @param <T>        the type of {@link Marshalled} {@link Object}
-     * @return the {@link Marshalled} {@link Object}
-     * @throws IOException should an exception occur
-     */
     @SuppressWarnings("unchecked")
-    public <T> Marshalled<T> read(final JsonParser parser,
-                                  final Marshaller marshaller)
-        throws IOException {
+    private <T> Marshalled<T> decodeMarshalled(final JsonObject json, final Marshaller marshaller) {
+        final var typeName = json.get(TYPE_FIELD).asString().value();
+        final Class<?> typeClass = loadClass(typeName, null);
 
-        Objects.requireNonNull(parser, "The JsonParser must not be null");
-        Objects.requireNonNull(schemaFactory, "The SchemaFactory must not be null");
-
-        // ensure there's a current token from which to read the Marshalled
-        // (by default a newly created JsonParser may not have read any tokens!)
-        if (parser.currentToken() == null) {
-            parser.nextToken();
-        }
-
-        if (!parser.isExpectedStartObjectToken()) {
-            throw new IOException("Failed to read Marshalled Object at " + parser.currentLocation());
-        }
-
-        // skip the start of the start of the JsonObject Token
-        parser.clearCurrentToken();
-
-        // parse the class of type to unmarshal (from which we can then determine the available unmarshalling schemas)
-        final var typeField = parser.nextFieldName();
-        if (!typeField.equals(TYPE_FIELD_NAME)) {
-            throw new IOException("Expected " + TYPE_FIELD_NAME + " field defined at " + parser.currentLocation());
-        }
-
-        final var typeName = parser.nextTextValue();
-        if (typeName == null) {
-            throw new IOException("Expected " + TYPE_FIELD_NAME + " field value at " + parser.currentLocation());
-        }
-
-        final Class<?> typeClass;
-        try {
-            typeClass = Class.forName(typeName);
-        }
-        catch (final ClassNotFoundException e) {
-            throw new IOException("Failed to load class " + typeName + " to read at " + parser.currentLocation(), e);
-        }
-
-        // determine the Schemas, their Parameters and corresponding Out values that are candidates for unmarshalling
         final var schemas = this.schemaFactory.getUnmarshallingSchemas(typeClass)
             .map(schema -> Pair.of(
                 schema,
                 schema.parameters().stream()
-                    .collect(Collectors.toMap(
-                        Parameter::name,
-                        parameter -> Pair.of(parameter, Out.empty())))))
+                    .collect(Collectors.toMap(Parameter::name, p -> Pair.of(p, Out.empty())))))
             .collect(Collectors.toCollection(ArrayList::new));
 
         if (schemas.isEmpty()) {
-            throw new IOException("No schemas are defined for type " + typeName + " at " + parser.currentLocation());
+            throw new IllegalStateException("No schemas defined for type: " + typeName);
         }
 
-        // process the fields
-        while (parser.nextToken() != JsonToken.END_OBJECT) {
-            final var parameterName = parser.currentName();
+        for (final var entry : json.members().entrySet()) {
+            final var fieldName = entry.getKey();
+            if (TYPE_FIELD.equals(fieldName)) {
+                continue;
+            }
+            final var fieldValue = entry.getValue();
 
-            // skip the field name token to advance to the possible value
-            parser.nextToken();
-
-            // remove the Schemas that don't have such a named parameter
-            schemas.removeIf(pair -> !pair.second().containsKey(parameterName));
+            schemas.removeIf(pair -> !pair.second().containsKey(fieldName));
 
             if (schemas.isEmpty()) {
-                throw new IOException("Failed to locate schema to support unmarshalling the type " + typeName + " at "
-                    + parser.currentLocation());
+                throw new IllegalStateException("No schema supports field '" + fieldName + "' for type " + typeName);
             }
 
-            // attempt to use the first available schema's first parameter type to read the value
-            final var parameter = schemas.getFirst()
-                .second()
-                .get(parameterName)
-                .first();
+            final var parameter = schemas.getFirst().second().get(fieldName).first();
+            final var decoded = decode(parameter, parameter.type(), fieldValue, marshaller);
 
-            final var value = read(parameter, parameter.type(), parser, marshaller);
-
-            // update the remaining candidate schemas with the parameter value
-            schemas.forEach(schema -> {
-                final var argument = schema.second().get(parameterName);
-                argument.second().set(value);
-            });
+            schemas.forEach(pair -> pair.second().get(fieldName).second().set(decoded));
         }
 
-        // find the first schema with completed set of arguments
-        var optionalSchemaValues = schemas.stream()
-            .filter(pair -> pair.second().values().stream()
-                .map(Pair::second)
-                .allMatch(Out::isPresent))
+        var optionalMatch = schemas.stream()
+            .filter(pair -> pair.second().values().stream().map(Pair::second).allMatch(Out::isPresent))
             .findFirst();
 
-        if (optionalSchemaValues.isEmpty()) {
-            // attempt to complete missing values using ConditionalCodecs
-            optionalSchemaValues = schemas.stream()
+        if (optionalMatch.isEmpty()) {
+            optionalMatch = schemas.stream()
                 .filter(pair -> pair.second().values().stream()
-                    .map(triple -> Triple.of(triple.second(), triple.first().type(),
-                        triple.second().isEmpty() ? null : triple.second().get()))
-                    .allMatch(triple -> {
-                        // skip the parameter when the value is present
-                        if (triple.first().isPresent()) {
+                    .allMatch(entry -> {
+                        if (entry.second().isPresent()) {
                             return true;
                         }
-
-                        // attempt to use a ConditionalCodec for the parameter to provide a default value
-                        final var codec = getCodec(triple.second());
-
+                        final var codec = getCodec(entry.first().type());
                         codec.filter(ConditionalCodec.class::isInstance)
                             .map(ConditionalCodec.class::cast)
-                            .ifPresent(conditionalCodec -> triple.first().set(conditionalCodec.defaultValue()));
-
-                        return triple.first().isPresent();
+                            .ifPresent(cc -> entry.second().set(cc.defaultValue()));
+                        return entry.second().isPresent();
                     }))
                 .findFirst();
         }
 
-        final var schemaValues = optionalSchemaValues
-            .orElseThrow(() -> new IOException(
-                "Failed to parse required values for type " + typeName + " at " + parser.currentLocation()));
+        final var match = optionalMatch
+            .orElseThrow(() -> new IllegalStateException("Failed to decode required fields for type " + typeName));
 
-        // ensure the order of the values is the same order as the schema parameters
-        final var values = Streamable.of(schemaValues.first().parameters().stream()
-            .map(parameter -> schemaValues.second().get(parameter.name()).second().orElse(null)));
+        final var values = Streamable.of(match.first().parameters().stream()
+            .map(p -> match.second().get(p.name()).second().orElse(null)));
 
-        // establish a Marshalled representation using the schema and captured values
         return new Marshalled<T>() {
             @Override
             @SuppressWarnings("unchecked")
             public Schema<T> schema() {
-                return (Schema<T>) schemaValues.first();
+                return (Schema<T>) match.first();
             }
 
             @Override
@@ -448,143 +428,13 @@ public class JsonTransport
         };
     }
 
-    /**
-     * Reads a {@link Marshalled} {@link Object} using the provided {@link JsonParser} and a default {@link Marshaller}.
-     *
-     * @param parser the {@link JsonParser}
-     * @param <T>    the type of {@link Marshalled} {@link Object}
-     * @return the {@link Marshalled} {@link Object}
-     * @throws IOException should an exception occur
-     */
-    public <T> Marshalled<T> read(final JsonParser parser)
-        throws IOException {
-
-        return read(parser, this.schemaFactory.newMarshaller());
-    }
-
-    /**
-     * Read the specified {@link Type} of {@link Parameter} value, which may be different from the
-     * {@link Parameter#type()} due to transformation, using the {@link Codec}s known to the {@link Transport}
-     * with the provided {@link JsonParser}, further transforming the value as needed.
-     *
-     * @param parameter  the {@link Parameter}
-     * @param type       the {@link Type} of value
-     * @param parser     the {@link JsonParser}
-     * @param marshaller the {@link Marshaller}
-     * @return the read value
-     * @throws IOException should writing fail
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T read(final Parameter parameter,
-                      final Type type,
-                      final JsonParser parser,
-                      final Marshaller marshaller)
-        throws IOException {
-
-        if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
-            parser.clearCurrentToken();
-            return null;
+    private Class<?> loadClass(final String name, final Parameter parameter) {
+        try {
+            return Class.forName(name);
         }
-
-        // determine if there is a Transformer to use for the type
-        final var optionalTransformer = getTransformer(type);
-
-        if (optionalTransformer.isPresent()) {
-            final var transformer = optionalTransformer.get();
-            final var readValue = read(parameter, transformer.targetClass(), parser, marshaller);
-            final var transformedValue = transformer.reform(marshaller, parameter.type(), readValue);
-
-            if (Objects.equals(transformedValue, readValue)) {
-                throw new IOException("Failed to transform Parameter [" + parameter.name() + "]"
-                    + " with value [" + readValue + "]"
-                    + " into type [" + type + "]");
-            }
-            return (T) transformedValue;
-        }
-        else {
-            // determine the initially expected readable class based on the type of value
-            final var readableClass = Introspection.getClassFromType(type)
-                .orElseThrow(() -> new IOException("Failed to determine a class of value for Parameter ["
-                    + parameter.name() + "] of type [" + type + "]"
-                    + " at " + parser.currentLocation()));
-
-            // determine if there is a Codec to use for the type
-            final var optionalCodec = getCodec(type);
-
-            if (optionalCodec.isPresent()) {
-                return (T) optionalCodec.orElseThrow()
-                    .read(this, parameter, parser, marshaller);
-            }
-            else if (Marshalled.class.isAssignableFrom(readableClass)) {
-                return (T) read(parser, marshaller);
-            }
-            else if (marshaller.isMarshallable(readableClass)) {
-                final var marshalled = read(parser, marshaller);
-                return (T) marshaller.unmarshal(marshalled);
-            }
-            else {
-                // when the type is Object, an Interface or Abstract, attempt to use the concrete value type
-                if (readableClass == Object.class
-                    || readableClass.isInterface()
-                    || Modifier.isAbstract(readableClass.getModifiers())) {
-
-                    if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
-                        parser.clearCurrentToken();
-                        return null;
-                    }
-                    else if (parser.isExpectedStartObjectToken()) {
-                        parser.nextToken();
-
-                        // Expect that this object will be serialized with the 'type'
-                        // field first. If it is not, then we cannot know what type to
-                        // pass into the transport to parse the value.
-                        if (!parser.getText().equals("type")) {
-                            throw new IOException("Expected 'type' field name, but found ["
-                                + parser.getText() + "] for ["
-                                + parameter.name() + "] of type [" + parameter.type() + "]"
-                                + " at " + parser.currentLocation());
-                        }
-
-                        parser.nextToken();
-                        final var typeName = parser.getText();
-
-                        try {
-                            final var concreteType = Class.forName(typeName);
-
-                            parser.nextToken();
-                            if (!parser.getText().equals("value")) {
-                                throw new IOException("Expected 'value' field name, but found ["
-                                    + parser.getText() + "] for ["
-                                    + parameter.name() + "] of type [" + parameter.type() + "]"
-                                    + " at " + parser.currentLocation());
-                            }
-                            parser.nextToken();
-
-                            final var value = read(parameter, concreteType, parser, marshaller);
-
-                            // At this point we are still inside the serialized object, so we need to advance
-                            // to the end of the object for the parsing to continue properly.
-                            parser.nextToken();
-                            return (T) value;
-                        }
-                        catch (final ClassNotFoundException e) {
-                            throw new IOException("Failed to load class [" + typeName + "] for ["
-                                + parameter.name() + "] of type [" + parameter.type() + "]"
-                                + " at " + parser.currentLocation(), e);
-                        }
-                    }
-                    else {
-                        throw new IOException("Expected a JsonObject for ["
-                            + parameter.name() + "] of type [" + parameter.type() + "]"
-                            + " at " + parser.currentLocation());
-                    }
-                }
-                else {
-                    throw new IOException("Failed to determine a Transformer, Codec or @Marshal-able for ["
-                        + parameter.name() + "] of type [" + parameter.type() + "]"
-                        + " at " + parser.currentLocation());
-                }
-            }
+        catch (final ClassNotFoundException e) {
+            final var context = parameter == null ? "" : " for parameter [" + parameter.name() + "]";
+            throw new IllegalStateException("Failed to load class [" + name + "]" + context, e);
         }
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/BigDecimalCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/BigDecimalCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 
 /**
@@ -46,40 +45,20 @@ public class BigDecimalCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final BigDecimal value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final BigDecimal value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public BigDecimal read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public BigDecimal decode(final JsonTransport transport,
+                             final Parameter parameter,
+                             final JsonValue value,
+                             final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a BigDecimal but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return new BigDecimal(parser.getText());
-        }
+        return value instanceof JsonNull ? null : new BigDecimal(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/BigIntegerCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/BigIntegerCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.math.BigInteger;
 
 /**
@@ -46,40 +45,20 @@ public class BigIntegerCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final BigInteger value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final BigInteger value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public BigInteger read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public BigInteger decode(final JsonTransport transport,
+                             final Parameter parameter,
+                             final JsonValue value,
+                             final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a BigInteger but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return new BigInteger(parser.getText());
-        }
+        return value instanceof JsonNull ? null : new BigInteger(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/BooleanCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/BooleanCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonBoolean;
+import build.base.json.JsonNull;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Boolean} and {@code boolean} values.
+ * A {@link Codec} for {@link Boolean} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class BooleanCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Boolean value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Boolean value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeBoolean(value);
-        }
+        return value == null ? JsonNull.INSTANCE : JsonBoolean.of(value);
     }
 
     @Override
-    public Boolean read(final JsonTransport transport,
-                        final Parameter parameter,
-                        final JsonParser parser,
-                        final Marshaller marshaller)
-        throws IOException {
+    public Boolean decode(final JsonTransport transport,
+                          final Parameter parameter,
+                          final JsonValue value,
+                          final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_TRUE && currentToken != JsonToken.VALUE_FALSE) {
-            throw new IOException(
-                "Expected Boolean but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getBooleanValue();
-        }
+        return value instanceof JsonNull ? null : value.asBoolean().value();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/ByteCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/ByteCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Byte} and {@code byte} values.
+ * A {@link Codec} for {@link Byte} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class ByteCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Byte value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Byte value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value);
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value);
     }
 
     @Override
-    public Byte read(final JsonTransport transport,
-                     final Parameter parameter,
-                     final JsonParser parser,
-                     final Marshaller marshaller)
-        throws IOException {
+    public Byte decode(final JsonTransport transport,
+                       final Parameter parameter,
+                       final JsonValue value,
+                       final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_INT) {
-            throw new IOException(
-                "Expected a Byte but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getByteValue();
-        }
+        return value instanceof JsonNull ? null : value.asNumber().toNumber().byteValue();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/CharacterCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/CharacterCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Character} and {@code char} values.
+ * A {@link Codec} for {@link Character} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class CharacterCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Character value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Character value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(String.valueOf(value));
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(String.valueOf(value));
     }
 
     @Override
-    public Character read(final JsonTransport transport,
-                          final Parameter parameter,
-                          final JsonParser parser,
-                          final Marshaller marshaller)
-        throws IOException {
+    public Character decode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final JsonValue value,
+                            final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a Character but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getText().charAt(0);
-        }
+        return value instanceof JsonNull ? null : value.asString().value().charAt(0);
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/DateCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/DateCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.util.Date;
 
 /**
@@ -46,40 +45,20 @@ public class DateCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Date value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Date value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value.getTime());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value.getTime());
     }
 
     @Override
-    public Date read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public Date decode(final JsonTransport transport,
+                       final Parameter parameter,
+                       final JsonValue value,
+                       final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_INT) {
-            throw new IOException(
-                "Expected a Date but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return new Date(parser.getLongValue());
-        }
+        return value instanceof JsonNull ? null : new Date(value.asNumber().toNumber().longValue());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/DoubleCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/DoubleCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Double} and {@code double} values.
+ * A {@link Codec} for {@link Double} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class DoubleCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Double value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Double value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value);
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value);
     }
 
     @Override
-    public Double read(final JsonTransport transport,
-                       final Parameter parameter,
-                       final JsonParser parser,
-                       final Marshaller marshaller)
-        throws IOException {
+    public Double decode(final JsonTransport transport,
+                         final Parameter parameter,
+                         final JsonValue value,
+                         final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_FLOAT) {
-            throw new IOException(
-                "Expected a Double but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getDoubleValue();
-        }
+        return value instanceof JsonNull ? null : value.asNumber().toNumber().doubleValue();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/DurationCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/DurationCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.Duration;
 
 /**
@@ -46,40 +45,20 @@ public class DurationCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Duration value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Duration value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value.toNanos());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value.toNanos());
     }
 
     @Override
-    public Duration read(final JsonTransport transport,
+    public Duration decode(final JsonTransport transport,
                            final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+                           final JsonValue value,
+                           final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_INT) {
-            throw new IOException(
-                "Expected a Duration but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return Duration.ofNanos(parser.getLongValue());
-        }
+        return value instanceof JsonNull ? null : Duration.ofNanos(value.asNumber().toNumber().longValue());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/FloatCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/FloatCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Float} and {@code float} values.
+ * A {@link Codec} for {@link Float} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class FloatCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Float value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Float value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value);
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value);
     }
 
     @Override
-    public Float read(final JsonTransport transport,
-                      final Parameter parameter,
-                      final JsonParser parser,
-                      final Marshaller marshaller)
-        throws IOException {
+    public Float decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_FLOAT) {
-            throw new IOException(
-                "Expected a Float but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getFloatValue();
-        }
+        return value instanceof JsonNull ? null : value.asNumber().toNumber().floatValue();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/InstantCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/InstantCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.Instant;
 
 /**
  * A {@link Codec} for {@link Instant} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class InstantCodec
     implements Codec<Instant> {
@@ -46,40 +42,20 @@ public class InstantCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Instant value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Instant value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public Instant read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public Instant decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a Instant but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return Instant.parse(parser.getText());
-        }
+        return value instanceof JsonNull ? null : Instant.parse(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/IntegerCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/IntegerCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Integer} and {@code int} values.
+ * A {@link Codec} for {@link Integer} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class IntegerCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Integer value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Integer value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value);
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value);
     }
 
     @Override
-    public Integer read(final JsonTransport transport,
-                        final Parameter parameter,
-                        final JsonParser parser,
-                        final Marshaller marshaller)
-        throws IOException {
+    public Integer decode(final JsonTransport transport,
+                          final Parameter parameter,
+                          final JsonValue value,
+                          final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_INT) {
-            throw new IOException(
-                "Expected an Integer but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getIntValue();
-        }
+        return value instanceof JsonNull ? null : value.asNumber().toNumber().intValue();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/LocalDateCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/LocalDateCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.LocalDate;
 
 /**
  * A {@link Codec} for {@link LocalDate} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class LocalDateCodec
     implements Codec<LocalDate> {
@@ -46,40 +42,20 @@ public class LocalDateCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final LocalDate value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final LocalDate value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public LocalDate read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public LocalDate decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a LocalDate but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return LocalDate.parse(parser.getText());
-        }
+        return value instanceof JsonNull ? null : LocalDate.parse(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/LocalDateTimeCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/LocalDateTimeCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 
 /**
  * A {@link Codec} for {@link LocalDateTime} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class LocalDateTimeCodec
     implements Codec<LocalDateTime> {
@@ -46,40 +42,20 @@ public class LocalDateTimeCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final LocalDateTime value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final LocalDateTime value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public LocalDateTime read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public LocalDateTime decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a LocalDateTime but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return LocalDateTime.parse(parser.getText());
-        }
+        return value instanceof JsonNull ? null : LocalDateTime.parse(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/LocalTimeCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/LocalTimeCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.LocalTime;
 
 /**
  * A {@link Codec} for {@link LocalTime} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class LocalTimeCodec
     implements Codec<LocalTime> {
@@ -46,40 +42,20 @@ public class LocalTimeCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final LocalTime value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final LocalTime value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public LocalTime read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public LocalTime decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a LocalTime but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return LocalTime.parse(parser.getText());
-        }
+        return value instanceof JsonNull ? null : LocalTime.parse(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/LongCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/LongCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +20,16 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonNumber;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
- * A {@link Codec} for {@link Long} and {@code long} values.
+ * A {@link Codec} for {@link Long} values.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -45,40 +43,20 @@ public class LongCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Long value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Long value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeNumber(value);
-        }
+        return value == null ? JsonNull.INSTANCE : JsonNumber.of(value);
     }
 
     @Override
-    public Long read(final JsonTransport transport,
-                     final Parameter parameter,
-                     final JsonParser parser,
-                     final Marshaller marshaller)
-        throws IOException {
+    public Long decode(final JsonTransport transport,
+                       final Parameter parameter,
+                       final JsonValue value,
+                       final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_NUMBER_INT) {
-            throw new IOException(
-                "Expected a Long but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getLongValue();
-        }
+        return value instanceof JsonNull ? null : value.asNumber().toNumber().longValue();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/OptionalCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/OptionalCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,19 +21,20 @@ package build.base.transport.json.codec;
  */
 
 import build.base.foundation.Introspection;
+import build.base.json.JsonArray;
+import build.base.json.JsonNull;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.ConditionalCodec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 /**
- * A {@link ConditionalCodec} of {@link Optional} values.
+ * A {@link ConditionalCodec} for {@link Optional} values. Encoded as a JSON array: {@code []} for empty,
+ * {@code [element]} for present.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -58,79 +59,40 @@ public class OptionalCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Optional<?> optional,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
-        throws IOException {
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Optional<?> optional,
+                            final Marshaller marshaller) {
 
         if (optional == null) {
-            generator.writeNull();
+            return JsonNull.INSTANCE;
         }
-        else {
-            // determine the type of Optional element
-            final var elementType = Introspection.getParameterType(parameter.type())
-                .orElseThrow(() -> new IOException("Failed to determine a Optional<T> element type T for ["
-                    + parameter.name() + "] of type [" + parameter.type() + "]"));
-
-            if (optional.isEmpty()) {
-                generator.writeStartArray();
-                generator.writeEndArray();
-            }
-            else {
-                generator.writeStartArray();
-                final var element = optional.get();
-                transport.write(parameter, elementType, element, generator, marshaller);
-                generator.writeEndArray();
-            }
+        if (optional.isEmpty()) {
+            return JsonArray.of(List.of());
         }
+        final var elementType = Introspection.getParameterType(parameter.type())
+            .orElseThrow(() -> new IllegalStateException(
+                "Failed to determine Optional<T> element type for [" + parameter.name() + "]"));
+        return JsonArray.of(List.of(transport.encode(parameter, elementType, optional.get(), marshaller)));
     }
 
     @Override
-    public Optional<?> read(final JsonTransport transport,
-                            final Parameter parameter,
-                            final JsonParser parser,
-                            final Marshaller marshaller)
-        throws IOException {
+    public Optional<?> decode(final JsonTransport transport,
+                              final Parameter parameter,
+                              final JsonValue value,
+                              final Marshaller marshaller) {
 
-        if (parser.currentToken() == JsonToken.VALUE_NULL) {
-            parser.nextToken();
-
+        if (value instanceof JsonNull) {
             return null;
         }
-
-        // determine the type of Optional element
+        final var array = value.asArray();
+        if (array.values().isEmpty()) {
+            return Optional.empty();
+        }
         final var elementType = Introspection.getParameterType(parameter.type())
-            .orElseThrow(() -> new IOException("Failed to determine a Optional<T> element type T for ["
-                + parameter.name() + "] of type [" + parameter.type() + "]"
-                + " at " + parser.currentLocation()));
-
-        // determine the class of Optional element
-        final var elementClass = Introspection.getClassFromType(elementType)
-            .orElse(Object.class);
-
-        if (parser.currentToken() == JsonToken.START_ARRAY) {
-            // skip start of array "["
-            parser.nextToken();
-
-            if (parser.currentToken() == JsonToken.END_ARRAY) {
-                // skip end of array "]"
-                parser.nextToken();
-
-                return Optional.empty();
-            }
-
-            final var optional = Optional.ofNullable(transport.read(parameter, elementClass, parser, marshaller));
-
-            // skip end of array "]"
-            parser.nextToken();
-
-            return optional;
-        }
-        else {
-            // unexpected token
-            throw new IllegalStateException("Unexpected token [" + parser.currentToken() + "]");
-        }
+            .orElseThrow(() -> new IllegalStateException(
+                "Failed to determine Optional<T> element type for [" + parameter.name() + "]"));
+        final var elementClass = Introspection.getClassFromType(elementType).orElse(Object.class);
+        return Optional.ofNullable(transport.decode(parameter, elementClass, array.element(0), marshaller));
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/PeriodCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/PeriodCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.Period;
 
 /**
  * A {@link Codec} for {@link Period} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class PeriodCodec
     implements Codec<Period> {
@@ -46,40 +42,20 @@ public class PeriodCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Period value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Period value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public Period read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public Period decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a Period but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return Period.parse(parser.getText());
-        }
+        return value instanceof JsonNull ? null : Period.parse(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/StreamableCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/StreamableCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,19 +22,18 @@ package build.base.transport.json.codec;
 
 import build.base.foundation.Introspection;
 import build.base.foundation.stream.Streamable;
+import build.base.json.JsonArray;
+import build.base.json.JsonNull;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.ConditionalCodec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 
 /**
- * A {@link ConditionalCodec} of {@link Streamable} values.
+ * A {@link ConditionalCodec} for {@link Streamable} values. Encoded as a JSON array.
  *
  * @author brian.oliver
  * @since Nov-2024
@@ -58,71 +57,44 @@ public class StreamableCodec<T>
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Streamable<T> streamable,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
-        throws IOException {
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Streamable<T> streamable,
+                            final Marshaller marshaller) {
 
         if (streamable == null) {
-            generator.writeNull();
+            return JsonNull.INSTANCE;
         }
-        else {
-            // determine the type of Stream element
-            final var elementType = Introspection.getParameterType(parameter.type())
-                .orElseThrow(() -> new IOException("Failed to determine a Streamable type for "
-                    + parameter.name() + " of type " + parameter.type()));
-
-            generator.writeStartArray();
-
-            for (Object element : streamable) {
-                // only write non-null element values
-                // (no point in writing nulls into an array)
-                if (element != null) {
-                    transport.write(parameter, elementType, element, generator, marshaller);
-                }
+        final var elementType = Introspection.getParameterType(parameter.type())
+            .orElseThrow(() -> new IllegalStateException(
+                "Failed to determine Streamable<T> element type for [" + parameter.name() + "]"));
+        final var elements = new ArrayList<JsonValue>();
+        for (final var element : streamable) {
+            if (element != null) {
+                elements.add(transport.encode(parameter, elementType, element, marshaller));
             }
-
-            generator.writeEndArray();
         }
+        return JsonArray.of(elements);
     }
 
     @Override
-    public Streamable<T> read(final JsonTransport transport,
-                              final Parameter parameter,
-                              final JsonParser parser,
-                              final Marshaller marshaller)
-        throws IOException {
+    @SuppressWarnings("unchecked")
+    public Streamable<T> decode(final JsonTransport transport,
+                                final Parameter parameter,
+                                final JsonValue value,
+                                final Marshaller marshaller) {
 
-        // determine the type of Stream element
-        final var elementType = Introspection.getParameterType(parameter.type())
-            .orElseThrow(() -> new IOException("Failed to determine a Stream type for "
-                + parameter.name() + " of type " + parameter.type()
-                + " at " + parser.currentLocation()));
-
-        // determine the class of Stream element
-        final var elementClass = Introspection.getClassFromType(elementType)
-            .orElseThrow();
-
-        if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
+        if (value instanceof JsonNull) {
             return defaultValue();
         }
-
-        if (!parser.isExpectedStartArrayToken()) {
-            throw new IOException(
-                "Expected start of array at " + parser.currentLocation() + " for parameter " + parameter.name());
+        final var elementType = Introspection.getParameterType(parameter.type())
+            .orElseThrow(() -> new IllegalStateException(
+                "Failed to determine Streamable<T> element type for [" + parameter.name() + "]"));
+        final var elementClass = Introspection.getClassFromType(elementType).orElseThrow();
+        final var elements = new ArrayList<T>();
+        for (final var element : value.asArray().values()) {
+            elements.add((T) transport.decode(parameter, elementClass, element, marshaller));
         }
-
-        // skip the start of the start of the JsonArray Token
-        parser.clearCurrentToken();
-
-        final var elements = new LinkedList<T>();
-
-        while (parser.nextToken() != JsonToken.END_ARRAY) {
-            elements.add(transport.read(parameter, elementClass, parser, marshaller));
-        }
-
         return Streamable.of(elements);
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/StringCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/StringCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,13 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
-import java.io.IOException;
 
 /**
  * A {@link Codec} for {@link String} values.
@@ -45,35 +43,20 @@ public class StringCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final String value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final String value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        generator.writeString(value);
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value);
     }
 
     @Override
-    public String read(final JsonTransport transport,
-                       final Parameter parameter,
-                       final JsonParser parser,
-                       final Marshaller marshaller)
-        throws IOException {
+    public String decode(final JsonTransport transport,
+                         final Parameter parameter,
+                         final JsonValue value,
+                         final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a String but got " + currentToken + " at " + parser.currentLocation());
-        }
-        else {
-            return parser.getText();
-        }
+        return value instanceof JsonNull ? null : value.asString().value();
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/TimestampCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/TimestampCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 
 /**
  * A {@link Codec} for {@link Timestamp} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class TimestampCodec
     implements Codec<Timestamp> {
@@ -46,40 +42,20 @@ public class TimestampCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final Timestamp value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final Timestamp value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public Timestamp read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public Timestamp decode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final JsonValue value,
+                            final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a Timestamp but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return Timestamp.valueOf(parser.getText());
-        }
+        return value instanceof JsonNull ? null : Timestamp.valueOf(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/build/base/transport/json/codec/ZonedDateTimeCodec.java
+++ b/base-transport-json/src/main/java/build/base/transport/json/codec/ZonedDateTimeCodec.java
@@ -9,9 +9,9 @@ package build.base.transport.json.codec;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,18 @@ package build.base.transport.json.codec;
  * #L%
  */
 
+import build.base.json.JsonNull;
+import build.base.json.JsonString;
+import build.base.json.JsonValue;
 import build.base.marshalling.Marshaller;
 import build.base.marshalling.Parameter;
 import build.base.transport.json.Codec;
 import build.base.transport.json.JsonTransport;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 
 /**
  * A {@link Codec} for {@link ZonedDateTime} values.
- *
- * @author tim.berston
- * @since Jan-2025
  */
 public class ZonedDateTimeCodec
     implements Codec<ZonedDateTime> {
@@ -46,40 +42,20 @@ public class ZonedDateTimeCodec
     }
 
     @Override
-    public void write(final JsonTransport transport,
-                      final Parameter parameter,
-                      final ZonedDateTime value,
-                      final JsonGenerator generator,
-                      final Marshaller marshaller)
+    public JsonValue encode(final JsonTransport transport,
+                            final Parameter parameter,
+                            final ZonedDateTime value,
+                            final Marshaller marshaller) {
 
-        throws IOException {
-
-        if (value == null) {
-            generator.writeNull();
-        }
-        else {
-            generator.writeString(value.toString());
-        }
+        return value == null ? JsonNull.INSTANCE : JsonString.of(value.toString());
     }
 
     @Override
-    public ZonedDateTime read(final JsonTransport transport,
-                           final Parameter parameter,
-                           final JsonParser parser,
-                           final Marshaller marshaller)
-        throws IOException {
+    public ZonedDateTime decode(final JsonTransport transport,
+                        final Parameter parameter,
+                        final JsonValue value,
+                        final Marshaller marshaller) {
 
-        final var currentToken = parser.currentToken();
-
-        if (currentToken == JsonToken.VALUE_NULL) {
-            return null;
-        }
-        else if (currentToken != JsonToken.VALUE_STRING) {
-            throw new IOException(
-                "Expected a ZonedDateTime but got " + parser.currentToken() + " at " + parser.currentLocation());
-        }
-        else {
-            return ZonedDateTime.parse(parser.getText());
-        }
+        return value instanceof JsonNull ? null : ZonedDateTime.parse(value.asString().value());
     }
 }

--- a/base-transport-json/src/main/java/module-info.java
+++ b/base-transport-json/src/main/java/module-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,10 +25,10 @@
  */
 open module build.base.transport.json {
     requires build.base.foundation;
+    requires build.base.json;
     requires build.base.marshalling;
     requires build.base.transport;
 
-    requires com.fasterxml.jackson.core;
     requires java.sql;
 
     exports build.base.transport.json;

--- a/base-transport-json/src/test/java/build/base/transport/json/JsonTransportTests.java
+++ b/base-transport-json/src/test/java/build/base/transport/json/JsonTransportTests.java
@@ -1,5 +1,6 @@
 package build.base.transport.json;
 
+import build.base.json.JsonAssertionException;
 import build.base.marshalling.Bound;
 import build.base.marshalling.Marshal;
 import build.base.marshalling.Marshalled;
@@ -19,17 +20,14 @@ import build.base.transport.json.example.PersonWithOptionalLastName;
 import build.base.transport.json.example.StreamsAndOptionals;
 import build.base.transport.json.example.TemporalPerson;
 import build.base.transport.json.example.Uber;
-import com.fasterxml.jackson.core.JsonFactory;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,12 +43,9 @@ public class JsonTransportTests {
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} containing a {@link String} can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledString()
-        throws IOException {
+    void shouldWriteAndReadMarshalledString() {
 
         final var person = new PersonWithFirstName("Gustav");
 
@@ -58,19 +53,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithFirstName> transported = transport.read(parser);
+        final Marshalled<PersonWithFirstName> transported = transport.read(new StringReader(writer.toString()));
 
         final PersonWithFirstName unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -79,18 +66,13 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} containing a {@code null} {@link String} can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledNullString()
-        throws IOException {
+    void shouldWriteAndReadMarshalledNullString() {
 
         final var person = new PersonWithFirstName(null);
 
@@ -98,19 +80,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithFirstName> transported = transport.read(parser);
+        final Marshalled<PersonWithFirstName> transported = transport.read(new StringReader(writer.toString()));
 
         final PersonWithFirstName unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -119,18 +93,13 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} containing an empty {@link String} can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledEmptyString()
-        throws IOException {
+    void shouldWriteAndReadMarshalledEmptyString() {
 
         final var person = new PersonWithFirstName("");
 
@@ -138,19 +107,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithFirstName> transported = transport.read(parser);
+        final Marshalled<PersonWithFirstName> transported = transport.read(new StringReader(writer.toString()));
 
         final PersonWithFirstName unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -159,18 +120,13 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} containing an {@link Optional} {@link String} can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledOptionalString()
-        throws IOException {
+    void shouldWriteAndReadMarshalledOptionalString() {
 
         final var person = new PersonWithOptionalLastName("Gustav", Optional.of("von Redwitz"));
 
@@ -178,19 +134,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithOptionalLastName> transported = transport.read(parser);
+        final Marshalled<PersonWithOptionalLastName> transported = transport.read(new StringReader(writer.toString()));
 
         final PersonWithOptionalLastName unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -199,19 +147,14 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} containing an {@link Optional#empty()} {@link String} can be
      * transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledOptionalEmptyString()
-        throws IOException {
+    void shouldWriteAndReadMarshalledOptionalEmptyString() {
 
         final var person = new PersonWithOptionalLastName("Gustav", Optional.empty());
 
@@ -219,19 +162,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithOptionalLastName> transported = transport.read(parser);
+        final Marshalled<PersonWithOptionalLastName> transported = transport.read(new StringReader(writer.toString()));
 
         final PersonWithOptionalLastName unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -240,19 +175,14 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} containing a {@code null} {@link Optional} {@link String} can be
      * transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledNullOptionalString()
-        throws IOException {
+    void shouldWriteAndReadMarshalledNullOptionalString() {
 
         final var person = new PersonWithOptionalLastName("Gustav", null);
 
@@ -260,19 +190,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithOptionalLastName> transported = transport.read(parser);
+        final Marshalled<PersonWithOptionalLastName> transported = transport.read(new StringReader(writer.toString()));
 
         final PersonWithOptionalLastName unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -281,50 +203,36 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
-     * Ensure a {@link Marshal}lable {@link Object} containing a {@code null} {@link Optional} can be decoded.
-     *
-     * @throws IOException should an exception occur
+     * Ensure a {@link Marshal}lable {@link Object} containing a {@code null} {@link Optional} can be decoded
+     * from a raw JSON string.
      */
     @Test
-    void shouldReadMarshalledNullOptionalString()
-        throws IOException {
+    void shouldReadMarshalledNullOptionalString() {
 
         final var marshaller = Marshalling.newMarshaller();
-
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
 
         final var json = """
-            {"type":"build.base.transport.json.example.PersonWithOptionalLastName","firstName":"Gustav","lastName":null}
+            {"@type":"build.base.transport.json.example.PersonWithOptionalLastName","firstName":"Gustav","lastName":null}
             """;
 
-        final var reader = new StringReader(json);
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<PersonWithOptionalLastName> transported = transport.read(parser);
+        final Marshalled<PersonWithOptionalLastName> transported = transport.read(new StringReader(json));
 
         final PersonWithOptionalLastName person = marshaller.unmarshal(transported);
 
         assertThat(person)
             .isNotNull();
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} composed of another {@link Marshal}lable {@link Object} can be
      * transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadComposedObjectsUsingMarshalleds()
-        throws IOException {
+    void shouldWriteAndReadComposedObjectsUsingMarshalleds() {
 
         final var person = new Person(new Address("Big Street", "Munich"));
 
@@ -332,19 +240,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Person> transported = transport.read(parser);
+        final Marshalled<Person> transported = transport.read(new StringReader(writer.toString()));
 
         final Person unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -353,19 +253,14 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} composed of another {@link Marshal}lable {@link Object} can be
      * transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadComposedStreamableObjects()
-        throws IOException {
+    void shouldWriteAndReadComposedStreamableObjects() {
 
         final var company = new Company()
             .add(new Address("Big Street", "Munich"))
@@ -375,19 +270,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(company);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Company> transported = transport.read(parser);
+        final Marshalled<Company> transported = transport.read(new StringReader(writer.toString()));
 
         final Company unmarshalledCompany = marshaller.unmarshal(transported);
 
@@ -396,19 +283,14 @@ public class JsonTransportTests {
 
         assertThat(company)
             .isEqualTo(unmarshalledCompany);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} composed of another {@link Marshal}lable {@link Object}, but without
      * any {@link Object}s, can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadComposedEmptyStreamableObjects()
-        throws IOException {
+    void shouldWriteAndReadComposedEmptyStreamableObjects() {
 
         final var company = new Company();
 
@@ -416,19 +298,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(company);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Company> transported = transport.read(parser);
+        final Marshalled<Company> transported = transport.read(new StringReader(writer.toString()));
 
         final Company unmarshalledCompany = marshaller.unmarshal(transported);
 
@@ -437,50 +311,35 @@ public class JsonTransportTests {
 
         assertThat(company)
             .isEqualTo(unmarshalledCompany);
-
-        parser.close();
     }
 
     /**
-     * Ensure a {@link Marshal}lable {@link Object} using a {@code null} {@link Stream} can be decoded.
-     *
-     * @throws IOException should an exception occur
+     * Ensure a {@link Marshal}lable {@link Object} using a {@code null} {@link java.util.stream.Stream} can be decoded.
      */
     @Test
-    void shouldReadComposedNullStream()
-        throws IOException {
+    void shouldReadComposedNullStream() {
 
         final var marshaller = Marshalling.newMarshaller();
-
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
 
         final var json = """
-            {"type":"build.base.transport.json.example.Company","addresses":null}
+            {"@type":"build.base.transport.json.example.Company","addresses":null}
             """;
 
-        final var reader = new StringReader(json);
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Company> transported = transport.read(parser);
+        final Marshalled<Company> transported = transport.read(new StringReader(json));
 
         final Company company = marshaller.unmarshal(transported);
 
         assertThat(company)
             .isNotNull();
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} composed of another {@link Marshal}lable {@code null}s can be
      * transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadComposedStreamableNulls()
-        throws IOException {
+    void shouldWriteAndReadComposedStreamableNulls() {
 
         final var company = new Company()
             .add(null)
@@ -490,19 +349,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(company);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Company> transported = transport.read(parser);
+        final Marshalled<Company> transported = transport.read(new StringReader(writer.toString()));
 
         final Company unmarshalledCompany = marshaller.unmarshal(transported);
 
@@ -511,8 +362,6 @@ public class JsonTransportTests {
 
         assertThat(company)
             .isEqualTo(unmarshalledCompany);
-
-        parser.close();
     }
 
     /**
@@ -540,12 +389,9 @@ public class JsonTransportTests {
 
     /**
      * Ensure {@link Marshal}lable with an {@code enum} can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadClassWithEnum()
-        throws IOException {
+    void shouldWriteAndReadClassWithEnum() {
 
         final var address = new AddressWithCountry("Queen Street", "Brisbane", Country.Australia);
 
@@ -553,19 +399,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(address);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<AddressWithCountry> transported = transport.read(parser);
+        final Marshalled<AddressWithCountry> transported = transport.read(new StringReader(writer.toString()));
 
         final var unmarshalled = marshaller.unmarshal(transported);
 
@@ -574,18 +412,13 @@ public class JsonTransportTests {
 
         assertThat(address)
             .isEqualTo(unmarshalled);
-
-        parser.close();
     }
 
     /**
      * Ensure {@link Marshal}lable {@link Uber} can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadUberClass()
-        throws IOException {
+    void shouldWriteAndReadUberClass() {
 
         final var uber = new Uber();
 
@@ -593,19 +426,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(uber);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Uber> transported = transport.read(parser);
+        final Marshalled<Uber> transported = transport.read(new StringReader(writer.toString()));
 
         final Uber unmarshalledUber = marshaller.unmarshal(transported);
 
@@ -614,23 +439,19 @@ public class JsonTransportTests {
 
         assertThat(uber)
             .isEqualTo(unmarshalledUber);
-
-        parser.close();
     }
 
     /**
-     * Ensure {@link Marshal}lable object that contains a null or empty {@link Stream} or {@link Optional} can be transported.
+     * Ensure {@link Marshal}lable object that contains a null or empty {@link java.util.stream.Stream} or
+     * {@link Optional} can be transported.
      * <p>
-     * Note that null and empty {@link Stream} and {@link Optional} should not be written to the JSON, and
-     * unmarshalling should cope with this. This can not be tested directly without confirming the
+     * Note that null and empty {@link java.util.stream.Stream} and {@link Optional} should not be written to the JSON,
+     * and unmarshalling should cope with this. This can not be tested directly without confirming the
      * written JSON. It is confirmed indirectly by the unmarshalled object being slightly different
      * to the original.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadNullAndEmptySteamOrNullAndEmptyOptional()
-        throws IOException {
+    void shouldWriteAndReadNullAndEmptySteamOrNullAndEmptyOptional() {
 
         final var original = new StreamsAndOptionals();
 
@@ -638,19 +459,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<StreamsAndOptionals> transported = transport.read(parser);
+        final Marshalled<StreamsAndOptionals> transported = transport.read(new StringReader(writer.toString()));
 
         final var unmarshalled = marshaller.unmarshal(transported);
 
@@ -659,23 +472,19 @@ public class JsonTransportTests {
 
         assertThat(unmarshalled)
             .isEqualTo(original);
-
-        parser.close();
     }
 
     /**
-     * Ensure {@link Marshal}lable object that contains a mix of null and populated {@link Stream} or {@link Optional} can be transported.
+     * Ensure {@link Marshal}lable object that contains a mix of null and populated {@link java.util.stream.Stream} or
+     * {@link Optional} can be transported.
      * <p>
-     * Note that null and empty {@link Stream} and {@link Optional} should not be written to the JSON, and
-     * unmarshalling should cope with this. This can not be tested directly without confirming the
+     * Note that null and empty {@link java.util.stream.Stream} and {@link Optional} should not be written to the JSON,
+     * and unmarshalling should cope with this. This can not be tested directly without confirming the
      * written JSON. It is confirmed indirectly by the unmarshalled object being slightly different
      * to the original.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadObjectWithNullStreamAndOptional()
-        throws IOException {
+    void shouldWriteAndReadObjectWithNullStreamAndOptional() {
 
         final var original = new StreamsAndOptionals(null,
             Arrays.stream(new String[]{"One", "Two"}),
@@ -686,19 +495,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<StreamsAndOptionals> transported = transport.read(parser);
+        final Marshalled<StreamsAndOptionals> transported = transport.read(new StringReader(writer.toString()));
 
         final var unmarshalled = marshaller.unmarshal(transported);
 
@@ -707,18 +508,13 @@ public class JsonTransportTests {
 
         assertThat(unmarshalled)
             .isEqualTo(original);
-
-        parser.close();
     }
 
     /**
      * Ensure {@link Marshal}lable object that contains multiple unmarshalls will prefer one that has all provided values.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadObjectPreferringCompleteUnmarshall()
-        throws IOException {
+    void shouldWriteAndReadObjectPreferringCompleteUnmarshall() {
 
         final var original = new MultipleUnmarshalls("MyValue", Optional.of("Optional"));
 
@@ -726,19 +522,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<MultipleUnmarshalls> transported = transport.read(parser);
+        final Marshalled<MultipleUnmarshalls> transported = transport.read(new StringReader(writer.toString()));
 
         final var unmarshalled = marshaller.unmarshal(transported);
 
@@ -747,8 +535,6 @@ public class JsonTransportTests {
 
         assertThat(original)
             .isEqualTo(unmarshalled);
-
-        parser.close();
     }
 
     /**
@@ -759,12 +545,9 @@ public class JsonTransportTests {
      * unmarshalling should cope with this. This can not be tested directly without confirming the
      * written JSON. It is confirmed indirectly by the unmarshalled object being slightly different
      * to the original.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadObjectUsingIncompleteUnmarshall()
-        throws IOException {
+    void shouldWriteAndReadObjectUsingIncompleteUnmarshall() {
 
         final var original = new MultipleUnmarshalls("MyValue", null);
 
@@ -772,19 +555,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<MultipleUnmarshalls> transported = transport.read(parser);
+        final Marshalled<MultipleUnmarshalls> transported = transport.read(new StringReader(writer.toString()));
 
         final var unmarshalled = marshaller.unmarshal(transported);
 
@@ -793,40 +568,28 @@ public class JsonTransportTests {
 
         assertThat(original)
             .isEqualTo(unmarshalled);
-
-        parser.close();
     }
 
     /**
      * Ensure {@link Marshal}lable object that contains an Object can be transported.
      * <p>
      * Note that the type contained within the object must be transportable. If not, then
-     * an IOException will be thrown.
-     *
-     * @throws IOException should an exception occur
+     * an exception will be thrown.
      */
     @Test
-    void shouldWriteAndReadMarshalledClassWithObject()
-        throws IOException {
+    void shouldWriteAndReadMarshalledClassWithObject() {
+
         final var original = new ClassWithObjectProperty(16);
 
         final var marshaller = Marshalling.newMarshaller();
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<ClassWithObjectProperty> transported = transport.read(parser);
+        final Marshalled<ClassWithObjectProperty> transported = transport.read(new StringReader(writer.toString()));
 
         final ClassWithObjectProperty unmarshalled = marshaller.unmarshal(transported);
 
@@ -835,13 +598,11 @@ public class JsonTransportTests {
 
         assertThat(original)
             .isEqualTo(unmarshalled);
-
-        parser.close();
     }
 
     @Test
-    void shouldWriteAndReadMarshalledClassWithArrayOfClassesWithObject()
-        throws IOException {
+    void shouldWriteAndReadMarshalledClassWithArrayOfClassesWithObject() {
+
         final var original = new ClassWithArrayOfClassWithObjectProperty(new ArrayList<>());
         original.values().add(new ClassWithObjectProperty(16));
         original.values().add(new ClassWithObjectProperty(32));
@@ -850,19 +611,12 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<ClassWithArrayOfClassWithObjectProperty> transported = transport.read(parser);
+        final Marshalled<ClassWithArrayOfClassWithObjectProperty> transported =
+            transport.read(new StringReader(writer.toString()));
 
         final ClassWithArrayOfClassWithObjectProperty unmarshalled = marshaller.unmarshal(transported);
 
@@ -871,37 +625,25 @@ public class JsonTransportTests {
 
         assertThat(original)
             .isEqualTo(unmarshalled);
-
-        parser.close();
     }
 
     /**
      * Ensure {@link Marshal}lable object that contains an Object with a null value can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledClassWithNullObject()
-        throws IOException {
+    void shouldWriteAndReadMarshalledClassWithNullObject() {
+
         final var original = new ClassWithObjectProperty(null);
 
         final var marshaller = Marshalling.newMarshaller();
         final var marshalled = marshaller.marshal(original);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<ClassWithObjectProperty> transported = transport.read(parser);
+        final Marshalled<ClassWithObjectProperty> transported = transport.read(new StringReader(writer.toString()));
 
         final ClassWithObjectProperty unmarshalled = marshaller.unmarshal(transported);
 
@@ -910,120 +652,68 @@ public class JsonTransportTests {
 
         assertThat(original)
             .isEqualTo(unmarshalled);
-
-        parser.close();
     }
 
     /**
-     * Ensure that an IOException is thrown when attempting to read a malformed class that
-     * contains an Object. In this instance, the 'type' is not transportable.
-     *
-     * @throws IOException should an exception occur
+     * Ensure that an exception is thrown when attempting to read a class that contains an Object whose type
+     * is not transportable.
      */
     @Test
-    void shouldThrowOnReadMarshalledClassWithObjectThatIsNotTransportable()
-        throws IOException {
+    void shouldThrowOnReadMarshalledClassWithObjectThatIsNotTransportable() {
 
         final var serialized =
             """
-                {"type":"build.base.transport.json.example.ClassWithObjectProperty","object":{"type":"java.lang.StringBuilder","value":"16"}}
+                {"@type":"build.base.transport.json.example.ClassWithObjectProperty","object":{"@type":"java.lang.StringBuilder","value":"16"}}
                 """;
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
-        final var reader = new StringReader(serialized);
-        final var parser = factory.createParser(reader);
 
-        final var ex = assertThrows(IOException.class, () -> transport.read(parser));
+        final var ex = assertThrows(IllegalStateException.class,
+            () -> transport.read(new StringReader(serialized)));
         assertTrue(
-            ex.getMessage().startsWith("Failed to determine a Transformer, Codec or @Marshal-able for [object]"));
-
-        parser.close();
+            ex.getMessage().startsWith("No Transformer, Codec, or @Marshal-able found for parameter [object]"));
     }
 
     /**
-     * Ensure that an IOException is thrown when attempting to read a malformed class that
-     * contains an Object. In this instance, the 'value' exists before the 'type'.
-     *
-     * @throws IOException should an exception occur
+     * Ensure that an exception is thrown when attempting to read a class that contains an Object whose
+     * wrapper JSON is missing the 'value' field.
      */
     @Test
-    void shouldThrowOnReadMarshalledClassWithObjectThatWasSerializedIncorrectOrder()
-        throws IOException {
+    void shouldThrowOnReadMarshalledClassWithObjectThatWasSerializedWithMissingValue() {
 
         final var serialized =
             """
-                {"type":"build.base.transport.json.example.ClassWithObjectProperty","object":{"value":"16","type":"java.lang.StringBuilder"}}
+                {"@type":"build.base.transport.json.example.ClassWithObjectProperty","object":{"@type":"java.lang.StringBuilder"}}
                 """;
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
-        final var reader = new StringReader(serialized);
-        final var parser = factory.createParser(reader);
 
-        final var ex = assertThrows(IOException.class, () -> transport.read(parser));
-        assertTrue(ex.getMessage().startsWith("Expected 'type' field name, but found"));
-
-        parser.close();
+        final var ex = assertThrows(JsonAssertionException.class,
+            () -> transport.read(new StringReader(serialized)));
+        assertTrue(ex.getMessage().startsWith("No member named 'value'"));
     }
 
     /**
-     * Ensure that an IOException is thrown when attempting to read a malformed class that
-     * contains an Object. In this instance, the 'value' is missing.
-     *
-     * @throws IOException should an exception occur
+     * Ensure that an exception is thrown when attempting to read a class that contains an Object whose
+     * field value is a JSON primitive rather than a nested JSON object.
      */
     @Test
-    void shouldThrowOnReadMarshalledClassWithObjectThatWasSerializedWithMissingValue()
-        throws IOException {
+    void shouldThrowOnReadMarshalledClassWithObjectThatIsNotNested() {
 
         final var serialized =
             """
-                {"type":"build.base.transport.json.example.ClassWithObjectProperty","object":{"type":"java.lang.StringBuilder"}}
+                {"@type":"build.base.transport.json.example.ClassWithObjectProperty","object":16}
                 """;
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
-        final var reader = new StringReader(serialized);
-        final var parser = factory.createParser(reader);
 
-        final var ex = assertThrows(IOException.class, () -> transport.read(parser));
-        assertTrue(ex.getMessage().startsWith("Expected 'value' field name, but found"));
-
-        parser.close();
-    }
-
-    /**
-     * Ensure that an IOException is thrown when attempting to read a malformed class that
-     * contains an Object. In this instance, the 'object' is a value instead of a nested
-     * JSON object.
-     *
-     * @throws IOException should an exception occur
-     */
-    @Test
-    void shouldThrowOnReadMarshalledClassWithObjectThatIsNotNested()
-        throws IOException {
-
-        final var serialized =
-            """
-                {"type":"build.base.transport.json.example.ClassWithObjectProperty","object":16}
-                """;
-        final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
-        final var reader = new StringReader(serialized);
-        final var parser = factory.createParser(reader);
-
-        final var ex = assertThrows(IOException.class, () -> transport.read(parser));
-        assertTrue(ex.getMessage().startsWith("Expected a JsonObject for"));
-
-        parser.close();
+        final var ex = assertThrows(JsonAssertionException.class,
+            () -> transport.read(new StringReader(serialized)));
+        assertTrue(ex.getMessage().startsWith("Expected a JSON object but got:"));
     }
 
     /**
      * Ensure a {@link Marshal}lable {@link Object} requiring a {@link Bound} property can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadMarshalledWithBoundObject()
-        throws IOException {
+    void shouldWriteAndReadMarshalledWithBoundObject() {
 
         final var now = Instant.now();
         final var person = new TemporalPerson(now, "Sebastian");
@@ -1032,21 +722,13 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(person);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
-
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
+        transport.write(marshalled, writer);
 
         marshaller.bind(now).universally();
 
-        final Marshalled<TemporalPerson> transported = transport.read(parser, marshaller);
+        final Marshalled<TemporalPerson> transported = transport.read(new StringReader(writer.toString()), marshaller);
 
         final TemporalPerson unmarshalledPerson = marshaller.unmarshal(transported);
 
@@ -1055,18 +737,13 @@ public class JsonTransportTests {
 
         assertThat(person)
             .isEqualTo(unmarshalledPerson);
-
-        parser.close();
     }
 
     /**
      * Ensure a {@link Marshal}lable composed of another {@link Marshal}lable can be transported.
-     *
-     * @throws IOException should an exception occur
      */
     @Test
-    void shouldWriteAndReadComposedObject()
-        throws IOException {
+    void shouldWriteAndReadComposedObject() {
 
         final var expense = new Expense();
         expense.add(new ExpenseLine(expense, "Nasi Gorang", 100.0));
@@ -1076,19 +753,11 @@ public class JsonTransportTests {
         final var marshalled = marshaller.marshal(expense);
 
         final var transport = new JsonTransport();
-        final var factory = new JsonFactory();
         final var writer = new StringWriter();
 
-        final var generator = factory.createGenerator(writer);
+        transport.write(marshalled, writer);
 
-        transport.write(marshalled, generator);
-
-        generator.close();
-
-        final var reader = new StringReader(writer.toString());
-        final var parser = factory.createParser(reader);
-
-        final Marshalled<Expense> transported = transport.read(parser);
+        final Marshalled<Expense> transported = transport.read(new StringReader(writer.toString()));
 
         final Expense unmarshalledExpense = marshaller.unmarshal(transported);
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
 
         <!-- Module Dependency Versions -->
         <assertj.version>3.27.7</assertj.version>
-        <jackson-core.version>2.21.2</jackson-core.version>
         <junit.version>6.0.3</junit.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
         <jakarta-el-api.version>6.0.1</jakarta-el-api.version>
@@ -273,11 +272,6 @@
             </dependency>
 
             <!-- Third-party -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson-core.version}</version>
-            </dependency>
             <dependency>
                 <groupId>jakarta.el</groupId>
                 <artifactId>jakarta.el-api</artifactId>


### PR DESCRIPTION
Migrates `base-transport-json` off the Jackson streaming API (`JsonGenerator`/`JsonParser`) and onto the `base-json` typed value model introduced in #54. The `Codec` interface gains `encode`/`decode` methods that operate on `JsonValue` instead of `void` write/read methods that mutated a streaming generator/parser, all codec implementations simplify dramatically as a result, and `JsonTransport` itself drops its `requires com.fasterxml.jackson.core` module dependency entirely. Jackson is removed from the root BOM. Checked `IOException` is replaced with unchecked `IllegalStateException` throughout, since codec failures are programming errors rather than I/O failures. The polymorphic type discriminator field is renamed from `"type"` to `"@type"` to prevent silent key collisions with marshalled objects that have a field of the same name.