### PR TITLE
fix(base-query): fix five indexing and scope bugs; wire @Unique

### DIFF
--- a/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
+++ b/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
@@ -27,6 +27,8 @@ import build.base.foundation.tuple.Pair;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
@@ -79,12 +81,36 @@ public abstract class AbstractHeapBasedIndex implements Index {
             Pair<ConcurrentHashMap<Object, Object>, ConcurrentHashMap<Object, Set<Object>>>>> objectsByClassIndexableFunctionAndValue;
 
     /**
+     * The uniquely-indexed {@link Object}s by {@link Class}, {@link Indexable} {@link Unique} {@link Function}, and
+     * extracted key.
+     * <p>
+     * The {@link Pair} value holds:
+     * <ul>
+     *   <li>first — a reverse-index mapping each indexed {@link Object} to the key extracted at index time</li>
+     *   <li>second — a forward-index mapping each extracted key to the single {@link Object} indexed with that key</li>
+     * </ul>
+     */
+    private final ConcurrentHashMap<
+        Class<?>,
+        ConcurrentHashMap<
+            Function<Object, Object>,
+            Pair<ConcurrentHashMap<Object, Object>, ConcurrentHashMap<Object, Object>>>> uniqueObjectsByClassFunctionAndKey;
+
+    /**
+     * The {@link Indexable} {@link Unique} {@code public} {@code static} {@code final} {@link Function}s defined by
+     * {@link Field}s per known {@link Class}.
+     */
+    private final Memoizer<Class<?>, Streamable<Field>> uniqueIndexableFunctionFieldsByClass;
+
+    /**
      * Constructs an empty {@link AbstractHeapBasedIndex}.
      */
     protected AbstractHeapBasedIndex() {
         this.objectByClass = new ConcurrentHashMap<>();
         this.objectsByClassIndexableFunctionAndValue = new ConcurrentHashMap<>();
         this.indexableFunctionFieldsByClass = new Memoizer<>(AbstractHeapBasedIndex::getIndexableFunctionFields);
+        this.uniqueObjectsByClassFunctionAndKey = new ConcurrentHashMap<>();
+        this.uniqueIndexableFunctionFieldsByClass = new Memoizer<>(AbstractHeapBasedIndex::getUniqueIndexableFunctionFields);
     }
 
 
@@ -152,6 +178,53 @@ public abstract class AbstractHeapBasedIndex implements Index {
                         });
                     } catch (final IllegalAccessException e) {
                         throw new RuntimeException("Failed to index [" + objectClass.getName() + "] as the field [" + field.getName() + "] could not be accessed", e);
+                    }
+
+                    return functions;
+                }));
+
+        // index the values produced by public static final @Indexable @Unique Function fields
+        this.uniqueIndexableFunctionFieldsByClass
+            .compute(objectClass)
+            .forEach(field -> this.uniqueObjectsByClassFunctionAndKey
+                .compute(objectClass, (_, existingFunctions) -> {
+                    final var functions = existingFunctions == null
+                        ? new ConcurrentHashMap<Function<Object, Object>, Pair<ConcurrentHashMap<Object, Object>, ConcurrentHashMap<Object, Object>>>()
+                        : existingFunctions;
+
+                    try {
+                        field.setAccessible(true);
+                        @SuppressWarnings("unchecked") final var function = (Function<Object, Object>) field.get(null);
+
+                        functions.compute(function, (_, existingPair) -> {
+                            final var pair = existingPair == null
+                                ? Pair.of(new ConcurrentHashMap<>(), new ConcurrentHashMap<Object, Object>())
+                                : existingPair;
+
+                            try {
+                                final var value = function.apply(object);
+                                final var indexableValue = value == null ? NULL_OBJECT : value;
+
+                                // enforce uniqueness: two different objects must not share a key
+                                final var displaced = pair.second().putIfAbsent(indexableValue, object);
+                                if (displaced != null && displaced != object) {
+                                    throw new IllegalStateException(
+                                        "Unique key violation: key [" + value + "] produced by [" + field.getName()
+                                            + "] on [" + objectClass.getName() + "] is already held by [" + displaced + "]");
+                                }
+
+                                // record the reverse mapping: object → extracted key
+                                pair.first().put(object, indexableValue);
+
+                                return pair;
+                            } catch (final IllegalStateException e) {
+                                throw e;
+                            } catch (final Throwable e) {
+                                throw new UnsupportedOperationException("Failed to index [" + objectClass.getName() + "] as the unique function [" + field.getName() + "] failed to extract a value from the object", e);
+                            }
+                        });
+                    } catch (final IllegalAccessException e) {
+                        throw new RuntimeException("Failed to index [" + objectClass.getName() + "] as the unique field [" + field.getName() + "] could not be accessed", e);
                     }
 
                     return functions;
@@ -225,37 +298,68 @@ public abstract class AbstractHeapBasedIndex implements Index {
                         : existingFunctions; // return the functions if not empty
                 }));
 
+        // unindex the values produced by public static final @Indexable @Unique Function fields
+        this.uniqueIndexableFunctionFieldsByClass
+            .compute(objectClass)
+            .forEach(field -> this.uniqueObjectsByClassFunctionAndKey
+                .compute(objectClass, (_, existingFunctions) -> {
+                    if (existingFunctions == null) {
+                        return null;
+                    }
+                    try {
+                        field.setAccessible(true);
+                        @SuppressWarnings("unchecked") final var function = (Function<Object, Object>) field.get(null);
+
+                        existingFunctions.compute(function, (_, existingPair) -> {
+                            if (existingPair == null) {
+                                return null;
+                            }
+                            // look up the key from the reverse map — no function invocation needed
+                            final var indexableKey = existingPair.first().remove(object);
+                            if (indexableKey != null) {
+                                existingPair.second().remove(indexableKey);
+                            }
+                            return existingPair.second().isEmpty() ? null : existingPair;
+                        });
+                    } catch (final IllegalAccessException e) {
+                        throw new RuntimeException("Failed to unindex [" + objectClass.getName() + "] as the unique field [" + field.getName() + "] could not be accessed", e);
+                    }
+
+                    return existingFunctions.isEmpty() ? null : existingFunctions;
+                }));
     }
 
 
     @Override
     public <T> void add(final Class<T> valueClass, final T value) {
-        if (valueClass != null && value != null) {
-            this.objectByClass.compute(valueClass, (_, existing) -> {
-                final var objects = existing == null
-                    ? ConcurrentHashMap.newKeySet()
-                    : existing;
+        Objects.requireNonNull(valueClass, "The value class must not be null");
+        Objects.requireNonNull(value, "The value must not be null");
 
-                objects.add(value);
-                return objects;
-            });
-        }
+        this.objectByClass.compute(valueClass, (_, existing) -> {
+            final var objects = existing == null
+                ? ConcurrentHashMap.newKeySet()
+                : existing;
+
+            objects.add(value);
+            return objects;
+        });
     }
 
     @Override
     public <T> void remove(final Class<T> valueClass, final T value) {
-        if (valueClass != null && value != null) {
-            this.objectByClass.compute(valueClass, (_, existing) -> {
-                if (existing == null) {
-                    return null; // nothing to remove
-                } else {
-                    existing.remove(value);
-                    return existing.isEmpty()
-                        ? null
-                        : existing; // return null if empty
-                }
-            });
-        }
+        Objects.requireNonNull(valueClass, "The value class must not be null");
+        Objects.requireNonNull(value, "The value must not be null");
+
+        this.objectByClass.compute(valueClass, (_, existing) -> {
+            if (existing == null) {
+                return null;
+            } else {
+                existing.remove(value);
+                return existing.isEmpty()
+                    ? null
+                    : existing;
+            }
+        });
     }
 
     /**
@@ -294,6 +398,24 @@ public abstract class AbstractHeapBasedIndex implements Index {
     protected static Streamable<Field> getIndexableFunctionFields(final Class<?> indexableClass) {
         return Streamable.of(Introspection.getAllDeclaredFields(indexableClass)
             .filter(field -> field.getAnnotation(Indexable.class) != null
+                && field.getAnnotation(Unique.class) == null
+                && Modifier.isPublic(field.getModifiers())
+                && Modifier.isStatic(field.getModifiers())
+                && Modifier.isFinal(field.getModifiers())
+                && Function.class.isAssignableFrom(field.getType())));
+    }
+
+    /**
+     * Obtains the {@code public static final} {@link Function} {@link Field}s that are annotated as both
+     * {@link Indexable} and {@link Unique} for the specified {@link Class}.
+     *
+     * @param indexableClass the {@link Class} of queryable
+     * @return the {@link Streamable} of {@link Field}s annotated with both {@link Indexable} and {@link Unique}
+     */
+    protected static Streamable<Field> getUniqueIndexableFunctionFields(final Class<?> indexableClass) {
+        return Streamable.of(Introspection.getAllDeclaredFields(indexableClass)
+            .filter(field -> field.getAnnotation(Indexable.class) != null
+                && field.getAnnotation(Unique.class) != null
                 && Modifier.isPublic(field.getModifiers())
                 && Modifier.isStatic(field.getModifiers())
                 && Modifier.isFinal(field.getModifiers())
@@ -350,27 +472,38 @@ public abstract class AbstractHeapBasedIndex implements Index {
          * @return the {@link Stream} of {@link Object}s
          */
         Stream<Q> stream(final Scope scope) {
-            // attempt to use the indexed Objects by Class
             final var objects = AbstractHeapBasedIndex.this.objectByClass.get(this.objectClass);
 
-            if (objects != null) {
-                return objects.stream()
+            if (scope == Scope.Indexed) {
+                return objects == null
+                    ? Stream.empty()
+                    : objects.stream().map(this.objectClass::cast);
+            }
+
+            // For Direct/BreadthFirst/DepthFirst: traversal is additive, not a fallback
+            final var traversedByClass = this.index.traverse(this.objectClass, scope);
+            final Stream<Q> traversalStream;
+
+            if (traversedByClass != null && traversedByClass.hasNext()) {
+                traversalStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(traversedByClass, 0), false);
+            } else {
+                final var traversedAll = this.index.traverse(scope);
+                traversalStream = traversedAll == null || !traversedAll.hasNext()
+                    ? Stream.empty()
+                    : StreamSupport.stream(Spliterators.spliteratorUnknownSize(traversedAll, 0), false)
+                    .filter(this.objectClass::isInstance)
                     .map(this.objectClass::cast);
             }
 
-            final var unindexedObjectsByClass = this.index.traverse(this.objectClass, scope);
-
-            if (unindexedObjectsByClass != null && unindexedObjectsByClass.hasNext()) {
-                return StreamSupport.stream(Spliterators.spliteratorUnknownSize(unindexedObjectsByClass, 0), false);
+            if (objects == null) {
+                return traversalStream;
             }
 
-            final var unindexedObjects = this.index.traverse(scope);
-
-            return unindexedObjects == null || !unindexedObjects.hasNext()
-                ? Stream.empty()
-                : StreamSupport.stream(Spliterators.spliteratorUnknownSize(unindexedObjects, 0), false)
-                .filter(this.objectClass::isInstance)
-                .map(this.objectClass::cast);
+            // Concatenate indexed + traversal, deduplicated by identity
+            final Set<Object> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            return Stream.concat(
+                objects.stream().map(this.objectClass::cast).filter(seen::add),
+                traversalStream.filter(seen::add));
         }
 
         @Override
@@ -479,7 +612,7 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
             this.where = Objects.requireNonNull(where, "The Where must not be null");
             this.value = Objects.requireNonNull(value, "The Value must not be null");
-            this.scope = Scope.Direct;
+            this.scope = where.select.scope;
         }
 
         @Override
@@ -490,7 +623,22 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
         @Override
         public Stream<Q> findAll() {
-            // first attempt to use the function indexed values
+            // check the unique index first — O(1) direct lookup
+            final var uniqueByFunction = AbstractHeapBasedIndex.this
+                .uniqueObjectsByClassFunctionAndKey.get(this.where.select.objectClass);
+
+            if (uniqueByFunction != null) {
+                final var pair = uniqueByFunction.get(this.where.function);
+
+                if (pair != null) {
+                    final var object = pair.second().get(this.value);
+                    return object == null
+                        ? Stream.empty()
+                        : Stream.of(this.where.select.objectClass.cast(object));
+                }
+            }
+
+            // then attempt to use the non-unique function indexed values
             final var objectsByFunction = AbstractHeapBasedIndex.this
                 .objectsByClassIndexableFunctionAndValue.get(this.where.select.objectClass);
 
@@ -508,7 +656,7 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
             // failing that, use the objects provided by the query
             return this.where.select.stream(this.scope)
-                .filter(queryable -> Objects.equals(this.where.function.apply(queryable), this.value));
+                .filter(queryable -> Objects.equals(this.where.nonNull(this.where.function.apply(queryable)), this.value));
         }
     }
 
@@ -548,7 +696,7 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
             this.where = Objects.requireNonNull(where, "The Where must not be null");
             this.value = Objects.requireNonNull(value, "The Value must not be null");
-            this.scope = Scope.Direct;
+            this.scope = where.select.scope;
         }
 
         @Override
@@ -559,7 +707,21 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
         @Override
         public Stream<Q> findAll() {
-            // first attempt to use the function indexed values
+            // check the unique index first
+            final var uniqueByFunction = AbstractHeapBasedIndex.this
+                .uniqueObjectsByClassFunctionAndKey.get(this.where.select.objectClass);
+
+            if (uniqueByFunction != null) {
+                final var pair = uniqueByFunction.get(this.where.function);
+
+                if (pair != null) {
+                    return pair.second().entrySet().stream()
+                        .filter(entry -> !Objects.equals(entry.getKey(), this.value))
+                        .map(entry -> this.where.select.objectClass.cast(entry.getValue()));
+                }
+            }
+
+            // then attempt to use the non-unique function indexed values
             final var objectsByFunction = AbstractHeapBasedIndex.this
                 .objectsByClassIndexableFunctionAndValue.get(this.where.select.objectClass);
 
@@ -617,7 +779,7 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
             this.where = Objects.requireNonNull(where, "The Where must not be null");
             this.predicate = Objects.requireNonNull(predicate, "The Predicate must not be null");
-            this.scope = Scope.Direct;
+            this.scope = where.select.scope;
         }
 
         @Override
@@ -629,7 +791,22 @@ public abstract class AbstractHeapBasedIndex implements Index {
         @Override
         @SuppressWarnings("unchecked")
         public Stream<Q> findAll() {
-            // first attempt to use the function indexed values
+            // check the unique index first
+            final var uniqueByFunction = AbstractHeapBasedIndex.this
+                .uniqueObjectsByClassFunctionAndKey.get(this.where.select.objectClass);
+
+            if (uniqueByFunction != null) {
+                final var pair = uniqueByFunction.get(this.where.function);
+
+                if (pair != null) {
+                    return pair.second().entrySet().stream()
+                        .filter(entry -> this.predicate
+                            .test((V) (entry.getKey() == NULL_OBJECT ? null : entry.getKey())))
+                        .map(entry -> this.where.select.objectClass.cast(entry.getValue()));
+                }
+            }
+
+            // then attempt to use the non-unique function indexed values
             final var objectsByFunction = AbstractHeapBasedIndex.this
                 .objectsByClassIndexableFunctionAndValue.get(this.where.select.objectClass);
 

--- a/base-query/src/main/java/build/base/query/Unique.java
+++ b/base-query/src/main/java/build/base/query/Unique.java
@@ -24,16 +24,23 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
+import java.util.function.Function;
 
 /**
- * Specifies that the result of a {@link Indexable} {@link Method} is unique within the context of a {@link Object}.
+ * Specifies that the key produced by an {@link Indexable} {@code public} {@code static} {@code final} {@link Function}
+ * {@link Field} is unique within the {@link Index} — i.e. no two indexed objects will ever produce the same key for
+ * that function.
+ *
+ * <p>When present alongside {@link Indexable} on a {@link Function} field, the index stores a direct
+ * {@code key → object} mapping instead of {@code key → Set<object>}, making {@code isEqualTo} lookups O(1) and
+ * enforcing uniqueness at index time.
  *
  * @author brian.oliver
  * @since Jun-2025
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target(ElementType.FIELD)
 public @interface Unique {
 
 }

--- a/base-query/src/test/java/build/base/query/HeapBasedIndexTests.java
+++ b/base-query/src/test/java/build/base/query/HeapBasedIndexTests.java
@@ -1,5 +1,14 @@
 package build.base.query;
 
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests for {@link HeapBasedIndex}es.
  *
@@ -11,5 +20,103 @@ public class HeapBasedIndexTests implements IndexCompatibilityTests {
     @Override
     public Index createIndex() {
         return new HeapBasedIndex();
+    }
+
+    /**
+     * Ensure a {@link Scope} set on a {@link Match} is inherited by the terminal so that
+     * {@code traverse(Class, Scope)} receives the match-level scope rather than the default {@link Scope#Direct}.
+     * The terminal's own {@link Terminal#scope} override must still take precedence.
+     */
+    @Test
+    void shouldPropagateMatchScopeToTerminal() {
+        final var capturedScope = new AtomicReference<Scope>();
+        final Index index = getIndex(capturedScope);
+
+        // match-level scope propagates to terminal
+        index.match(String.class)
+            .scope(Scope.BreadthFirst)
+            .where(s -> s)
+            .isEqualTo("hello")
+            .findAll()
+            .toList();
+
+        assertThat(capturedScope.get()).isEqualTo(Scope.BreadthFirst);
+
+        // terminal-level scope overrides match-level scope
+        index.match(String.class)
+            .scope(Scope.BreadthFirst)
+            .where(s -> s)
+            .isEqualTo("hello")
+            .scope(Scope.DepthFirst)
+            .findAll()
+            .toList();
+
+        assertThat(capturedScope.get()).isEqualTo(Scope.DepthFirst);
+    }
+
+    /**
+     * Ensure that {@link Scope#Direct}, {@link Scope#BreadthFirst}, and {@link Scope#DepthFirst} are additive:
+     * results from both the index and {@code traverse} are returned, deduplicated by identity.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldConcatenateIndexedAndTraversedObjectsForNonIndexedScopes() {
+        final var indexedOnly = "indexed-only";
+        final var traversedOnly = "traversed-only";
+        final var shared = "shared";
+
+        final Index index = new AbstractHeapBasedIndex() {
+            @Override
+            protected <T> Iterator<T> traverse(final Class<T> cls, final Scope scope) {
+                if (cls == String.class) {
+                    return (Iterator<T>) List.of(shared, traversedOnly).iterator();
+                }
+                return Collections.emptyIterator();
+            }
+
+            @Override
+            protected Iterator<Object> traverse(final Scope scope) {
+                return Collections.emptyIterator();
+            }
+        };
+
+        index.add(String.class, indexedOnly);
+        index.add(String.class, shared);
+
+        for (final var scope : List.of(Scope.Direct, Scope.BreadthFirst, Scope.DepthFirst)) {
+            assertThat(index.match(String.class).scope(scope).findAll().toList())
+                .as("scope %s should be additive", scope)
+                .containsExactlyInAnyOrder(indexedOnly, shared, traversedOnly);
+        }
+    }
+
+    /**
+     * Ensure that {@link Scope#Indexed} short-circuits without invoking {@code traverse}.
+     */
+    @Test
+    void shouldNotTraverseWhenScopeIsIndexed() {
+        final var capturedScope = new AtomicReference<Scope>();
+        final Index index = getIndex(capturedScope);
+
+        index.add(String.class, "hello");
+
+        index.match(String.class).scope(Scope.Indexed).findAll().toList();
+
+        assertThat(capturedScope.get()).isNull();
+    }
+
+    private static Index getIndex(final AtomicReference<Scope> capturedScope) {
+        return new AbstractHeapBasedIndex() {
+            @Override
+            protected <T> Iterator<T> traverse(final Class<T> cls, final Scope scope) {
+                capturedScope.set(scope);
+                return Collections.emptyIterator();
+            }
+
+            @Override
+            protected Iterator<Object> traverse(final Scope scope) {
+                return Collections.emptyIterator();
+            }
+        };
     }
 }

--- a/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
+++ b/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 /**
  * Compatibility tests for {@link Index} implementations.
@@ -221,6 +222,102 @@ public interface IndexCompatibilityTests {
     }
 
     /**
+     * Ensure {@code isEqualTo(null)} works on the fallback (non-{@link Indexable}) path.
+     *
+     * <p>{@link NullFallbackColorful#COLOR} is not {@link Indexable}, so the query bypasses the index
+     * and evaluates the predicate against the raw stream. Before the fix, {@code Objects.equals(null, NULL_OBJECT)}
+     * returned {@code false}, so the object was never returned.
+     */
+    @Test
+    default void shouldFindObjectWithNullValueOnFallbackPath() {
+        final var index = createIndex();
+
+        final var colorful = new NullFallbackColorful();
+        index.add(NullFallbackColorful.class, colorful);
+
+        assertThat(index.match(NullFallbackColorful.class)
+            .where(NullFallbackColorful.COLOR)
+            .isEqualTo(null)
+            .findFirst())
+            .contains(colorful);
+    }
+
+    /**
+     * Ensure a {@link Unique} {@link Indexable} field is indexed and queried correctly.
+     */
+    @Test
+    default void shouldIndexAndQueryUniqueIndexableField() {
+        final var index = createIndex();
+
+        index.index(new UniqueColorful(Color.RED));
+        index.index(new UniqueColorful(Color.GREEN));
+
+        assertThat(index.match(UniqueColorful.class)
+            .where(UniqueColorful.COLOR)
+            .isEqualTo(Color.RED)
+            .findFirst())
+            .contains(new UniqueColorful(Color.RED));
+
+        assertThat(index.match(UniqueColorful.class)
+            .where(UniqueColorful.COLOR)
+            .isEqualTo(Color.BLUE)
+            .findFirst())
+            .isEmpty();
+    }
+
+    /**
+     * Ensure a {@link Unique} {@link Indexable} field can be unindexed.
+     */
+    @Test
+    default void shouldUnindexUniqueIndexableField() {
+        final var index = createIndex();
+
+        index.index(new UniqueColorful(Color.RED));
+        index.unindex(new UniqueColorful(Color.RED));
+
+        assertThat(index.match(UniqueColorful.class)
+            .where(UniqueColorful.COLOR)
+            .isEqualTo(Color.RED)
+            .findFirst())
+            .isEmpty();
+    }
+
+    /**
+     * Ensure indexing two objects with the same key on a {@link Unique} field throws {@link IllegalStateException}.
+     */
+    @Test
+    default void shouldRejectDuplicateKeyOnUniqueIndexableField() {
+        final var index = createIndex();
+
+        index.index(new UniqueColorful(Color.RED));
+
+        assertThrowsExactly(IllegalStateException.class,
+            () -> index.index(new UniqueColorful(Color.RED)));
+    }
+
+    /**
+     * Ensure {@link Index#add} rejects a {@code null} class or value.
+     */
+    @Test
+    default void shouldRejectNullArgumentsInAdd() {
+        final var index = createIndex();
+
+        assertThrowsExactly(NullPointerException.class, () -> index.add(null, Color.RED));
+        assertThrowsExactly(NullPointerException.class, () -> index.add(Color.class, null));
+    }
+
+    /**
+     * Ensure {@link Index#remove} rejects a {@code null} class or value.
+     */
+    @Test
+    default void shouldRejectNullArgumentsInRemove() {
+        final var index = createIndex();
+
+        assertThrowsExactly(NullPointerException.class, () -> index.remove(null, Color.RED));
+        assertThrowsExactly(NullPointerException.class, () -> index.remove(Color.class, null));
+    }
+
+    /**
      * Ensure a non-{@link Indexable} {@link Object}, which throws an {@link Exception} when indexed, can't be indexed.
      */
     @Test
@@ -321,6 +418,18 @@ public interface IndexCompatibilityTests {
     }
 
     /**
+     * A class whose {@link #COLOR} function is intentionally <em>not</em> {@link Indexable}, forcing queries to
+     * evaluate against the fallback stream rather than the index.  The function always returns {@code null}.
+     */
+    record NullFallbackColorful() {
+
+        /**
+         * A non-{@link Indexable} function that always returns {@code null}.
+         */
+        public static final Function<NullFallbackColorful, Color> COLOR = _ -> null;
+    }
+
+    /**
      * A simple {@code record} for testing purposes that is not indexable.
      *
      * @param color the {@link Color}
@@ -332,5 +441,17 @@ public interface IndexCompatibilityTests {
 
         @Indexable
         public static final Function<NotIndexable, Color> COLOR = NotIndexable::color;
+    }
+
+    /**
+     * A {@code record} whose {@link #COLOR} function is both {@link Indexable} and {@link Unique}.
+     *
+     * @param color the {@link Color}
+     */
+    record UniqueColorful(Color color) {
+
+        @Indexable
+        @Unique
+        public static final Function<UniqueColorful, Color> COLOR = UniqueColorful::color;
     }
 }


### PR DESCRIPTION
Q1 — `IsEqualTo` fallback path was null-asymmetric: when a queried value was null, the fallback stream filter called `Objects.equals(rawValue, NULL_OBJECT)` which always returned false. The fix wraps the extracted value with `nonNull()` before comparing, matching the behaviour of the indexed fast path.

Q2 — Match-level scope was silently ignored by all three terminals (`IsEqualTo`, `IsNotEqualTo`, `Matches`). Each terminal initialised `this.scope = Scope.Direct` unconditionally, discarding any scope set via `Match.scope()`. The fix initialises `this.scope = where.select.scope` so the terminal inherits the match scope, with its own override still taking precedence.

Q3 — `Scope.Direct`, `Scope.BreadthFirst`, and `Scope.DepthFirst` were not additive as their Javadoc promised. If `objectByClass` contained any entry for the queried class, `traverse()` was never called. The fix restructures `stream(Scope)` so `Scope.Indexed` is the only short-circuit; all other scopes concatenate indexed objects with traversal results, deduplicated by identity.

Q4 — `add(Class, T)` and `remove(Class, T)` silently swallowed null arguments via an `if (x != null)` guard. Null class or value is a programmer error; both parameters are now validated with `Objects.requireNonNull`.

Q5 — `@Unique` was annotated `@Target(METHOD)` but nothing ever read it on methods, making it dead code. The target is changed to `FIELD` so it can coexist with `@Indexable` on `public static final Function` fields. When present, the index stores a direct `key → object` mapping instead of `key → Set<object>`, `isEqualTo` lookups become O(1), and duplicate keys throw `IllegalStateException` at index time.