### PR TITLE
feat(base-mereology, base-query): add Composites.verify and Index.reindex

### DIFF
--- a/base-mereology/src/main/java/build/base/mereology/Composites.java
+++ b/base-mereology/src/main/java/build/base/mereology/Composites.java
@@ -24,7 +24,9 @@ import build.base.foundation.Arrays;
 import build.base.foundation.iterator.Iterators;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Provides mechanisms to work with {@link Composite}s.
@@ -106,5 +108,23 @@ public class Composites {
      */
     public static <V> Composite valuesOf(final Map<?, V> map) {
         return of(map.values());
+    }
+
+    /**
+     * Walks the transitive composition of {@code root} and returns every reachable {@link Composite}
+     * that matches {@code suspect} and exposes no parts — a signal that
+     * {@link Composite#iterator(Class)} is not correctly implemented for that node.
+     *
+     * @param root    the root {@link Composite} to walk, included reflexively
+     * @param suspect identifies which {@link Composite}s are expected to have parts
+     * @return the list of suspect empty {@link Composite}s; empty when none are found
+     */
+    public static List<Composite> verify(final Composite root, final Predicate<? super Composite> suspect) {
+        return root.traverse(Composite.class)
+            .reflexive(true)
+            .stream()
+            .filter(suspect)
+            .filter(c -> !c.iterator(Object.class).hasNext())
+            .toList();
     }
 }

--- a/base-mereology/src/test/java/build/base/mereology/CompositeTests.java
+++ b/base-mereology/src/test/java/build/base/mereology/CompositeTests.java
@@ -843,6 +843,40 @@ class CompositeTests {
     }
 
     /**
+     * Ensure {@link Composites#verify} returns an empty list when every reachable {@link Composite} has parts.
+     */
+    @Test
+    void shouldFindNoSuspectCompositesWhenAllHaveParts() {
+        final var leaf = Composites.of("Hello");
+        final var root = Composites.of(leaf, "World");
+
+        assertThat(Composites.verify(root, c -> true)).isEmpty();
+    }
+
+    /**
+     * Ensure {@link Composites#verify} flags a reachable {@link Composite} that exposes no parts.
+     */
+    @Test
+    void shouldFindEmptyNestedCompositeAsSuspect() {
+        final var empty = Composite.empty();
+        final var root = Composites.of(empty, "Hello");
+
+        assertThat(Composites.verify(root, c -> true))
+            .containsExactly(empty);
+    }
+
+    /**
+     * Ensure {@link Composites#verify} respects the predicate: composites rejected by it are not reported.
+     */
+    @Test
+    void shouldRespectSuspectPredicateInVerify() {
+        final var empty = Composite.empty();
+        final var root = Composites.of(empty, "Hello");
+
+        assertThat(Composites.verify(root, c -> c != empty)).isEmpty();
+    }
+
+    /**
      * Ensure the hierarchy in {@link Entity}s shows the complete path from root to element.
      */
     @Test

--- a/base-query/src/main/java/build/base/query/Index.java
+++ b/base-query/src/main/java/build/base/query/Index.java
@@ -56,6 +56,21 @@ public interface Index extends Queryable {
     void unindex(Object object);
 
     /**
+     * Re-indexes the specified {@link Object} by first unindexing it and then re-indexing it.
+     * <p>
+     * Use this after mutating an object whose indexed values may have changed, so that the
+     * forward and reverse maps reflect the new state.
+     *
+     * @param object the {@link Object} to re-index
+     * @see #index(Object)
+     * @see #unindex(Object)
+     */
+    default void reindex(final Object object) {
+        unindex(object);
+        index(object);
+    }
+
+    /**
      * Adds the specified value {@link Object} to the index so that is may be returned when the specified {@link Class}
      * is queried or matched.
      *

--- a/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
+++ b/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
@@ -318,6 +318,28 @@ public interface IndexCompatibilityTests {
     }
 
     /**
+     * Ensure {@link Index#reindex} reflects value changes after mutation.
+     */
+    @Test
+    default void shouldReflectMutatedValueAfterReindex() {
+        final var index = createIndex();
+
+        final var colorful = new MutableColorful(Color.RED);
+        index.index(colorful);
+
+        assertThat(index.match(MutableColorful.class).where(MutableColorful.COLOR).isEqualTo(Color.RED).findFirst())
+            .contains(colorful);
+
+        colorful.setColor(Color.GREEN);
+        index.reindex(colorful);
+
+        assertThat(index.match(MutableColorful.class).where(MutableColorful.COLOR).isEqualTo(Color.RED).findFirst())
+            .isEmpty();
+        assertThat(index.match(MutableColorful.class).where(MutableColorful.COLOR).isEqualTo(Color.GREEN).findFirst())
+            .contains(colorful);
+    }
+
+    /**
      * Ensure a non-{@link Indexable} {@link Object}, which throws an {@link Exception} when indexed, can't be indexed.
      */
     @Test


### PR DESCRIPTION
- **`Composites.verify(root, suspect)`** — walks the transitive composition of a `Composite` (including the root) and returns every reachable `Composite` that matches the caller-supplied predicate but exposes no parts. Catches the class of bug fixed in https://github.com/Workday/codemodel.build/pull/54 before it silently corrupts `TypeReference` derivation. Three tests cover the no-suspects path, the flagging path, and predicate filtering.
- **`Index.reindex(object)`** — default method on `Index` that unindexes then re-indexes an object. Replaces the hand-rolled `unindex`/`index` pair that `CodeModelTraitable` currently repeats at every trait mutation site. One test in `IndexCompatibilityTests` verifies that a mutated `@Indexable` value is reflected correctly after a `reindex` call.