### PR TITLE
chore(base-assertion, base-retryable, base-telemetry-ansi): reduce test durations

### DIFF
--- a/base-assertion/src/test/java/build/base/assertion/test/EventuallyTests.java
+++ b/base-assertion/src/test/java/build/base/assertion/test/EventuallyTests.java
@@ -46,7 +46,7 @@ class EventuallyTests {
      */
     @Test
     void shouldRetryForASpecificTimeout() {
-        final var duration = Duration.ofSeconds(1);
+        final var duration = Duration.ofMillis(500);
         final var timeout = Timeout.of(duration);
         final var start = Instant.now();
 
@@ -113,7 +113,7 @@ class EventuallyTests {
     @Test
     void shouldRetryRetryableLambdaThrowingARuntimeException() {
 
-        final var duration = Duration.ofSeconds(1);
+        final var duration = Duration.ofMillis(500);
         final var timeout = Timeout.of(duration);
         final var start = Instant.now();
 
@@ -212,7 +212,7 @@ class EventuallyTests {
         final Thread thread = Thread.startVirtualThread(() -> {
             // wait for a second to allow the Eventually to start checking
             try {
-                Thread.sleep(1000);
+                Thread.sleep(500);
             }
             catch (final Exception e) {
 
@@ -255,7 +255,7 @@ class EventuallyTests {
         final Thread thread = Thread.startVirtualThread(() -> {
             // wait for a second to allow the Eventually to start checking
             try {
-                Thread.sleep(1000);
+                Thread.sleep(500);
             }
             catch (final Exception e) {
 
@@ -287,7 +287,7 @@ class EventuallyTests {
     void shouldRetryARunnableThrowingARuntimeException() {
         assertThrows(AssertionError.class, () -> {
             // establish a Timeout for Eventually.assertThat(...)
-            final var duration = Duration.ofSeconds(2);
+            final var duration = Duration.ofMillis(500);
             final var timeout = Timeout.of(duration);
 
             // establish a counter to determine the number of retries
@@ -322,7 +322,7 @@ class EventuallyTests {
     void shouldRetryARunnableThrowingAnAssertionError() {
         assertThrows(AssertionError.class, () -> {
             // establish a Timeout for Eventually.assertThat(...)
-            final var duration = Duration.ofSeconds(2);
+            final var duration = Duration.ofMillis(500);
             final var timeout = Timeout.of(duration);
 
             // establish a counter to determine the number of retries
@@ -355,7 +355,7 @@ class EventuallyTests {
     @Test
     void shouldInvokeARunnableOnceAndOnlyOnce() {
         // establish a Timeout for Eventually.assertThat(...)
-        final var duration = Duration.ofSeconds(2);
+        final var duration = Duration.ofMillis(500);
         final var timeout = Timeout.of(duration);
 
         // establish a counter to determine the number of retries
@@ -386,7 +386,7 @@ class EventuallyTests {
      */
     @Test
     void shouldPreserveUnderlyingCause() {
-        final var timeout = Timeout.of(Duration.ofSeconds(2));
+        final var timeout = Timeout.of(Duration.ofMillis(500));
         final Function<String, String> normalFunction = s -> s;
         final RuntimeException runtimeException = new RuntimeException("exceptional");
         final Function<String, String> exceptionalFunction = s -> {

--- a/base-retryable/src/test/java/build/base/retryable/BlockingRetryTests.java
+++ b/base-retryable/src/test/java/build/base/retryable/BlockingRetryTests.java
@@ -42,7 +42,7 @@ class BlockingRetryTests {
     @Test
     void shouldRetryForASpecificTimeout() {
         assertTimeout(TIMEOUT, () -> {
-            final var duration = Duration.ofSeconds(2);
+            final var duration = Duration.ofMillis(500);
             final var timeout = Timeout.of(duration);
 
             final var start = Instant.now();
@@ -164,7 +164,7 @@ class BlockingRetryTests {
     @Test
     void shouldDelayRetrying() {
         assertTimeout(TIMEOUT, () -> {
-            final var duration = Duration.ofSeconds(2);
+            final var duration = Duration.ofMillis(500);
 
             final var start = Instant.now();
 
@@ -234,7 +234,7 @@ class BlockingRetryTests {
     @Test
     void shouldUseAMaximumDelay() {
         assertTimeout(TIMEOUT, () -> {
-            final var maximumDuration = Duration.ofSeconds(1);
+            final var maximumDuration = Duration.ofMillis(500);
             final var timeoutDuration = Duration.ofSeconds(2);
 
             final var start = Instant.now();

--- a/base-telemetry-ansi/src/test/java/build/base/telemetry/ansi/ANSIBasedTelemetryRecorderTests.java
+++ b/base-telemetry-ansi/src/test/java/build/base/telemetry/ansi/ANSIBasedTelemetryRecorderTests.java
@@ -18,7 +18,7 @@ class ANSIBasedTelemetryRecorderTests {
             try (final var meter = telemetryRecorder.commence(100, "This should be fun!");
                  final var anotherMeter = telemetryRecorder.commence(50, "A second meter")) {
 
-                for (int i = 1; i <= 100; i++) {
+                for (int i = 1; i <= 10; i++) {
                     meter.progress();
 
                     Thread.sleep(100);


### PR DESCRIPTION
Cuts several test timeouts and sleep durations from 1–2 seconds down to 500ms, and reduces the ANSI telemetry recorder's progress loop from 100 iterations (10 s) to 10 (1 s). All assertions remain logically equivalent — no behavioral coverage was changed. The suite should run several seconds faster as a result.