### PR TITLE
fix(base-mereology): handle cycles in Composite traversal

### DIFF
--- a/base-mereology/src/main/java/build/base/mereology/AbstractBreadthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/AbstractBreadthFirstIterator.java
@@ -4,7 +4,7 @@ package build.base.mereology;
  * #%L
  * base.build Mereology
  * %%
- * Copyright (C) 2025 Workday Inc
+ * Copyright (C) 2026 Workday Inc
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base-mereology/src/main/java/build/base/mereology/AbstractBreadthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/AbstractBreadthFirstIterator.java
@@ -1,0 +1,162 @@
+package build.base.mereology;
+
+/*-
+ * #%L
+ * base.build Mereology
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.foundation.Capture;
+import build.base.foundation.iterator.Iterators;
+import build.base.foundation.predicate.Predicates;
+import build.base.foundation.tuple.Triple;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Base breadth-first {@link Iterator} over the parts of a {@link Composite}.
+ * <p>
+ * Each queue entry carries the current {@link Composite}, its remaining part {@link Iterator}, and the
+ * ancestor hierarchy accumulated so far.  Subclasses decide how to wrap each matched element into the
+ * return type {@code R} via {@link #wrapReflexive} and {@link #wrap}.  Cycle detection is handled here
+ * via an identity-based visited set.
+ *
+ * @param <T> the element type matched against {@code elementClass}
+ * @param <R> the type returned by the {@link Iterator}
+ * @author reed.vonredwitz
+ * @since May-2026
+ */
+abstract class AbstractBreadthFirstIterator<T, R>
+    implements Iterator<R> {
+
+    /**
+     * The {@link Class} of element over which iteration is being performed.
+     */
+    protected final Class<T> elementClass;
+
+    /**
+     * Queue entries: (current composite, its part iterator, ancestor hierarchy above it).
+     */
+    private final Queue<Triple<Composite, Iterator<?>, List<Composite>>> queue;
+
+    /**
+     * The captured next element to return.
+     */
+    private final Capture<R> nextElement;
+
+    /**
+     * The {@link Predicate} to exclude {@link Composite}s during traversal.
+     */
+    private final Predicate<? super Composite> exclude;
+
+    /**
+     * Tracks visited {@link Composite}s by identity to break cycles.
+     */
+    private final Set<Composite> visited;
+
+    AbstractBreadthFirstIterator(final Composite composite,
+                                 final Class<T> elementClass,
+                                 final boolean reflexive,
+                                 final Predicate<? super Composite> exclude) {
+
+        this.elementClass = elementClass;
+        this.queue = new LinkedList<>();
+        this.visited = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        this.exclude = exclude == null
+            ? Predicates.never()
+            : exclude;
+
+        this.nextElement = reflexive && this.elementClass.isInstance(composite) && !this.exclude.test(composite)
+            ? Capture.of(wrapReflexive(composite))
+            : Capture.empty();
+
+        if (!this.exclude.test(composite)) {
+            this.visited.add(composite);
+            this.queue.add(Triple.of(composite,
+                Iterators.distinct(
+                    Iterators.concat(composite.iterator(this.elementClass), composite.iterator(Composite.class))),
+                List.of()));
+        }
+    }
+
+    /**
+     * Wraps the root {@link Composite} when {@code reflexive} is {@code true}.
+     */
+    protected abstract R wrapReflexive(Composite composite);
+
+    /**
+     * Wraps a matched element into the return type.
+     *
+     * @param element   the matched element
+     * @param current   the {@link Composite} that directly contains {@code element}
+     * @param hierarchy the ancestor composites above {@code current}, nearest-last
+     */
+    protected abstract R wrap(T element, Composite current, List<Composite> hierarchy);
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean hasNext() {
+        while (this.nextElement.isEmpty() && !this.queue.isEmpty()) {
+            final var current = this.queue.peek();
+            if (current.second().hasNext()) {
+                final var next = current.second().next();
+
+                final var exclude = next instanceof Composite composite
+                    && this.exclude.test(composite);
+
+                if (this.elementClass.isInstance(next) && !exclude) {
+                    this.nextElement.set(wrap((T) next, current.first(), current.third()));
+                }
+
+                if (next instanceof Composite nextComposite && !exclude && this.visited.add(nextComposite)) {
+                    final var iterator = Iterators.distinct(
+                        Iterators.concat(
+                            nextComposite.iterator(this.elementClass),
+                            nextComposite.iterator(Composite.class)));
+
+                    final var hierarchy = new ArrayList<>(current.third());
+                    hierarchy.add(current.first());
+
+                    this.queue.add(Triple.of(nextComposite, iterator, hierarchy));
+                }
+            } else {
+                this.queue.remove();
+            }
+        }
+
+        return this.nextElement.isPresent();
+    }
+
+    @Override
+    public R next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more elements to iterate over");
+        }
+
+        return this.nextElement.consume();
+    }
+}

