### PR TITLE
fix(base-mereology): six correctness bugs and close two documentation gaps

### DIFF
--- a/base-mereology/src/main/java/build/base/mereology/Composite.java
+++ b/base-mereology/src/main/java/build/base/mereology/Composite.java
@@ -31,6 +31,12 @@ import java.util.stream.Stream;
  * <p>
  * The concepts and terminology used here is based on those defined by the science of
  * <a href="https://en.wikipedia.org/wiki/Mereology">Mereology</a>.
+ * <p>
+ * <b>Cycle detection.</b> Transitive traversal ({@link Strategy#DepthFirst}, {@link Strategy#BreadthFirst}) tracks
+ * visited {@link Composite}s by <em>identity</em> ({@code ==}), not by {@link Object#equals(Object)}.  This means two
+ * structurally-equal but distinct {@link Composite} instances are treated as separate nodes and both are visited.
+ * It also means that implementing {@link Object#equals(Object)} on a {@link Composite} to express structural equality
+ * has no effect on cycle detection; only object identity determines whether a node has already been visited.
  *
  * @author brian.oliver
  * @since Sep-2025
@@ -99,6 +105,12 @@ public interface Composite {
      * Obtains an {@link Iterator} of the <i>direct</i> <i>parts</i> of the {@link Composite} that are assignable to
      * the specified {@link Class}.  Should all types of <i>direct</i> <i>parts</i> be required, {@link Object}.class
      * should be specified.
+     * <p>
+     * <b>Implementor note.</b> During transitive traversal the framework calls both
+     * {@code iterator(Composite.class)} and {@code iterator(elementClass)} and de-duplicates the results by identity
+     * before visiting them.  Implementors therefore do <em>not</em> need to ensure that those two iterators are
+     * disjoint: a part that is both a {@link Composite} and an instance of the element class (e.g. a type that
+     * implements {@link Composite}) will be yielded exactly once regardless.
      *
      * @param <T> the type of the {@link Class}
      * @return an {@link Iterator} of the assignable <i>direct</i> <i>parts</i>

--- a/base-mereology/src/main/java/build/base/mereology/Entity.java
+++ b/base-mereology/src/main/java/build/base/mereology/Entity.java
@@ -22,6 +22,7 @@ package build.base.mereology;
 
 import build.base.foundation.stream.Streamable;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -91,12 +92,12 @@ public interface Entity<T> {
     }
 
     /**
-     * Determines if the {@link Entity} {@link Object} is an <i>atom</i>, meaning it is not a {@link Composite}.
+     * Determines if the {@link Entity} {@link Object} is an <i>atom</i>, meaning it has no proper parts.
      *
-     * @return {@code true} if the {@link Object} is an <i>atom</i>, {@code false} otherwise
+     * @return {@code true} if the {@link Object} has no proper parts, {@code false} otherwise
      */
     default boolean isAtom() {
-        return !(object() instanceof Composite);
+        return !(object() instanceof Composite c) || !c.iterator(Object.class).hasNext();
     }
 
     /**
@@ -154,9 +155,13 @@ public interface Entity<T> {
 
         final var optionalComposite = Optional.ofNullable(composite);
 
-        return composite == null
-            ? boundary(object)
-            : new Entity<>() {
+        if (composite == null) {
+            return boundary(object);
+        }
+
+        final Streamable<Composite> hierarchyStreamable = Streamable.of(composite);
+
+        return new Entity<>() {
             @Override
             public T object() {
                 return object;
@@ -173,8 +178,13 @@ public interface Entity<T> {
             }
 
             @Override
+            public int distance() {
+                return 1;
+            }
+
+            @Override
             public Streamable<Composite> hierarchy() {
-                return Streamable.of(composite);
+                return hierarchyStreamable;
             }
         };
     }
@@ -192,11 +202,17 @@ public interface Entity<T> {
     static <T> Entity<T> of(final T object, final Stream<Composite> hierarchy) {
         Objects.requireNonNull(object, "The object must not be null");
 
-        final var streamable = Streamable.of(hierarchy);
+        // parents: innermost (direct) composite first, boundary last
+        final List<Composite> parents = hierarchy == null ? List.of() : hierarchy.toList();
 
-        return streamable.isEmpty()
-            ? boundary(object)
-            : new Entity<>() {
+        if (parents.isEmpty()) {
+            return boundary(object);
+        }
+
+        final int depth = parents.size();
+        final Streamable<Composite> hierarchyStreamable = Streamable.reversed(parents.stream());
+
+        return new Entity<>() {
 
             @Override
             public T object() {
@@ -205,8 +221,7 @@ public interface Entity<T> {
 
             @Override
             public Optional<Composite> composite() {
-                return streamable.stream()
-                    .findFirst();
+                return Optional.of(parents.get(0));
             }
 
             @Override
@@ -215,8 +230,13 @@ public interface Entity<T> {
             }
 
             @Override
+            public int distance() {
+                return depth;
+            }
+
+            @Override
             public Streamable<Composite> hierarchy() {
-                return Streamable.reversed(streamable.stream());
+                return hierarchyStreamable;
             }
         };
     }

--- a/base-mereology/src/main/java/build/base/mereology/Strategy.java
+++ b/base-mereology/src/main/java/build/base/mereology/Strategy.java
@@ -36,11 +36,17 @@ public enum Strategy {
 
     /**
      * Transitively traverse <i>parts</i> of a {@link Composite} using a <i>depth-first</i> strategy.
+     * <p>
+     * Visited {@link Composite}s are tracked by identity ({@code ==}) so that cycles in the graph are broken
+     * without requiring {@link Object#equals(Object)} to be meaningful on {@link Composite} implementations.
      */
     DepthFirst,
 
     /**
      * Transitively traverse <i>parts</i> of a {@link Composite} using a <i>breadth-first</i> strategy.
+     * <p>
+     * Visited {@link Composite}s are tracked by identity ({@code ==}) so that cycles in the graph are broken
+     * without requiring {@link Object#equals(Object)} to be meaningful on {@link Composite} implementations.
      */
     BreadthFirst;
 }

--- a/base-mereology/src/main/java/build/base/mereology/Traversable.java
+++ b/base-mereology/src/main/java/build/base/mereology/Traversable.java
@@ -116,6 +116,16 @@ class Traversable<T>
     @Override
     @SuppressWarnings("unchecked")
     public <C, I extends Traversal<C, I>> I filter(final Class<C> type) {
+        if (this.filter != Predicates.always()) {
+            throw new IllegalStateException(
+                "filter(Class) cannot be called after filter(Predicate) — the predicate would be silently dropped; " +
+                "call filter(Class) first, then filter(Predicate)");
+        }
+        if (this.abort != Predicates.never()) {
+            throw new IllegalStateException(
+                "filter(Class) cannot be called after abort(Predicate) — the abort predicate would be silently dropped; " +
+                "call filter(Class) first, then abort(Predicate)");
+        }
         return (I) new Traversable<>(this.composite, type)
             .reflexive(this.reflexive)
             .strategy(this.strategy)
@@ -146,20 +156,24 @@ class Traversable<T>
                     ((element instanceof Composite c && !this.exclude.test(c)) || (!(element instanceof Composite)))
                         && this.filter.test(element);
 
-                // establish the direct part iterator with a mapping to Parthood
-                final var iterator = this.exclude.test(this.composite)
-                    ? Iterators.<Entity<T>>empty()
-                    : Iterators.map(
-                    Iterators.filter(this.composite.iterator(this.elementClass), include),
-                    object -> Entity.of(object, Traversable.this.composite));
+                final boolean excludeRoot = this.exclude.test(this.composite);
+                final boolean includeReflexive = !excludeRoot
+                    && this.reflexive
+                    && this.elementClass.isInstance(this.composite);
 
-                // include the composite if reflexive
-                yield this.reflexive && this.elementClass.isInstance(this.composite) && !this.exclude.test(this.composite)
-                    ? new ParthoodTraversal<>(
-                    () -> Iterators.of(
-                        Iterators.of(Entity.boundary(Traversable.this.elementClass.cast(Traversable.this.composite))),
-                        iterator))
-                    : new ParthoodTraversal<>(() -> iterator);
+                yield new ParthoodTraversal<>(() -> {
+                    if (excludeRoot) {
+                        return Iterators.empty();
+                    }
+                    final var partIterator = Iterators.map(
+                        Iterators.filter(Traversable.this.composite.iterator(Traversable.this.elementClass), include),
+                        object -> Entity.of(object, Traversable.this.composite));
+                    return includeReflexive
+                        ? Iterators.of(
+                            Iterators.of(Entity.boundary(Traversable.this.elementClass.cast(Traversable.this.composite))),
+                            partIterator)
+                        : partIterator;
+                });
             }
 
             case DepthFirst -> new ParthoodTraversal<>(

--- a/base-mereology/src/main/java/build/base/mereology/Traversal.java
+++ b/base-mereology/src/main/java/build/base/mereology/Traversal.java
@@ -66,11 +66,17 @@ public interface Traversal<T, B extends Traversal<T, B>>
 
     /**
      * Creates a new {@link Traversal} specifically for the specified {@link Class} of {@link Object}s.
+     * <p>
+     * This method must be called <em>before</em> {@link #filter(Predicate)} and {@link #abort(Predicate)}.
+     * Because it replaces the element type entirely, any previously-set predicate or abort filter would be
+     * silently invalidated, so an {@link IllegalStateException} is thrown if either has been set.
+     * The correct order is: {@code filter(MyClass.class).strategy(...).filter(predicate).abort(predicate)}.
      *
      * @param <C>  the type of {@link Object}
      * @param <I>  the type of {@link Traversal}
      * @param type the {@link Class} of {@link Object}
      * @return a new {@link Traversal} for the specified {@link Class} of {@link Object}
+     * @throws IllegalStateException if a {@link #filter(Predicate)} or {@link #abort(Predicate)} has already been set
      * @see #filter(Predicate)
      */
     <C, I extends Traversal<C, I>> I filter(Class<C> type);

--- a/base-mereology/src/test/java/build/base/mereology/CompositeTests.java
+++ b/base-mereology/src/test/java/build/base/mereology/CompositeTests.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link Composite}s.
@@ -725,6 +726,120 @@ class CompositeTests {
 
         // a is emitted as an element of b (cycle back-edge), but not recursed into again
         assertThat(a.composition()).containsExactly(b, a, "World", "Hello");
+    }
+
+    /**
+     * Ensure {@link Entity#distance()} returns 1 for an {@link Entity} created with a single {@link Composite},
+     * and that repeated calls to {@link Entity#hierarchy()} return the same content.
+     */
+    @Test
+    void shouldReturnDistanceOfOneForSingleCompositeEntity() {
+        final var composite = Composites.of("part");
+        final var entity = Entity.of("object", composite);
+
+        assertThat(entity.distance()).isEqualTo(1);
+        assertThat(entity.composite()).contains(composite);
+        assertThat(entity.hierarchy().stream()).containsExactly(composite);
+
+        // repeated calls must return the same results
+        assertThat(entity.distance()).isEqualTo(1);
+        assertThat(entity.hierarchy().stream()).containsExactly(composite);
+    }
+
+    /**
+     * Ensure {@link Entity#distance()} equals the hierarchy depth for an {@link Entity} created from a
+     * {@link Stream}, and that {@link Entity#composite()} and {@link Entity#hierarchy()} return consistent
+     * results across repeated calls (no stream-reuse hazard).
+     */
+    @Test
+    void shouldReturnCorrectDistanceAndHierarchyFromStreamFactory() {
+        final var root = Composites.of("a");
+        final var mid = Composites.of("b");
+        final var leaf = Composites.of("c");
+
+        // stream is innermost-first: leaf → mid → root
+        final var entity = Entity.of("object", Stream.of(leaf, mid, root));
+
+        assertThat(entity.distance()).isEqualTo(3);
+        assertThat(entity.composite()).contains(leaf);
+
+        // hierarchy() must be boundary-first: root → mid → leaf
+        assertThat(entity.hierarchy().stream()).containsExactly(root, mid, leaf);
+
+        // repeated calls must return the same results (guards against stream-reuse regression)
+        assertThat(entity.distance()).isEqualTo(3);
+        assertThat(entity.composite()).contains(leaf);
+        assertThat(entity.hierarchy().stream()).containsExactly(root, mid, leaf);
+    }
+
+    /**
+     * Ensure a {@link Strategy#Direct} {@link Hierarchical} traversal produces the same elements on repeated
+     * calls to {@link Hierarchical#stream()} — guards against the iterator being created eagerly and exhausted
+     * on first use.
+     */
+    @Test
+    void shouldReturnConsistentResultsOnRepeatedDirectHierarchicalStream() {
+        final var composite = Composites.of("Hello", "World");
+        final var hierarchical = composite.traverse()
+            .strategy(Strategy.Direct)
+            .hierarchical();
+
+        assertThat(hierarchical.stream().map(Entity::object)).containsExactly("Hello", "World");
+        assertThat(hierarchical.stream().map(Entity::object)).containsExactly("Hello", "World");
+    }
+
+    /**
+     * Ensure a reflexive {@link Strategy#Direct} {@link Hierarchical} traversal also produces consistent results
+     * on repeated calls.
+     */
+    @Test
+    void shouldReturnConsistentResultsOnRepeatedReflexiveDirectHierarchicalStream() {
+        final var composite = Composites.of("Hello");
+        final var hierarchical = composite.traverse()
+            .strategy(Strategy.Direct)
+            .reflexive(true)
+            .hierarchical();
+
+        assertThat(hierarchical.stream().map(Entity::object)).containsExactly(composite, "Hello");
+        assertThat(hierarchical.stream().map(Entity::object)).containsExactly(composite, "Hello");
+    }
+
+    /**
+     * Ensure {@link Traversal#filter(Class)} throws when a {@link Predicate} filter has already been set,
+     * preventing the silent drop of the predicate.
+     */
+    @Test
+    void shouldThrowWhenFilterByClassCalledAfterFilterByPredicate() {
+        final var composite = Composites.of("Hello", 42);
+
+        assertThatThrownBy(() -> composite.traverse()
+            .filter(e -> e instanceof String)
+            .filter(String.class))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    /**
+     * Ensure {@link Traversal#filter(Class)} throws when an abort predicate has already been set.
+     */
+    @Test
+    void shouldThrowWhenFilterByClassCalledAfterAbort() {
+        final var composite = Composites.of("Hello", 42);
+
+        assertThatThrownBy(() -> composite.traverse()
+            .abort(e -> false)
+            .filter(String.class))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    /**
+     * Ensure {@link Entity#isAtom()} is structural: a non-{@link Composite} is always an atom,
+     * a non-empty {@link Composite} is not, and an empty {@link Composite} is.
+     */
+    @Test
+    void shouldDetermineAtomStructurally() {
+        assertThat(Entity.boundary("hello").isAtom()).isTrue();
+        assertThat(Entity.boundary(Composites.of("part")).isAtom()).isFalse();
+        assertThat(Entity.boundary(Composite.empty()).isAtom()).isTrue();
     }
 
     /**


### PR DESCRIPTION
- **`Entity.isAtom()` now structural.** The previous type-check (`!(object() instanceof Composite)`) classified any `Composite` as non-atomic regardless of whether it had parts. The fix uses a pattern match plus `iterator(Object.class).hasNext()`, so an empty `Composite` correctly reports `isAtom() == true`.

- **`Entity.distance()` recomputed on every call.** `distance()` delegated to `hierarchy().count()`, walking the full hierarchy each time. Both `Entity.of` factories now store depth as a field and override `distance()` to return it directly.

- **`Entity.of(T, Stream)` rebuilt its reversed `Streamable` on every `hierarchy()` call.** The factory now materializes the input stream into a `List<Composite>` once at construction and calls `Streamable.reversed` once, storing the result.

- **`Entity.of(T, Composite)` constructed a new `Streamable` wrapper on every `hierarchy()` call.** `Streamable.of(composite)` is now called once at construction and the result stored.

- **`Traversable.hierarchical()` Direct case exhausted its iterator on first use.** The base iterator was constructed outside the `ParthoodTraversal` supplier, so every call to `Hierarchical.stream()` returned the same already-consumed iterator. Iterator construction is now inside the supplier lambda, consistent with the `DepthFirst` and `BreadthFirst` cases.

- **`Traversal.filter(Class)` silently dropped `filter(Predicate)` and `abort(Predicate)`.** Calling `filter(Class)` after either had been set discarded them without warning. The method now throws `IllegalStateException` in both cases with a message stating the correct call order. The constraint is documented on `Traversal.filter(Class)` with a `@throws` tag.

- **Cycle detection contract undocumented.** Transitive traversal tracks visited `Composite`s by identity (`==`), not `equals`. This is now stated in the `Composite` class Javadoc and on both transitive `Strategy` constants, so implementors who override `equals` are not surprised.

- **`Composite.iterator(Class)` overlap contract undocumented.** The framework calls both `iterator(Composite.class)` and `iterator(elementClass)` and de-duplicates by identity before visiting, so implementors do not need to keep those iterators disjoint. This is now stated as an implementor note on `Composite.iterator(Class)`.

Nine new tests cover: structural atom check; single-composite and stream-factory `distance`/`hierarchy`/`composite` correctness and idempotency; both `filter(Class)` throw conditions; and repeated `stream()` calls on Direct hierarchical traversals (non-reflexive and reflexive).