### PR TITLE
chore: remove Mockito from test dependencies

### DIFF
--- a/base-configuration/pom.xml
+++ b/base-configuration/pom.xml
@@ -35,36 +35,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dependency-properties</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>-XX:+EnableDynamicAgentLoading -javaagent:${org.mockito:mockito-core:jar}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/base-configuration/src/test/java/build/base/configuration/ConfigurationTests.java
+++ b/base-configuration/src/test/java/build/base/configuration/ConfigurationTests.java
@@ -10,11 +10,9 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link Configuration}s.
@@ -128,22 +126,19 @@ class ConfigurationTests {
      * Ensure that a provided {@link Supplier} is not invoked when an {@link Option} is present.
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldAvoidSupplierWhenNonNull() {
         final var configuration = ConfigurationBuilder.create()
             .add(Color.GREEN)
             .build();
 
-        // establish a mock supplier for the Color.BLUE
-        // (so we can track interactions with the supplier)
-        final Supplier<Color> blueSupplier = mock(Supplier.class);
-        when(blueSupplier.get()).thenReturn(Color.BLUE);
+        final var supplierCalled = new AtomicBoolean(false);
 
-        assertThat(configuration.getOrDefault(Color.class, blueSupplier))
-            .isEqualTo(Color.GREEN);
+        assertThat(configuration.getOrDefault(Color.class, () -> {
+            supplierCalled.set(true);
+            return Color.BLUE;
+        })).isEqualTo(Color.GREEN);
 
-        // ensure the supplier was never used
-        verify(blueSupplier, times(0)).get();
+        assertThat(supplierCalled).isFalse();
     }
 
     /**

--- a/base-flow/pom.xml
+++ b/base-flow/pom.xml
@@ -35,36 +35,5 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dependency-properties</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>-XX:+EnableDynamicAgentLoading -javaagent:${org.mockito:mockito-core:jar}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/base-flow/src/test/java/build/base/flow/FilteringSubscriberTests.java
+++ b/base-flow/src/test/java/build/base/flow/FilteringSubscriberTests.java
@@ -1,7 +1,6 @@
 package build.base.flow;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,6 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since Aug-2018
  */
 class FilteringSubscriberTests {
+
+    private static final Subscription NO_OP_SUBSCRIPTION = new Subscription() {
+        @Override public void request(final long number) {}
+        @Override public void cancel() {}
+    };
 
     /**
      * Ensure a {@link FilteringSubscriber} can be created.
@@ -28,11 +32,10 @@ class FilteringSubscriberTests {
     @Test
     void shouldObserveFilteredValues() {
 
-        final var subscription = Mockito.mock(Subscription.class);
         final var recordingSubscriber = new RecordingSubscriber<String>();
         final var filteringObserver = FilteringSubscriber.of(s -> s.startsWith("Hello"), recordingSubscriber);
 
-        filteringObserver.onSubscribe(subscription);
+        filteringObserver.onSubscribe(NO_OP_SUBSCRIPTION);
 
         assertThat(recordingSubscriber.isSubscribed())
             .isTrue();
@@ -71,11 +74,10 @@ class FilteringSubscriberTests {
     @Test
     void shouldObserveCompletionWhenFilteringSubscriberObservesCompletion() {
 
-        final var subscription = Mockito.mock(Subscription.class);
         final var recordingSubscriber = new RecordingSubscriber<String>();
         final var filteringObserver = FilteringSubscriber.of(s -> s.startsWith("Hello"), recordingSubscriber);
 
-        filteringObserver.onSubscribe(subscription);
+        filteringObserver.onSubscribe(NO_OP_SUBSCRIPTION);
 
         filteringObserver.onComplete();
 
@@ -89,12 +91,10 @@ class FilteringSubscriberTests {
     @Test
     void shouldObserveAnErrorWhenFilteringObserverObservesAnError() {
 
-        final var subscription = Mockito.mock(Subscription.class);
-
         final var recordingSubscriber = new RecordingSubscriber<String>();
         final var filteringObserver = FilteringSubscriber.of(s -> s.startsWith("Hello"), recordingSubscriber);
 
-        filteringObserver.onSubscribe(subscription);
+        filteringObserver.onSubscribe(NO_OP_SUBSCRIPTION);
 
         assertThat(recordingSubscriber.isSubscribed())
             .isTrue();

--- a/base-flow/src/test/java/build/base/flow/MappingSubscriberTests.java
+++ b/base-flow/src/test/java/build/base/flow/MappingSubscriberTests.java
@@ -1,7 +1,6 @@
 package build.base.flow;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,6 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since Aug-2018
  */
 class MappingSubscriberTests {
+
+    private static final Subscription NO_OP_SUBSCRIPTION = new Subscription() {
+        @Override public void request(final long number) {}
+        @Override public void cancel() {}
+    };
 
     /**
      * Ensure a {@link MappingSubscriber} can be created.
@@ -27,11 +31,10 @@ class MappingSubscriberTests {
     @Test
     void shouldObserveMapValues() {
 
-        final var subscription = Mockito.mock(Subscription.class);
         final var recordingObserver = new RecordingSubscriber<Integer>();
         final var mappingObserver = MappingSubscriber.of(String::length, recordingObserver);
 
-        mappingObserver.onSubscribe(subscription);
+        mappingObserver.onSubscribe(NO_OP_SUBSCRIPTION);
 
         assertThat(recordingObserver.isSubscribed())
             .isTrue();
@@ -59,11 +62,10 @@ class MappingSubscriberTests {
     @Test
     void shouldObserveCompletionWhenMappingSubscriberObservesCompletion() {
 
-        final var subscription = Mockito.mock(Subscription.class);
         final var recordingObserver = new RecordingSubscriber<Integer>();
         final var mappingObserver = MappingSubscriber.of(String::length, recordingObserver);
 
-        mappingObserver.onSubscribe(subscription);
+        mappingObserver.onSubscribe(NO_OP_SUBSCRIPTION);
 
         mappingObserver.onComplete();
 
@@ -77,11 +79,10 @@ class MappingSubscriberTests {
     @Test
     void shouldObserveAnErrorWhenMappingSubscriberObservesAnError() {
 
-        final var subscription = Mockito.mock(Subscription.class);
         final var recordingObserver = new RecordingSubscriber<Integer>();
         final var mappingObserver = MappingSubscriber.of(String::length, recordingObserver);
 
-        mappingObserver.onSubscribe(subscription);
+        mappingObserver.onSubscribe(NO_OP_SUBSCRIPTION);
 
         assertThat(recordingObserver.isSubscribed())
             .isTrue();

--- a/base-flow/src/test/java/build/base/flow/SubscriberRegistryTests.java
+++ b/base-flow/src/test/java/build/base/flow/SubscriberRegistryTests.java
@@ -1,16 +1,13 @@
 package build.base.flow;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link SubscriberRegistry}s.
@@ -29,31 +26,19 @@ class SubscriberRegistryTests {
     }
 
     /**
-     * Creates an unbounded mocked {@link Subscriber}.
-     *
-     * @return a {@link Subscriber}
-     */
-    @SuppressWarnings("unchecked")
-    private <T> Subscriber<T> createUnboundedMockSubscriber() {
-        final Subscriber<T> subscriber = Mockito.mock(Subscriber.class);
-        doCallRealMethod().when(subscriber).onSubscribe(any());
-        return subscriber;
-    }
-
-    /**
      * Ensure a {@link Subscriber} can be subscribed to a {@link SubscriberRegistry}.
      */
     @Test
     void shouldSubscribe() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         subscriberRegistry.subscribe(subscriber);
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isFalse();
+        assertThat(subscriber.throwable()).isEmpty();
     }
 
     /**
@@ -63,22 +48,20 @@ class SubscriberRegistryTests {
     void shouldCancelSubscription() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         subscriberRegistry.subscribe(subscriber);
 
-        final ArgumentCaptor<Subscription> captor = ArgumentCaptor.forClass(Subscription.class);
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isFalse();
+        assertThat(subscriber.throwable()).isEmpty();
 
-        verify(subscriber, times(1)).onSubscribe(captor.capture());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        subscriber.subscription().cancel();
 
-        captor.getValue().cancel();
-
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(1)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isTrue();
+        assertThat(subscriber.throwable()).isEmpty();
     }
 
     /**
@@ -88,21 +71,19 @@ class SubscriberRegistryTests {
     void shouldObserveAnItem() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         subscriberRegistry.subscribe(subscriber);
 
         final String message = "G'day Mate";
 
         subscriberRegistry.publish(message);
 
-        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).hasSize(1);
+        assertThat(subscriber.isCompleted()).isFalse();
+        assertThat(subscriber.throwable()).isEmpty();
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(1)).onNext(captor.capture());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(0)).onError(any());
-
-        assertThat(captor.getValue())
+        assertThat(subscriber.items().getFirst())
             .isEqualTo(message);
     }
 
@@ -113,15 +94,15 @@ class SubscriberRegistryTests {
     void shouldObserveCompletion() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         subscriberRegistry.subscribe(subscriber);
 
         subscriberRegistry.complete();
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(1)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isTrue();
+        assertThat(subscriber.throwable()).isEmpty();
     }
 
     /**
@@ -131,21 +112,16 @@ class SubscriberRegistryTests {
     void shouldObserveAnError() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         subscriberRegistry.subscribe(subscriber);
 
         final Throwable throwable = new RuntimeException("Oops!");
         subscriberRegistry.error(throwable);
 
-        final ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(1)).onError(captor.capture());
-
-        assertThat(captor.getValue())
-            .isEqualTo(throwable);
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isFalse();
+        assertThat(subscriber.throwable()).contains(throwable);
     }
 
     /**
@@ -156,21 +132,17 @@ class SubscriberRegistryTests {
     void shouldNotObserveItemDuringSubscription() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
-
-        doAnswer(invocation -> {
-            invocation.getArgument(0, Subscription.class).request(Long.MAX_VALUE);
-
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>(subscription -> {
+            subscription.request(Long.MAX_VALUE);
             subscriberRegistry.publish("Should Never See This!");
-            return null;
-        }).when(subscriber).onSubscribe(any());
+        });
 
         subscriberRegistry.subscribe(subscriber);
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isFalse();
+        assertThat(subscriber.throwable()).isEmpty();
     }
 
     /**
@@ -181,20 +153,14 @@ class SubscriberRegistryTests {
     void shouldCancelDuringSubscription() {
         final SubscriberRegistry<String> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
-
-        doAnswer(invocation -> {
-            final Subscription subscription = invocation.getArgument(0);
-            subscription.cancel();
-            return null;
-        }).when(subscriber).onSubscribe(any());
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>(Subscription::cancel);
 
         subscriberRegistry.subscribe(subscriber);
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(0)).onNext(any());
-        verify(subscriber, times(1)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).isEmpty();
+        assertThat(subscriber.isCompleted()).isTrue();
+        assertThat(subscriber.throwable()).isEmpty();
     }
 
     /**
@@ -204,7 +170,7 @@ class SubscriberRegistryTests {
     void shouldObserveItemsInOrder() {
         final SubscriberRegistry<Integer> subscriberRegistry = new SubscriberRegistry<>();
 
-        final Subscriber<Integer> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<Integer> subscriber = new TrackingSubscriber<>();
         subscriberRegistry.subscribe(subscriber);
 
         subscriberRegistry.publish(1);
@@ -212,14 +178,12 @@ class SubscriberRegistryTests {
         subscriberRegistry.publish(3);
         subscriberRegistry.publish(4);
 
-        final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).hasSize(4);
+        assertThat(subscriber.isCompleted()).isFalse();
+        assertThat(subscriber.throwable()).isEmpty();
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(4)).onNext(captor.capture());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(0)).onError(any());
-
-        assertThat(captor.getAllValues())
+        assertThat(subscriber.items())
             .containsExactly(1, 2, 3, 4);
     }
 
@@ -230,7 +194,7 @@ class SubscriberRegistryTests {
     void shouldPublishAndComplete() {
         final SubscriberRegistry<String> registry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         registry.subscribe(subscriber);
 
         final String message = "G'day Mate";
@@ -242,17 +206,15 @@ class SubscriberRegistryTests {
 
         registry.complete();
 
-        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(1)).onNext(captor.capture());
-        verify(subscriber, times(1)).onComplete();
-        verify(subscriber, times(0)).onError(any());
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).hasSize(1);
+        assertThat(subscriber.isCompleted()).isTrue();
+        assertThat(subscriber.throwable()).isEmpty();
 
         assertThat(registry.onComplete())
             .isCompleted();
 
-        assertThat(captor.getValue())
+        assertThat(subscriber.items().getFirst())
             .isEqualTo(message);
     }
 
@@ -263,7 +225,7 @@ class SubscriberRegistryTests {
     void shouldPublishAndCompleteDueToError() {
         final SubscriberRegistry<String> registry = new SubscriberRegistry<>();
 
-        final Subscriber<String> subscriber = createUnboundedMockSubscriber();
+        final TrackingSubscriber<String> subscriber = new TrackingSubscriber<>();
         registry.subscribe(subscriber);
 
         final String message = "G'day Mate";
@@ -272,39 +234,33 @@ class SubscriberRegistryTests {
         registry.publish(message);
         registry.error(throwable);
 
-        final ArgumentCaptor<String> itemCaptor = ArgumentCaptor.forClass(String.class);
-        final ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+        assertThat(subscriber.subscription()).isNotNull();
+        assertThat(subscriber.items()).hasSize(1);
+        assertThat(subscriber.isCompleted()).isFalse();
 
-        verify(subscriber, times(1)).onSubscribe(any());
-        verify(subscriber, times(1)).onNext(itemCaptor.capture());
-        verify(subscriber, times(0)).onComplete();
-        verify(subscriber, times(1)).onError(throwableCaptor.capture());
-
-        assertThat(itemCaptor.getValue())
+        assertThat(subscriber.items().getFirst())
             .isEqualTo(message);
 
-        assertThat(throwableCaptor.getValue())
-            .isEqualTo(throwable);
+        assertThat(subscriber.throwable())
+            .contains(throwable);
     }
 
     /**
      * Ensure {@link SubscriberRegistry} prevents subscription once publishing has completed.
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldPreventSubscriptionWhenCompleted() {
         final SubscriberRegistry<String> registry = new SubscriberRegistry<>();
 
         registry.complete();
 
-        assertThrows(IllegalStateException.class, () -> registry.subscribe(Mockito.mock(Subscriber.class)));
+        assertThrows(IllegalStateException.class, () -> registry.subscribe(item -> {}));
     }
 
     /**
      * Ensure {@link SubscriberRegistry} prevents subscription once publishing has completed due to a error.
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldPreventSubscriptionWhenError() {
         final SubscriberRegistry<String> registry = new SubscriberRegistry<>();
         final Throwable throwable = new RuntimeException("Oops!");
@@ -312,7 +268,7 @@ class SubscriberRegistryTests {
         registry.error(throwable);
 
         final Throwable cause = assertThrows(IllegalStateException.class,
-            () -> registry.subscribe(Mockito.mock(Subscriber.class)));
+            () -> registry.subscribe(item -> {}));
 
         assertThat(cause.getCause())
             .isEqualTo(throwable);
@@ -338,5 +294,67 @@ class SubscriberRegistryTests {
 
         assertThat(thirdTry)
             .isFalse();
+    }
+
+    /**
+     * A {@link Subscriber} that records all interactions for assertion in tests.
+     */
+    private static class TrackingSubscriber<T> implements Subscriber<T> {
+
+        @FunctionalInterface
+        interface OnSubscribe {
+            void accept(Subscription subscription);
+        }
+
+        private final List<T> items = new ArrayList<>();
+        private final OnSubscribe onSubscribeAction;
+        private Subscription subscription;
+        private Throwable throwable;
+        private boolean completed;
+
+        TrackingSubscriber() {
+            this(s -> s.request(Long.MAX_VALUE));
+        }
+
+        TrackingSubscriber(final OnSubscribe onSubscribeAction) {
+            this.onSubscribeAction = onSubscribeAction;
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            this.subscription = subscription;
+            this.onSubscribeAction.accept(subscription);
+        }
+
+        @Override
+        public void onNext(final T item) {
+            this.items.add(item);
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            this.throwable = throwable;
+        }
+
+        @Override
+        public void onComplete() {
+            this.completed = true;
+        }
+
+        Subscription subscription() {
+            return this.subscription;
+        }
+
+        List<T> items() {
+            return this.items;
+        }
+
+        Optional<Throwable> throwable() {
+            return Optional.ofNullable(this.throwable);
+        }
+
+        boolean isCompleted() {
+            return this.completed;
+        }
     }
 }

--- a/base-mereology/pom.xml
+++ b/base-mereology/pom.xml
@@ -41,47 +41,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>build.base</groupId>
             <artifactId>base-assertion</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dependency-properties</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <ignoredUnusedDeclaredDependencies>
-                        <!-- needed for javaagent -->
-                        <ignoredUnusedDeclaredDependency>org.mockito:mockito-core</ignoredUnusedDeclaredDependency>
-                    </ignoredUnusedDeclaredDependencies>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>-XX:+EnableDynamicAgentLoading -javaagent:${org.mockito:mockito-core:jar}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/base-query/pom.xml
+++ b/base-query/pom.xml
@@ -34,43 +34,5 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dependency-properties</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <ignoredUnusedDeclaredDependencies>
-                        <!-- needed for javaagent -->
-                        <ignoredUnusedDeclaredDependency>org.mockito:mockito-core</ignoredUnusedDeclaredDependency>
-                    </ignoredUnusedDeclaredDependencies>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>-XX:+EnableDynamicAgentLoading -javaagent:${org.mockito:mockito-core:jar}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/base-retryable/pom.xml
+++ b/base-retryable/pom.xml
@@ -44,37 +44,5 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dependency-properties</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>-XX:+EnableDynamicAgentLoading -javaagent:${org.mockito:mockito-core:jar}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/base-retryable/src/test/java/build/base/retryable/BlockingRetryTests.java
+++ b/base-retryable/src/test/java/build/base/retryable/BlockingRetryTests.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Stack;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static build.base.retryable.ConditionallyRetryable.retrying;
 import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,10 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link BlockingRetry}.
