### PR TITLE
chore: bump GH Actions versions and fix version extraction for Maven 4

### DIFF
--- a/.github/workflows/main-pull-request.yml
+++ b/.github/workflows/main-pull-request.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -37,7 +37,7 @@ jobs:
       - name: Determine Versions
         id: versions
         run: |
-          CURRENT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          CURRENT_VERSION=$(grep -m1 '<revision>' pom.xml | sed 's/.*<revision>\(.*\)<\/revision>.*/\1/' | tr -d '[:space:]')
 
           RELEASE_VERSION="${{ inputs.release-version }}"
           if [ -z "$RELEASE_VERSION" ]; then


### PR DESCRIPTION
`release.yml`'s "Determine Versions" step previously used `./mvnw help:evaluate -DforceStdout` to read the current version. Maven 4 wraps the output in `[INFO] [stdout] <value>` when writing to a TTY but drops the prefix  when stdout is piped, making it impossible to strip reliably. Replaced with a direct `grep`/`sed` on `pom.xml`'s `<revision>` property — no Maven invocation, no format ambiguity.

The new approach works for both 3 and 4.