### PR TITLE
feat(base-query): supertype-aware function-indexed lookups

### DIFF
--- a/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
+++ b/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
@@ -624,35 +624,33 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
         @Override
         public Stream<Q> findAll() {
-            // check the unique index first — O(1) direct lookup
-            final var uniqueByFunction = AbstractHeapBasedIndex.this
-                .uniqueObjectsByClassFunctionAndKey.get(this.where.select.objectClass);
+            // check the unique index across all assignable classes
+            final var uniquePairs = AbstractHeapBasedIndex.this.uniqueObjectsByClassFunctionAndKey.entrySet().stream()
+                .filter(e -> this.where.select.objectClass.isAssignableFrom(e.getKey()))
+                .map(e -> e.getValue().get(this.where.function))
+                .filter(pair -> pair != null)
+                .toList();
 
-            if (uniqueByFunction != null) {
-                final var pair = uniqueByFunction.get(this.where.function);
-
-                if (pair != null) {
-                    final var object = pair.second().get(this.value);
-                    return object == null
-                        ? Stream.empty()
-                        : Stream.of(this.where.select.objectClass.cast(object));
-                }
+            if (!uniquePairs.isEmpty()) {
+                return uniquePairs.stream()
+                    .map(pair -> pair.second().get(this.value))
+                    .filter(obj -> obj != null)
+                    .map(this.where.select.objectClass::cast);
             }
 
-            // then attempt to use the non-unique function indexed values
-            final var objectsByFunction = AbstractHeapBasedIndex.this
-                .objectsByClassIndexableFunctionAndValue.get(this.where.select.objectClass);
+            // then attempt to use the non-unique function indexed values across all assignable classes
+            final var indexPairs = AbstractHeapBasedIndex.this.objectsByClassIndexableFunctionAndValue.entrySet().stream()
+                .filter(e -> this.where.select.objectClass.isAssignableFrom(e.getKey()))
+                .map(e -> e.getValue().get(this.where.function))
+                .filter(pair -> pair != null)
+                .toList();
 
-            if (objectsByFunction != null) {
-                final var pair = objectsByFunction.get(this.where.function);
-
-                if (pair != null) {
-                    final var objects = pair.second().get(this.value);
-                    return objects == null || objects.isEmpty()
-                        ? Stream.empty()
-                        : objects.stream()
-                        .map(this.where.select.objectClass::cast);
-                }
+            if (!indexPairs.isEmpty()) {
+                return indexPairs.stream()
+                    .map(pair -> pair.second().get(this.value))
+                    .filter(objects -> objects != null && !objects.isEmpty())
+                    .flatMap(Set::stream)
+                    .map(this.where.select.objectClass::cast);
             }
 
             // failing that, use the objects provided by the query
@@ -708,34 +706,33 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
         @Override
         public Stream<Q> findAll() {
-            // check the unique index first
-            final var uniqueByFunction = AbstractHeapBasedIndex.this
-                .uniqueObjectsByClassFunctionAndKey.get(this.where.select.objectClass);
+            // check the unique index across all assignable classes
+            final var uniquePairs = AbstractHeapBasedIndex.this.uniqueObjectsByClassFunctionAndKey.entrySet().stream()
+                .filter(e -> this.where.select.objectClass.isAssignableFrom(e.getKey()))
+                .map(e -> e.getValue().get(this.where.function))
+                .filter(pair -> pair != null)
+                .toList();
 
-            if (uniqueByFunction != null) {
-                final var pair = uniqueByFunction.get(this.where.function);
-
-                if (pair != null) {
-                    return pair.second().entrySet().stream()
-                        .filter(entry -> !Objects.equals(entry.getKey(), this.value))
-                        .map(entry -> this.where.select.objectClass.cast(entry.getValue()));
-                }
+            if (!uniquePairs.isEmpty()) {
+                return uniquePairs.stream()
+                    .flatMap(pair -> pair.second().entrySet().stream())
+                    .filter(entry -> !Objects.equals(entry.getKey(), this.value))
+                    .map(entry -> this.where.select.objectClass.cast(entry.getValue()));
             }
 
-            // then attempt to use the non-unique function indexed values
-            final var objectsByFunction = AbstractHeapBasedIndex.this
-                .objectsByClassIndexableFunctionAndValue.get(this.where.select.objectClass);
+            // then attempt to use the non-unique function indexed values across all assignable classes
+            final var indexPairs = AbstractHeapBasedIndex.this.objectsByClassIndexableFunctionAndValue.entrySet().stream()
+                .filter(e -> this.where.select.objectClass.isAssignableFrom(e.getKey()))
+                .map(e -> e.getValue().get(this.where.function))
+                .filter(pair -> pair != null)
+                .toList();
 
-            if (objectsByFunction != null) {
-                final var pair = objectsByFunction.get(this.where.function);
-
-                if (pair != null) {
-                    return pair.second().entrySet()
-                        .stream()
-                        .filter(entry -> !Objects.equals(entry.getKey(), this.value))
-                        .flatMap(entry -> entry.getValue().stream())
-                        .map(this.where.select.objectClass::cast);
-                }
+            if (!indexPairs.isEmpty()) {
+                return indexPairs.stream()
+                    .flatMap(pair -> pair.second().entrySet().stream())
+                    .filter(entry -> !Objects.equals(entry.getKey(), this.value))
+                    .flatMap(entry -> entry.getValue().stream())
+                    .map(this.where.select.objectClass::cast);
             }
 
             // failing that, use the objects provided by the query
@@ -792,37 +789,35 @@ public abstract class AbstractHeapBasedIndex implements Index {
         @Override
         @SuppressWarnings("unchecked")
         public Stream<Q> findAll() {
-            // check the unique index first
-            final var uniqueByFunction = AbstractHeapBasedIndex.this
-                .uniqueObjectsByClassFunctionAndKey.get(this.where.select.objectClass);
+            // check the unique index across all assignable classes
+            final var uniquePairs = AbstractHeapBasedIndex.this.uniqueObjectsByClassFunctionAndKey.entrySet().stream()
+                .filter(e -> this.where.select.objectClass.isAssignableFrom(e.getKey()))
+                .map(e -> e.getValue().get(this.where.function))
+                .filter(pair -> pair != null)
+                .toList();
 
-            if (uniqueByFunction != null) {
-                final var pair = uniqueByFunction.get(this.where.function);
-
-                if (pair != null) {
-                    return pair.second().entrySet().stream()
-                        .filter(entry -> this.predicate
-                            .test((V) (entry.getKey() == NULL_OBJECT ? null : entry.getKey())))
-                        .map(entry -> this.where.select.objectClass.cast(entry.getValue()));
-                }
+            if (!uniquePairs.isEmpty()) {
+                return uniquePairs.stream()
+                    .flatMap(pair -> pair.second().entrySet().stream())
+                    .filter(entry -> this.predicate
+                        .test((V) (entry.getKey() == NULL_OBJECT ? null : entry.getKey())))
+                    .map(entry -> this.where.select.objectClass.cast(entry.getValue()));
             }
 
-            // then attempt to use the non-unique function indexed values
-            final var objectsByFunction = AbstractHeapBasedIndex.this
-                .objectsByClassIndexableFunctionAndValue.get(this.where.select.objectClass);
+            // then attempt to use the non-unique function indexed values across all assignable classes
+            final var indexPairs = AbstractHeapBasedIndex.this.objectsByClassIndexableFunctionAndValue.entrySet().stream()
+                .filter(e -> this.where.select.objectClass.isAssignableFrom(e.getKey()))
+                .map(e -> e.getValue().get(this.where.function))
+                .filter(pair -> pair != null)
+                .toList();
 
-            if (objectsByFunction != null) {
-                final var pair = objectsByFunction.get(this.where.function);
-
-                if (pair != null) {
-                    return pair.second().entrySet().stream()
-                        .filter(entry -> this.predicate
-                            .test((V) ((entry.getKey() == NULL_OBJECT)
-                                ? null // convert the constant back to null
-                                : entry.getKey())))
-                        .flatMap(entry -> entry.getValue().stream())
-                        .map(this.where.select.objectClass::cast);
-                }
+            if (!indexPairs.isEmpty()) {
+                return indexPairs.stream()
+                    .flatMap(pair -> pair.second().entrySet().stream())
+                    .filter(entry -> this.predicate
+                        .test((V) ((entry.getKey() == NULL_OBJECT) ? null : entry.getKey())))
+                    .flatMap(entry -> entry.getValue().stream())
+                    .map(this.where.select.objectClass::cast);
             }
 
             // failing that, use the objects provided by the query

--- a/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
+++ b/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
@@ -354,8 +354,10 @@ public interface IndexCompatibilityTests {
         index.add(Circle.class, circle);
         index.add(Square.class, square);
 
-        assertThat(index.match(Shape.class).findAll().toList())
-            .containsExactlyInAnyOrder(circle, square);
+        assertThat(index.match(Shape.class)
+            .findAll()
+            .toList()
+        ).containsExactlyInAnyOrder(circle, square);
     }
 
     /**
@@ -368,14 +370,106 @@ public interface IndexCompatibilityTests {
 
         index.add(Circle.class, circle);
 
-        assertThat(index.match(Shape.class).scope(Scope.Indexed).findAll().toList())
-            .containsExactly(circle);
+        assertThat(index.match(Shape.class)
+            .scope(Scope.Indexed)
+            .findAll()
+            .toList()
+        ).containsExactly(circle);
+    }
+
+    /**
+     * Ensure a non-{@link Indexable} {@code where} predicate falls through to {@code indexedStream()} correctly
+     * when querying by supertype with {@link Scope#Indexed}.
+     */
+    @Test
+    default void shouldFilterBySupertypeViaFallbackPredicateWithIndexedScope() {
+        final var index = createIndex();
+        final var redCircle = new Circle("red");
+        final var blueSquare = new Square("blue");
+
+        index.add(Circle.class, redCircle);
+        index.add(Square.class, blueSquare);
+
+        assertThat(index.match(Shape.class)
+            .scope(Scope.Indexed)
+            .where(Shape::color)
+            .isEqualTo("red")
+            .findAll()
+            .toList()
+        ).containsExactly(redCircle);
+    }
+
+    /**
+     * Ensure {@link Condition#isEqualTo} uses the indexed path when the {@link Indexable} function is declared on
+     * a supertype and the query class is that supertype.
+     */
+    @Test
+    default void shouldFindBySupertypeUsingIndexedFunctionEquality() {
+        final var index = createIndex();
+        final var red = new Circle("red");
+        final var blue = new Square("blue");
+
+        index.index(red);
+        index.index(blue);
+
+        assertThat(index.match(Shape.class).scope(Scope.Indexed).where(Shape.COLOR).isEqualTo("red").findFirst()).contains(red);
+        assertThat(index.match(Shape.class).scope(Scope.Indexed).where(Shape.COLOR).isEqualTo("blue").findFirst()).contains(blue);
+        assertThat(index.match(Shape.class).scope(Scope.Indexed).where(Shape.COLOR).isEqualTo("green").findFirst()).isEmpty();
+    }
+
+    /**
+     * Ensure {@link Condition#isNotEqualTo} uses the indexed path when the {@link Indexable} function is declared on
+     * a supertype and the query class is that supertype.
+     */
+    @Test
+    default void shouldFindBySupertypeUsingIndexedFunctionInequality() {
+        final var index = createIndex();
+        final var red = new Circle("red");
+        final var blue = new Square("blue");
+
+        index.index(red);
+        index.index(blue);
+
+        assertThat(index.match(Shape.class)
+            .scope(Scope.Indexed)
+            .where(Shape.COLOR)
+            .isNotEqualTo("red")
+            .findAll()
+            .toList()
+        ).containsExactly(blue);
+    }
+
+    /**
+     * Ensure {@link Condition#matches} uses the indexed path when the {@link Indexable} function is declared on
+     * a supertype and the query class is that supertype.
+     */
+    @Test
+    default void shouldFindBySupertypeUsingIndexedFunctionPredicate() {
+        final var index = createIndex();
+        final var red = new Circle("red");
+        final var blue = new Square("blue");
+
+        index.index(red);
+        index.index(blue);
+
+        assertThat(index.match(Shape.class)
+            .scope(Scope.Indexed)
+            .where(Shape.COLOR)
+            .matches(c -> c.startsWith("r"))
+            .findAll()
+            .toList()
+        ).containsExactly(red);
     }
 
     /**
      * A simple marker interface for supertype-query tests.
      */
     interface Shape {
+        String color();
+
+        @Indexable
+        @Unique
+        public static final Function<Shape, String> COLOR = Shape::color;
     }
 
     record Circle(String color) implements Shape {


### PR DESCRIPTION
PR #63 made `match(Super.class).findAll()` hierarchy-aware by scanning `objectByClass` with `isAssignableFrom`. However, the three condition implementations — `IsEqualTo`, `IsNotEqualTo`, and `Matches` — still resolved the function index maps with an exact-class `get(objectClass)`, so `match(Super.class).where(Super.FUNCTION).isEqualTo(X)` would always miss subclass instances even when those instances were correctly indexed.

This PR replaces the exact-class lookup in all three conditions with an `isAssignableFrom` scan across the relevant map's entry set, collecting all matching pairs before falling through to the traversal path. The fix applies symmetrically to both the unique index (`uniqueObjectsByClassFunctionAndKey`) and the non-unique index (`objectsByClassIndexableFunctionAndValue`).

Four new tests in `IndexCompatibilityTests` cover the indexed path for equality, inequality, and predicate conditions queried by supertype, plus a fallback-to-`indexedStream()` case using a non-`@Indexable` method reference.