### PR TITLE
feat(base-query): hierarchy-aware querying — match(Super.class) finds indexed subclass instances

### DIFF
--- a/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
+++ b/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
@@ -466,18 +466,25 @@ public abstract class AbstractHeapBasedIndex implements Index {
         }
 
         /**
+         * Returns a {@link Stream} of all objects in the index whose concrete class is assignable to
+         * {@link #objectClass}, drawn from {@code objectByClass} across all matching keys.
+         */
+        private Stream<Q> indexedStream() {
+            return AbstractHeapBasedIndex.this.objectByClass.entrySet().stream()
+                .filter(e -> this.objectClass.isAssignableFrom(e.getKey()))
+                .flatMap(e -> e.getValue().stream())
+                .map(this.objectClass::cast);
+        }
+
+        /**
          * Obtain the {@link Stream} of {@link Object}s of the specified {@link Class}.
          *
          * @param scope the {@link Scope} for obtaining {@link Object}s to query
          * @return the {@link Stream} of {@link Object}s
          */
         Stream<Q> stream(final Scope scope) {
-            final var objects = AbstractHeapBasedIndex.this.objectByClass.get(this.objectClass);
-
             if (scope == Scope.Indexed) {
-                return objects == null
-                    ? Stream.empty()
-                    : objects.stream().map(this.objectClass::cast);
+                return indexedStream();
             }
 
             // For Direct/BreadthFirst/DepthFirst: traversal is additive, not a fallback
@@ -495,14 +502,10 @@ public abstract class AbstractHeapBasedIndex implements Index {
                     .map(this.objectClass::cast);
             }
 
-            if (objects == null) {
-                return traversalStream;
-            }
-
-            // Concatenate indexed + traversal, deduplicated by identity
+            // Concatenate indexed (all assignable subclasses) + traversal, deduplicated by identity
             final Set<Object> seen = Collections.newSetFromMap(new IdentityHashMap<>());
             return Stream.concat(
-                objects.stream().map(this.objectClass::cast).filter(seen::add),
+                indexedStream().filter(seen::add),
                 traversalStream.filter(seen::add));
         }
 

--- a/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
+++ b/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
@@ -340,6 +340,45 @@ public interface IndexCompatibilityTests {
     }
 
     /**
+     * Ensure {@link Match#findAll()} returns instances indexed under subclasses when the query class is a supertype.
+     */
+    @Test
+    default void shouldFindSubclassInstancesWhenQueryingBySupertype() {
+        final var index = createIndex();
+        final var circle = new Circle("red");
+        final var square = new Square("blue");
+
+        index.add(Circle.class, circle);
+        index.add(Square.class, square);
+
+        assertThat(index.match(Shape.class).findAll().toList())
+            .containsExactlyInAnyOrder(circle, square);
+    }
+
+    /**
+     * Ensure {@link Scope#Indexed} also returns subclass instances when querying by supertype.
+     */
+    @Test
+    default void shouldFindSubclassInstancesWithIndexedScopeWhenQueryingBySupertype() {
+        final var index = createIndex();
+        final var circle = new Circle("red");
+
+        index.add(Circle.class, circle);
+
+        assertThat(index.match(Shape.class).scope(Scope.Indexed).findAll().toList())
+            .containsExactly(circle);
+    }
+
+    /**
+     * A simple marker interface for supertype-query tests.
+     */
+    interface Shape {}
+
+    record Circle(String color) implements Shape {}
+
+    record Square(String color) implements Shape {}
+
+    /**
      * Ensure a non-{@link Indexable} {@link Object}, which throws an {@link Exception} when indexed, can't be indexed.
      */
     @Test


### PR DESCRIPTION
- `Query.stream(Scope)` previously looked up `objectByClass` with an exact class key, so `match(Super.class)` only returned objects explicitly added under `Super.class`. Now `indexedStream()` scans all keys in `objectByClass` for assignability, unioning the results — so subclass instances surface automatically regardless of which concrete class they were indexed under.
- Both the `Scope.Indexed` short-circuit and the additive `Direct`/`BreadthFirst`/`DepthFirst` paths use `indexedStream()`. Identity-based deduplication is preserved.
- Two new tests in `IndexCompatibilityTests` cover the default-scope and `Scope.Indexed` cases.