--- a/base-mereology/src/main/java/build/base/mereology/AbstractDepthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/AbstractDepthFirstIterator.java
@@ -4,7 +4,7 @@ package build.base.mereology;
  * #%L
  * base.build Mereology
  * %%
- * Copyright (C) 2025 Workday Inc
+ * Copyright (C) 2026 Workday Inc
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base-mereology/src/main/java/build/base/mereology/AbstractDepthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/AbstractDepthFirstIterator.java
@@ -1,0 +1,149 @@
+package build.base.mereology;
+
+/*-
+ * #%L
+ * base.build Mereology
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import build.base.foundation.Capture;
+import build.base.foundation.iterator.Iterators;
+import build.base.foundation.predicate.Predicates;
+import build.base.foundation.tuple.Pair;
+
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Base depth-first {@link Iterator} over the parts of a {@link Composite}.
+ * <p>
+ * Subclasses decide how to wrap each matched element into the return type {@code R} via
+ * {@link #wrapReflexive} and {@link #wrap}.  Cycle detection is handled here via an identity-based
+ * visited set so that a {@link Composite} that appears as its own (transitive) part does not cause
+ * infinite traversal.
+ *
+ * @param <T> the element type matched against {@code elementClass}
+ * @param <R> the type returned by the {@link Iterator}
+ * @author reed.vonredwitz
+ * @since May-2026
+ */
+abstract class AbstractDepthFirstIterator<T, R>
+    implements Iterator<R> {
+
+    /**
+     * The {@link Class} of element over which iteration is being performed.
+     */
+    protected final Class<T> elementClass;
+
+    /**
+     * The stack of {@link Composite}s and their direct part {@link Iterator}s remaining to be processed.
+     */
+    private final Deque<Pair<Composite, Iterator<?>>> stack;
+
+    /**
+     * The captured next element to return.
+     */
+    private final Capture<R> nextElement;
+
+    /**
+     * The {@link Predicate} to exclude {@link Composite}s during traversal.
+     */
+    private final Predicate<? super Composite> exclude;
+
+    /**
+     * Tracks visited {@link Composite}s by identity to break cycles.
+     */
+    private final Set<Composite> visited;
+
+    AbstractDepthFirstIterator(final Composite composite,
+                               final Class<T> elementClass,
+                               final boolean reflexive,
+                               final Predicate<? super Composite> exclude) {
+
+        this.elementClass = elementClass;
+        this.stack = new LinkedList<>();
+        this.visited = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        this.exclude = exclude == null
+            ? Predicates.never()
+            : exclude;
+
+        this.nextElement = reflexive && this.elementClass.isInstance(composite) && !this.exclude.test(composite)
+            ? Capture.of(wrapReflexive(composite))
+            : Capture.empty();
+
+        if (!this.exclude.test(composite)) {
+            this.visited.add(composite);
+            this.stack.push(Pair.of(composite,
+                Iterators.distinct(
+                    Iterators.concat(composite.iterator(Composite.class), composite.iterator(this.elementClass)))));
+        }
+    }
+
+    /**
+     * Wraps the root {@link Composite} when {@code reflexive} is {@code true}.
+     */
+    protected abstract R wrapReflexive(Composite composite);
+
+    /**
+     * Wraps a matched element into the return type, given the current traversal stack for hierarchy access.
+     */
+    protected abstract R wrap(T element, Deque<Pair<Composite, Iterator<?>>> stack);
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean hasNext() {
+        while (this.nextElement.isEmpty() && !this.stack.isEmpty()) {
+            final var current = this.stack.peek();
+            if (current.second().hasNext()) {
+                final var next = current.second().next();
+
+                final var exclude = next instanceof Composite composite
+                    && this.exclude.test(composite);
+
+                if (this.elementClass.isInstance(next) && !exclude) {
+                    this.nextElement.set(wrap((T) next, this.stack));
+                }
+
+                if (next instanceof Composite composite && !exclude && this.visited.add(composite)) {
+                    this.stack.push(Pair.of(composite,
+                        Iterators.distinct(
+                            Iterators.concat(composite.iterator(Composite.class), composite.iterator(this.elementClass)))));
+                }
+            } else {
+                this.stack.pop();
+            }
+        }
+
+        return this.nextElement.isPresent();
+    }
+
+    @Override
+    public R next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more elements to iterate over");
+        }
+
+        return this.nextElement.consume();
+    }
+}