@@ -189,14 +187,14 @@ class BlockingRetryTests {
      * Ensure a {@link BlockingRetry} retries a final time after timing out
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldDelayRetryingFinalTime() {
         assertTimeout(TIMEOUT, () -> {
 
-            final Retryable<Integer> retryable = mock(Retryable.class);
-            when(retryable.get())
-                .thenThrow(new EphemeralFailureException("First Failure"))
-                .thenReturn(123);
+            final AtomicInteger calls = new AtomicInteger();
+            final Retryable<Integer> retryable = () -> {
+                if (calls.incrementAndGet() == 1) throw new EphemeralFailureException("First Failure");
+                return 123;
+            };
 
             final var value = BlockingRetry.retry(
                 retryable,
@@ -205,8 +203,7 @@ class BlockingRetryTests {
                 RetryFrequency.once(Duration.ofMinutes(1)));
 
             assertEquals(123, value);
-
-            verify(retryable, times(2)).get();
+            assertEquals(2, calls.get());
         });
     }
 
@@ -214,17 +211,18 @@ class BlockingRetryTests {
      * Ensure a {@link BlockingRetry} with a timeout of 0 only executes the {@link Retryable} once
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldRetryOnceWithZeroTimeout() {
         assertTimeout(TIMEOUT, () -> {
 
-            final Retryable<Integer> retryable = mock(Retryable.class);
-            when(retryable.get())
-                .thenThrow(new EphemeralFailureException("First Failure"));
+            final AtomicInteger calls = new AtomicInteger();
+            final Retryable<Integer> retryable = () -> {
+                calls.incrementAndGet();
+                throw new EphemeralFailureException("First Failure");
+            };
 
             assertThrows(PermanentFailureException.class, () -> BlockingRetry.retry(retryable, Timeout.ofMillis(0)));
 
-            verify(retryable, times(1)).get();
+            assertEquals(1, calls.get());
         });
     }
 
@@ -390,29 +388,28 @@ class BlockingRetryTests {
      * laundered
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldRetryWhenErrorAndRuntimeExceptionsAreExperienced() {
-        final Retryable<Integer> retryable = mock(Retryable.class);
-        when(retryable.isDone()).thenReturn(false);
-        when(retryable.get())
-            .thenThrow(AssertionError.class)
-            .thenThrow(RuntimeException.class)
-            .thenThrow(Error.class);
+        final AtomicInteger calls = new AtomicInteger();
+        final Retryable<Integer> retryable = () -> {
+            switch (calls.incrementAndGet()) {
+                case 1: throw new AssertionError();
+                case 2: throw new RuntimeException();
+                default: throw new Error();
+            }
+        };
 
         assertThrows(Error.class, () -> BlockingRetry.retry(retryable));
-        verify(retryable, times(3)).get();
+        assertEquals(3, calls.get());
     }
 
     /**
      * Ensure that a {@link Retryable} times out before a {@link MinimumDelay}.
      */
     @Test
-    @SuppressWarnings("unchecked")
     void shouldTimeoutBeforeMinimumDelay() {
         assertTimeout(TIMEOUT, () -> {
 
-            final Retryable<Integer> retryable = mock(Retryable.class);
-            when(retryable.get()).thenReturn(123);
+            final Retryable<Integer> retryable = () -> 123;
 
             final int value = BlockingRetry.retry(retryable,
                 Timeout.ofMillis(1),

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <junit.version>6.0.3</junit.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
         <jakarta-el-api.version>6.0.1</jakarta-el-api.version>
-        <mockito.version>5.23.0</mockito.version>
 
         <!-- Plugin Dependency Versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -291,11 +290,6 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
                 <version>${junit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Removes Mockito from all modules that depended on it (`base-configuration`, `base-flow`, `base-mereology`, `base-query`, `base-retryable`) and replaces every mock with a hand-rolled test double or a simple inline lambda. The `maven-dependency-plugin` and `maven-surefire-plugin` build configuration that each module carried solely to wire Mockito as a `-javaagent` is removed as well, along with the root `mockito.version` property and its `dependencyManagement` entry.

Replacements: a `TrackingSubscriber` inner class in `SubscriberRegistryTests` captures subscription, items, completion, and error state in place of `mock(Subscriber.class)` + `ArgumentCaptor`; a shared `NO_OP_SUBSCRIPTION` constant stands in for mocked `Subscription`s in `FilteringSubscriberTests` and `MappingSubscriberTests`; `AtomicBoolean`/`AtomicInteger` counters replace mocked suppliers and retryables in `ConfigurationTests` and `BlockingRetryTests`.