--- a/base-mereology/src/main/java/build/base/mereology/BreadthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/BreadthFirstIterator.java
@@ -9,9 +9,9 @@ package build.base.mereology;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,120 +20,33 @@ package build.base.mereology;
  * #L%
  */
 
-import build.base.foundation.Capture;
-import build.base.foundation.iterator.Iterators;
-import build.base.foundation.predicate.Predicates;
-import build.base.foundation.tuple.Pair;
-
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.NoSuchElementException;
-import java.util.Queue;
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
- * An internal breadth-first {@link Iterator} for <i>parts</i> of {@link Composite}s that are assignable to a specified
- * {@link Class}, inclusive of the {@link Composite} itself.
+ * A breadth-first {@link java.util.Iterator} over the parts of a {@link Composite}, returning raw elements.
  *
- * @param <T> the type of {@link Object}s to be returned as {@link Iterator} elements
+ * @param <T> the type of elements returned
  * @author brian.oliver
  * @since Sep-2025
  */
 class BreadthFirstIterator<T>
-    implements Iterator<T> {
+    extends AbstractBreadthFirstIterator<T, T> {
 
-    /**
-     * The {@link Class} of element over which iteration is being performed.
-     */
-    private final Class<T> elementClass;
-
-    /**
-     * The queue of {@link Composite}s and their <i>direct</i> <i>part</i> {@link Iterator}s remaining to
-     * be processed.
-     */
-    private final Queue<Pair<Composite, Iterator<?>>> queue;
-
-    /**
-     * The {@link Capture}d next element to return.
-     */
-    private final Capture<T> nextElement;
-
-    /**
-     * The {@link Predicate} to exclude {@link Composite}s during traversal.
-     */
-    private final Predicate<? super Composite> exclude;
-
-    /**
-     * Constructs a {@link BreadthFirstIterator} <i>inclusively</i> commencing at the specified
-     * {@link Composite}, returning only <i>parts</i> that are assignable to the provided {@link Class}.
-     *
-     * @param composite    the {@link Composite} from which to commence the breadth-first traversal
-     * @param elementClass the {@link Class} of element to return
-     * @param reflexive    {@code true} if the {@link Composite} itself should be included in the iteration,
-     *                     otherwise {@code false}
-     * @param exclude      the {@link Predicate} to exclude {@link Composite}s during traversal
-     */
     BreadthFirstIterator(final Composite composite,
                          final Class<T> elementClass,
                          final boolean reflexive,
                          final Predicate<? super Composite> exclude) {
-
-        this.elementClass = elementClass;
-        this.queue = new LinkedList<>();
-
-        this.exclude = exclude == null
-            ? Predicates.never()
-            : exclude;
-
-        this.nextElement = reflexive && this.elementClass.isInstance(composite) && !this.exclude.test(composite)
-            ? Capture.of(this.elementClass.cast(composite))
-            : Capture.empty();
-
-        if (!this.exclude.test(composite)) {
-            // the composite.iterator(T) will return the direct parts of the composite assignable to T
-            // these may or may not include other composites with are assignable to T
-            // however there may be other direct parts that are not assignable to T, that we also have to traverse
-            // which we should only return once
-            this.queue.add(Pair.of(composite,
-                Iterators.distinct(
-                    Iterators.concat(composite.iterator(this.elementClass), composite.iterator(Composite.class)))));
-        }
+        super(composite, elementClass, reflexive, exclude);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public boolean hasNext() {
-        while (this.nextElement.isEmpty() && !this.queue.isEmpty()) {
-            final var current = this.queue.peek();
-            if (current.second().hasNext()) {
-                final var next = current.second().next();
-
-                final var exclude = next instanceof Composite composite
-                    && this.exclude.test(composite);
-
-                if (this.elementClass.isInstance(next) && !exclude) {
-                    this.nextElement.set((T) next);
-                }
-
-                if (next instanceof Composite composite && !exclude) {
-                    this.queue.add(Pair.of(composite,
-                        Iterators.distinct(
-                            Iterators.concat(composite.iterator(this.elementClass), composite.iterator(Composite.class)))));
-                }
-            } else {
-                this.queue.remove();
-            }
-        }
-
-        return this.nextElement.isPresent();
+    protected T wrapReflexive(final Composite composite) {
+        return this.elementClass.cast(composite);
     }
 
     @Override
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException("No more elements to iterate over");
-        }
-
-        return this.nextElement.consume();
+    protected T wrap(final T element, final Composite current, final List<Composite> hierarchy) {
+        return element;
     }
 }

--- a/base-mereology/src/main/java/build/base/mereology/DepthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/DepthFirstIterator.java
@@ -9,9 +9,9 @@ package build.base.mereology;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,123 +20,36 @@ package build.base.mereology;
  * #L%
  */
 
-import build.base.foundation.Capture;
-import build.base.foundation.iterator.Iterators;
-import build.base.foundation.predicate.Predicates;
 import build.base.foundation.tuple.Pair;
 
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 
 /**
- * An internal depth-first {@link Iterator} for <i>parts</i> of {@link Composite}s that are assignable to a specified
- * {@link Class}, inclusive of the {@link Composite} itself.
+ * A depth-first {@link Iterator} over the parts of a {@link Composite}, returning raw elements.
  *
- * @param <T> the type of {@link Object}s to be returned as {@link Iterator} elements
+ * @param <T> the type of elements returned
  * @author brian.oliver
  * @since Sep-2025
  */
 class DepthFirstIterator<T>
-    implements Iterator<T> {
+    extends AbstractDepthFirstIterator<T, T> {
 
-    /**
-     * The {@link Class} of element over which iteration is being performed.
-     */
-    private final Class<T> elementClass;
-
-    /**
-     * The stack of {@link Composite}s and their <i>direct</i> <i>part</i> {@link Iterator}s remaining to
-     * be processed.
-     */
-    private final Deque<Pair<Composite, Iterator<?>>> stack;
-
-    /**
-     * The {@link Capture}d next element to return.
-     */
-    private final Capture<T> nextElement;
-
-    /**
-     * The {@link Predicate} to exclude {@link Composite}s during traversal.
-     */
-    private final Predicate<? super Composite> exclude;
-
-    /**
-     * Constructs an <i>exhaustive</i> {@link DepthFirstIterator} commencing at the specified {@link Composite},
-     * returning only <i>parts</i> that are assignable to the provided {@link Class}.
-     * <p>
-     * TODO: Unless <i>excluded</i>, all {@link Composite} <i>parts</i> are traversed, transitively, irrespective of
-     * whether they are assignable to the specified {@link Class}.
-     *
-     * @param composite    the {@link Composite} from which to commence the depth-first traversal
-     * @param elementClass the {@link Class} of element to return
-     * @param reflexive    {@code true} if the {@link Composite} itself should be included in the iteration,
-     *                     otherwise {@code false}
-     * @param exclude      the {@link Predicate} to exclude {@link Composite}s during traversal
-     */
     DepthFirstIterator(final Composite composite,
                        final Class<T> elementClass,
                        final boolean reflexive,
                        final Predicate<? super Composite> exclude) {
-
-        this.elementClass = elementClass;
-        this.stack = new LinkedList<>();
-
-        this.exclude = exclude == null
-            ? Predicates.never()
-            : exclude;
-
-        this.nextElement = reflexive && this.elementClass.isInstance(composite) && !this.exclude.test(composite)
-            ? Capture.of(this.elementClass.cast(composite))
-            : Capture.empty();
-
-        if (!this.exclude.test(composite)) {
-            // the composite.iterator(T) will return the direct parts of the composite assignable to T
-            // these may or may not include other composites with are assignable to T
-            // however there may be other direct parts that are not assignable to T, that we also have to traverse
-            // which we should only return once
-            this.stack.push(Pair.of(composite,
-                Iterators.distinct(
-                    Iterators.concat(composite.iterator(Composite.class), composite.iterator(this.elementClass)))));
-        }
+        super(composite, elementClass, reflexive, exclude);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public boolean hasNext() {
-        while (this.nextElement.isEmpty() && !this.stack.isEmpty()) {
-            final var current = this.stack.peek();
-            if (current.second().hasNext()) {
-                final var next = current.second().next();
-
-                final var exclude = next instanceof Composite composite
-                    && this.exclude.test(composite);
-
-                if (this.elementClass.isInstance(next) && !exclude) {
-                    this.nextElement.set((T) next);
-                }
-
-                if (next instanceof Composite composite && !exclude) {
-                    this.stack.push(Pair.of(composite,
-                        Iterators.distinct(
-                            Iterators.concat(composite.iterator(Composite.class), composite.iterator(this.elementClass)))));
-                }
-            } else {
-                this.stack.pop();
-            }
-        }
-
-        return this.nextElement.isPresent();
+    protected T wrapReflexive(final Composite composite) {
+        return this.elementClass.cast(composite);
     }
 
     @Override
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException("No more elements to iterate over");
-        }
-
-        return this.nextElement.consume();
+    protected T wrap(final T element, final Deque<Pair<Composite, Iterator<?>>> stack) {
+        return element;
     }
 }

--- a/base-mereology/src/main/java/build/base/mereology/ParthoodBreadthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/ParthoodBreadthFirstIterator.java
@@ -9,9 +9,9 @@ package build.base.mereology;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,136 +20,39 @@ package build.base.mereology;
  * #L%
  */
 
-import build.base.foundation.Capture;
-import build.base.foundation.iterator.Iterators;
-import build.base.foundation.predicate.Predicates;
 import build.base.foundation.stream.Streamable;
-import build.base.foundation.tuple.Triple;
 
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Queue;
 import java.util.function.Predicate;
 
 /**
- * An internal breadth-first {@link Iterator} for <i>parts</i> of {@link Composite}s that are assignable to a specified
- * {@link Class}, inclusive of the {@link Composite} itself, providing access to {@link Entity} relationships.
+ * A breadth-first {@link java.util.Iterator} over the parts of a {@link Composite}, returning {@link Entity}
+ * wrappers that expose parthood hierarchy relationships.
  *
- * @param <T> the type of {@link Object}s to be returned as {@link Entity}-based {@link Iterator} elements
+ * @param <T> the type of elements returned (wrapped in {@link Entity})
  * @author brian.oliver
  * @since Sep-2025
  */
 class ParthoodBreadthFirstIterator<T>
-    implements Iterator<Entity<T>> {
+    extends AbstractBreadthFirstIterator<T, Entity<T>> {
 
-    /**
-     * The {@link Class} of element over which iteration is being performed.
-     */
-    private final Class<T> elementClass;
-
-    /**
-     * The queue of {@link Composite}s, their <i>direct</i> <i>part</i> {@link Iterator}s remaining to
-     * be processed, and the current hierarchy of {@link Composite}s (from the top).
-     */
-    private final Queue<Triple<Composite, Iterator<?>, List<Composite>>> queue;
-
-    /**
-     * The {@link Capture}d next element to return.
-     */
-    private final Capture<Entity<T>> nextElement;
-
-    /**
-     * The {@link Predicate} to exclude {@link Composite}s during traversal.
-     */
-    private final Predicate<? super Composite> exclude;
-
-    /**
-     * Constructs a {@link ParthoodBreadthFirstIterator} <i>inclusively</i> commencing at the specified
-     * {@link Composite}, returning only <i>parts</i> that are assignable to the provided {@link Class}.
-     *
-     * @param composite    the {@link Composite} from which to commence the breadth-first traversal
-     * @param elementClass the {@link Class} of element to return
-     * @param reflexive    {@code true} if the {@link Composite} itself should be included in the iteration,
-     *                     otherwise {@code false}
-     * @param exclude      the {@link Predicate} to exclude {@link Composite}s during traversal
-     */
     ParthoodBreadthFirstIterator(final Composite composite,
                                  final Class<T> elementClass,
                                  final boolean reflexive,
                                  final Predicate<? super Composite> exclude) {
-
-        this.elementClass = elementClass;
-        this.queue = new LinkedList<>();
-
-        this.exclude = exclude == null
-            ? Predicates.never()
-            : exclude;
-
-        this.nextElement = reflexive && this.elementClass.isInstance(composite) && !this.exclude.test(composite)
-            ? Capture.of(Entity.boundary(this.elementClass.cast(composite)))
-            : Capture.empty();
-
-        if (!this.exclude.test(composite)) {
-            // the composite.iterator(T) will return the direct parts of the composite assignable to T
-            // these may or may not include other composites with are assignable to T
-            // however there may be other direct parts that are not assignable to T, that we also have to traverse
-            // which we should only return once
-            this.queue.add(Triple.of(
-                composite,
-                Iterators.distinct(
-                    Iterators.concat(composite.iterator(this.elementClass), composite.iterator(Composite.class))),
-                List.of()));
-        }
+        super(composite, elementClass, reflexive, exclude);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public boolean hasNext() {
-        while (this.nextElement.isEmpty() && !this.queue.isEmpty()) {
-            final var current = this.queue.peek();
-            if (current.second().hasNext()) {
-                final var next = current.second().next();
-
-                final var exclude = next instanceof Composite composite
-                    && this.exclude.test(composite);
-
-                if (this.elementClass.isInstance(next) && !exclude) {
-                    final var hierarchy = new ArrayList<>(current.third());
-                    hierarchy.add(current.first());
-
-                    this.nextElement.set(Entity.of(
-                        (T) next,
-                        Streamable.reversed(hierarchy.stream()).stream()));
-                }
-
-                if (next instanceof Composite nextComposite && !exclude) {
-                    final var iterator = Iterators.distinct(
-                        Iterators.concat(
-                            nextComposite.iterator(this.elementClass),
-                            nextComposite.iterator(Composite.class)));
-
-                    final var hierarchy = new ArrayList<>(current.third());
-                    hierarchy.add(current.first());
-
-                    this.queue.add(Triple.of(nextComposite, iterator, hierarchy));
-                }
-            } else {
-                this.queue.remove();
-            }
-        }
-
-        return this.nextElement.isPresent();
+    protected Entity<T> wrapReflexive(final Composite composite) {
+        return Entity.boundary(this.elementClass.cast(composite));
     }
 
     @Override
-    public Entity<T> next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException("No more elements to iterate over");
-        }
-
-        return this.nextElement.consume();
+    protected Entity<T> wrap(final T element, final Composite current, final List<Composite> hierarchy) {
+        final var h = new ArrayList<>(hierarchy);
+        h.add(current);
+        return Entity.of(element, Streamable.reversed(h.stream()).stream());
     }
 }

--- a/base-mereology/src/main/java/build/base/mereology/ParthoodDepthFirstIterator.java
+++ b/base-mereology/src/main/java/build/base/mereology/ParthoodDepthFirstIterator.java
@@ -9,9 +9,9 @@ package build.base.mereology;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,120 +20,37 @@ package build.base.mereology;
  * #L%
  */
 
-import build.base.foundation.Capture;
-import build.base.foundation.iterator.Iterators;
-import build.base.foundation.predicate.Predicates;
 import build.base.foundation.tuple.Pair;
 
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 
 /**
- * An internal depth-first {@link Iterator} for <i>parts</i> of {@link Composite}s that are assignable to a specified
- * {@link Class}, inclusive of the {@link Composite} itself, providing access to {@link Entity} relationships.
+ * A depth-first {@link Iterator} over the parts of a {@link Composite}, returning {@link Entity} wrappers
+ * that expose parthood hierarchy relationships.
  *
- * @param <T> the type of {@link Object}s to be returned as {@link Entity}-based {@link Iterator} elements
+ * @param <T> the type of elements returned (wrapped in {@link Entity})
  * @author brian.oliver
  * @since Sep-2025
  */
 class ParthoodDepthFirstIterator<T>
-    implements Iterator<Entity<T>> {
+    extends AbstractDepthFirstIterator<T, Entity<T>> {
 
-    /**
-     * The {@link Class} of element over which iteration is being performed.
-     */
-    private final Class<T> elementClass;
-
-    /**
-     * The stack of {@link Composite}s and their <i>direct</i> <i>part</i> {@link Iterator}s remaining to
-     * be processed.
-     */
-    private final Deque<Pair<Composite, Iterator<?>>> stack;
-
-    /**
-     * The {@link Capture}d next {@link Entity} element to return.
-     */
-    private final Capture<Entity<T>> nextElement;
-
-    /**
-     * The {@link Predicate} to exclude {@link Composite}s during traversal.
-     */
-    private final Predicate<? super Composite> exclude;
-
-    /**
-     * Constructs a {@link DepthFirstIterator} <i>inclusively</i> commencing at the specified {@link Composite},
-     * returning only <i>parts</i> that are assignable to the provided {@link Class}.
-     *
-     * @param composite    the {@link Composite} from which to commence the depth-first traversal
-     * @param elementClass the {@link Class} of element to return
-     * @param reflexive    {@code true} if the {@link Composite} itself should be included in the iteration,
-     *                     otherwise {@code false}
-     * @param exclude      the {@link Predicate} to exclude {@link Composite}s during traversal
-     */
     ParthoodDepthFirstIterator(final Composite composite,
                                final Class<T> elementClass,
                                final boolean reflexive,
                                final Predicate<? super Composite> exclude) {
-
-        this.elementClass = elementClass;
-        this.stack = new LinkedList<>();
-
-        this.exclude = exclude == null
-            ? Predicates.never()
-            : exclude;
-
-        this.nextElement = reflexive && this.elementClass.isInstance(composite) && !this.exclude.test(composite)
-            ? Capture.of(Entity.boundary(this.elementClass.cast(composite)))
-            : Capture.empty();
-
-        if (!this.exclude.test(composite)) {
-            // the composite.iterator(T) will return the direct parts of the composite assignable to T
-            // these may or may not include other composites with are assignable to T
-            // however there may be other direct parts that are not assignable to T, that we also have to traverse
-            // which we should only return once
-            this.stack.push(Pair.of(composite,
-                Iterators.distinct(
-                    Iterators.concat(composite.iterator(Composite.class), composite.iterator(this.elementClass)))));
-        }
+        super(composite, elementClass, reflexive, exclude);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public boolean hasNext() {
-        while (this.nextElement.isEmpty() && !this.stack.isEmpty()) {
-            final var current = this.stack.peek();
-            if (current.second().hasNext()) {
-                final var next = current.second().next();
-
-                final var exclude = next instanceof Composite composite
-                    && this.exclude.test(composite);
-
-                if (this.elementClass.isInstance(next) && !exclude) {
-                    this.nextElement.set(Entity.of((T) next, this.stack.stream().map(Pair::first)));
-                }
-
-                if (next instanceof Composite composite && !exclude) {
-                    this.stack.push(Pair.of(composite,
-                        Iterators.distinct(
-                            Iterators.concat(composite.iterator(Composite.class), composite.iterator(this.elementClass)))));
-                }
-            } else {
-                this.stack.pop();
-            }
-        }
-
-        return this.nextElement.isPresent();
+    protected Entity<T> wrapReflexive(final Composite composite) {
+        return Entity.boundary(this.elementClass.cast(composite));
     }
 
     @Override
-    public Entity<T> next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException("No more elements to iterate over");
-        }
-
-        return this.nextElement.consume();
+    protected Entity<T> wrap(final T element, final Deque<Pair<Composite, Iterator<?>>> stack) {
+        return Entity.of(element, stack.stream().map(Pair::first));
     }
 }

--- a/base-mereology/src/test/java/build/base/mereology/CompositeTests.java
+++ b/base-mereology/src/test/java/build/base/mereology/CompositeTests.java
@@ -4,6 +4,7 @@ import build.base.assertion.IteratorAssert;
 import build.base.foundation.stream.Streams;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -692,6 +693,38 @@ class CompositeTests {
                 assertThat(list.get(4).object()).isEqualTo("Direct");
                 assertThat(list.get(4).composite()).contains(composite);
             });
+    }
+
+    /**
+     * Ensure {@link Composite#composition()} does not hang or recurse infinitely when the composite graph contains a self-loop.
+     */
+    @Test
+    void shouldHandleSelfLoopCycleInComposition() {
+        final var parts = new ArrayList<>();
+        final var composite = Composites.of(parts);
+        parts.add("Hello");
+        parts.add(composite); // cycle: composite contains itself
+
+        // composite is emitted as an element (it is a part of itself) but not recursed into again
+        assertThat(composite.composition()).containsExactly(composite, "Hello");
+    }
+
+    /**
+     * Ensure {@link Composite#composition()} does not hang or recurse infinitely when the composite graph contains a mutual cycle.
+     */
+    @Test
+    void shouldHandleMutualCycleInComposition() {
+        final var partsA = new ArrayList<>();
+        final var partsB = new ArrayList<>();
+        final var a = Composites.of(partsA);
+        final var b = Composites.of(partsB);
+        partsA.add("Hello");
+        partsA.add(b);   // A → B
+        partsB.add("World");
+        partsB.add(a);   // B → A (cycle)
+
+        // a is emitted as an element of b (cycle back-edge), but not recursed into again
+        assertThat(a.composition()).containsExactly(b, a, "World", "Hello");
     }
 
     /**


### PR DESCRIPTION
`Composite#composition()` (and all traversal strategies) would hang or stack-overflow when the composite graph contained a cycle — e.g. a composite that directly or transitively contained itself as a part.                    
 
The fix adds an identity-based visited set to the traversal iterators. When a `Composite` is encountered as a part, it is emitted as an element (if it matches the element type) but is only pushed onto the stack/queue for further descent if it has not been visited before, breaking the cycle.

As part of this change the four iterators (`DepthFirstIterator`, `BreadthFirstIterator`, `ParthoodDepthFirstIterator`, `ParthoodBreadthFirstIterator`) were refactored to extend two new abstract base classes (`AbstractDepthFirstIterator`, `AbstractBreadthFirstIterator`) that own all traversal mechanics — including the visited set — leaving each concrete class responsible only for wrapping matched elements into the appropriate return type (raw `T` or `Entity<T>`).

Two tests are added to `CompositeTests`: one covering a self-loop (a composite that contains itself) and one covering a mutual cycle (A → B → A), each with exact-order assertions that pin the expected emission sequence.