### PR TITLE
feat(base-query): Indexable(each = true) with contains/doesNotContain

### DIFF
--- a/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
+++ b/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
@@ -27,6 +27,7 @@ import build.base.foundation.tuple.Pair;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -55,6 +56,13 @@ public abstract class AbstractHeapBasedIndex implements Index {
      * {@link Object} index.
      */
     private static final Object NULL_OBJECT = new Object();
+
+    /**
+     * Wraps the set of element-keys stored in the reverse index for a multi-valued {@link Indexable} function,
+     * distinguishing it from a plain scalar value stored in the same map.
+     */
+    private record MultiValuedKeys(Set<Object> keys) {
+    }
 
     /**
      * The {@link Object}s known to the index by {@link Class}.
@@ -104,6 +112,18 @@ public abstract class AbstractHeapBasedIndex implements Index {
     private final Memoizer<Class<?>, Streamable<Function<Object, Object>>> dynamicUniqueFunctionsByClass;
 
     /**
+     * The resolved {@link Indexable#each() each} (non-{@link Unique}) {@link Function}s per {@link Class}, memoized
+     * so that reflection is performed at most once per class.
+     */
+    private final Memoizer<Class<?>, Streamable<Function<Object, Object>>> eachFunctionsByClass;
+
+    /**
+     * The resolved {@link Indexable#each() each} {@link Dynamic} (non-{@link Unique}) {@link Function}s per
+     * {@link Class}, memoized so that reflection is performed at most once per class.
+     */
+    private final Memoizer<Class<?>, Streamable<Function<Object, Object>>> dynamicEachFunctionsByClass;
+
+    /**
      * Constructs an empty {@link AbstractHeapBasedIndex}.
      */
     protected AbstractHeapBasedIndex() {
@@ -114,18 +134,22 @@ public abstract class AbstractHeapBasedIndex implements Index {
         this.uniqueIndexableFunctionsByClass = new Memoizer<>(AbstractHeapBasedIndex::resolveUniqueIndexableFunctions);
         this.dynamicNonUniqueFunctionsByClass = new Memoizer<>(AbstractHeapBasedIndex::resolveDynamicNonUniqueFunctions);
         this.dynamicUniqueFunctionsByClass = new Memoizer<>(AbstractHeapBasedIndex::resolveDynamicUniqueFunctions);
+        this.eachFunctionsByClass = new Memoizer<>(AbstractHeapBasedIndex::resolveEachFunctions);
+        this.dynamicEachFunctionsByClass = new Memoizer<>(AbstractHeapBasedIndex::resolveDynamicEachFunctions);
     }
 
     @Override
     public void index(final Object object) {
         final var objectClass = object.getClass();
         final var nonUniqueFunctions = this.indexableFunctionsByClass.compute(objectClass);
+        final var eachFunctions = this.eachFunctionsByClass.compute(objectClass);
         final var uniqueFunctions = this.uniqueIndexableFunctionsByClass.compute(objectClass);
 
         nonUniqueFunctions.forEach(function -> indexNonUnique(objectClass, function, object));
+        eachFunctions.forEach(function -> indexEach(objectClass, function, object));
         uniqueFunctions.forEach(function -> indexUnique(objectClass, function, object));
 
-        if (isIndexParticipant(objectClass, nonUniqueFunctions, uniqueFunctions)) {
+        if (isIndexParticipant(objectClass, nonUniqueFunctions, eachFunctions, uniqueFunctions)) {
             this.objectByClass.compute(objectClass, (_, existing) -> {
                 final var objects = existing == null ? ConcurrentHashMap.newKeySet() : existing;
                 objects.add(object);
@@ -138,12 +162,14 @@ public abstract class AbstractHeapBasedIndex implements Index {
     public void unindex(final Object object) {
         final var objectClass = object.getClass();
         final var nonUniqueFunctions = this.indexableFunctionsByClass.compute(objectClass);
+        final var eachFunctions = this.eachFunctionsByClass.compute(objectClass);
         final var uniqueFunctions = this.uniqueIndexableFunctionsByClass.compute(objectClass);
 
         nonUniqueFunctions.forEach(function -> unindexNonUnique(objectClass, function, object));
+        eachFunctions.forEach(function -> unindexNonUnique(objectClass, function, object));
         uniqueFunctions.forEach(function -> unindexUnique(objectClass, function, object));
 
-        if (isIndexParticipant(objectClass, nonUniqueFunctions, uniqueFunctions)) {
+        if (isIndexParticipant(objectClass, nonUniqueFunctions, eachFunctions, uniqueFunctions)) {
             this.objectByClass.compute(objectClass, (_, existing) -> {
                 if (existing == null) {
                     return null;
@@ -158,6 +184,7 @@ public abstract class AbstractHeapBasedIndex implements Index {
     public void reindexDynamic(final Object object) {
         final var objectClass = object.getClass();
         this.dynamicNonUniqueFunctionsByClass.compute(objectClass).forEach(function -> reindexNonUnique(objectClass, function, object));
+        this.dynamicEachFunctionsByClass.compute(objectClass).forEach(function -> reindexEach(objectClass, function, object));
         this.dynamicUniqueFunctionsByClass.compute(objectClass).forEach(function -> reindexUnique(objectClass, function, object));
     }
 
@@ -225,6 +252,18 @@ public abstract class AbstractHeapBasedIndex implements Index {
         });
     }
 
+    private void indexEach(final Class<?> objectClass, final Function<Object, Object> function, final Object object) {
+        onNonUniquePair(objectClass, function, pair -> {
+            try {
+                indexMultiValued(object, toElementStream(function.apply(object), objectClass), pair);
+            } catch (final UnsupportedOperationException e) {
+                throw e;
+            } catch (final Throwable e) {
+                throw new UnsupportedOperationException("Failed to index [" + objectClass.getName() + "] as an each function failed to extract elements from the object", e);
+            }
+        });
+    }
+
     private void indexUnique(final Class<?> objectClass, final Function<Object, Object> function, final Object object) {
         onUniquePair(objectClass, function, pair -> {
             try {
@@ -265,6 +304,19 @@ public abstract class AbstractHeapBasedIndex implements Index {
                 putNonUnique(pair, object, toIndexableValue(function.apply(object)));
             } catch (final Throwable e) {
                 throw new UnsupportedOperationException("Failed to reindex [" + objectClass.getName() + "] as a dynamic function failed to extract a value from the object", e);
+            }
+        });
+    }
+
+    private void reindexEach(final Class<?> objectClass, final Function<Object, Object> function, final Object object) {
+        onNonUniquePair(objectClass, function, pair -> {
+            removeNonUnique(pair, object);
+            try {
+                indexMultiValued(object, toElementStream(function.apply(object), objectClass), pair);
+            } catch (final UnsupportedOperationException e) {
+                throw e;
+            } catch (final Throwable e) {
+                throw new UnsupportedOperationException("Failed to reindex [" + objectClass.getName() + "] as a dynamic each function failed to extract elements from the object", e);
             }
         });
     }
@@ -363,6 +415,21 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
     // ---- pair-level helpers
 
+    private static Stream<Object> toElementStream(final Object value, final Class<?> objectClass) {
+        if (value instanceof Stream<?> s) {
+            return s.map(e -> e == null ? NULL_OBJECT : e);
+        } else if (value instanceof Collection<?> c) {
+            return c.stream().map(e -> e == null ? NULL_OBJECT : e);
+        } else if (value instanceof Iterable<?> it) {
+            return StreamSupport.stream(it.spliterator(), false).map(e -> e == null ? NULL_OBJECT : e);
+        } else {
+            throw new UnsupportedOperationException(
+                "@Indexable(each = true) function on [" + objectClass.getName()
+                    + "] must return a Stream, Collection, or Iterable, but returned ["
+                    + (value == null ? "null" : value.getClass().getName()) + "]");
+        }
+    }
+
     private static void putNonUnique(final Pair<ConcurrentHashMap<Object, Object>, ConcurrentHashMap<Object, Set<Object>>> pair,
                                      final Object object,
                                      final Object indexableValue) {
@@ -377,7 +444,17 @@ public abstract class AbstractHeapBasedIndex implements Index {
     private static void removeNonUnique(final Pair<ConcurrentHashMap<Object, Object>, ConcurrentHashMap<Object, Set<Object>>> pair,
                                         final Object object) {
         final var old = pair.first().remove(object);
-        if (old != null) {
+        if (old instanceof MultiValuedKeys(Set<Object> keys)) {
+            for (final var key : keys) {
+                pair.second().compute(key, (_, existing) -> {
+                    if (existing == null) {
+                        return null;
+                    }
+                    existing.remove(object);
+                    return existing.isEmpty() ? null : existing;
+                });
+            }
+        } else if (old != null) {
             pair.second().compute(old, (_, existing) -> {
                 if (existing == null) {
                     return null;
@@ -417,9 +494,11 @@ public abstract class AbstractHeapBasedIndex implements Index {
      */
     private boolean isIndexParticipant(final Class<?> objectClass,
                                        final Streamable<Function<Object, Object>> nonUnique,
+                                       final Streamable<Function<Object, Object>> each,
                                        final Streamable<Function<Object, Object>> unique) {
         return Introspection.hasDeclaredAnnotation(objectClass, Indexable.class)
             || !nonUnique.isEmpty()
+            || !each.isEmpty()
             || !unique.isEmpty();
     }
 
@@ -455,6 +534,118 @@ public abstract class AbstractHeapBasedIndex implements Index {
     }
 
     /**
+     * Indexes each element produced by a multi-valued {@link Indexable} function into the forward and reverse maps.
+     *
+     * @param object   the object being indexed
+     * @param elements the stream of non-{@code null} element keys (nulls already replaced with {@link #NULL_OBJECT})
+     * @param pair     the pair of reverse and forward maps for the function
+     */
+    private static void indexMultiValued(final Object object,
+                                         final Stream<Object> elements,
+                                         final Pair<ConcurrentHashMap<Object, Object>, ConcurrentHashMap<Object, Set<Object>>> pair) {
+
+        final var keys = ConcurrentHashMap.newKeySet();
+
+        elements.forEach(key -> {
+            keys.add(key);
+            pair.second().compute(key, (_, existing) -> {
+                final var set = existing == null ? ConcurrentHashMap.newKeySet() : existing;
+                set.add(object);
+                return set;
+            });
+        });
+
+        pair.first().put(object, new MultiValuedKeys(keys));
+    }
+
+    /**
+     * A {@link Terminal} implementation for checking membership in a multi-valued extracted value.
+     * <p>
+     * When the underlying {@link Indexable} function has been indexed, performs an O(1) reverse-map lookup because
+     * each element was stored as an individual key during {@link #index(Object)}. Falls back to a linear scan that
+     * re-invokes the function and tests containment for unindexed objects.
+     *
+     * @param <Q> the type of {@link Object} being queried
+     * @param <V> the type of value extracted by the {@link Where} clause
+     */
+    private class Contains<Q, V>
+        extends AbstractTerminal<Q, V, Contains<Q, V>> {
+
+        private final Object element;
+
+        Contains(final Where<Q, V> where,
+                 final Object element) {
+
+            super(where);
+            this.element = element;
+        }
+
+        @Override
+        public Stream<Q> findAll() {
+            final var key = this.element == null ? NULL_OBJECT : this.element;
+
+            final var indexPairs = this.where.matchingIndexPairs();
+            if (!indexPairs.isEmpty()) {
+                return indexPairs.stream()
+                    .map(pair -> pair.second().get(key))
+                    .filter(objects -> objects != null && !objects.isEmpty())
+                    .flatMap(Set::stream)
+                    .map(this.where.select.objectClass::cast);
+            }
+
+            // fallback: linear scan with containment check
+            return this.where.select.stream(this.scope)
+                .filter(q -> containsElement(this.where.function.apply(q), this.element));
+        }
+
+        static boolean containsElement(final Object container, final Object element) {
+            if (container instanceof Collection<?> c) {
+                return c.contains(element);
+            }
+            if (container instanceof Stream<?> s) {
+                return s.anyMatch(e -> Objects.equals(e, element));
+            }
+            if (container instanceof Iterable<?> it) {
+                for (final var e : it) {
+                    if (Objects.equals(e, element)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return Objects.equals(container, element);
+        }
+    }
+
+    /**
+     * A {@link Terminal} implementation for checking that an element is absent from a multi-valued extracted value.
+     * <p>
+     * Always performs a linear scan. The reverse index only supports positive membership lookups; negation would
+     * require enumerating all objects and subtracting those in the membership set, which is no better than scanning.
+     *
+     * @param <Q> the type of {@link Object} being queried
+     * @param <V> the type of value extracted by the {@link Where} clause
+     */
+    private class DoesNotContain<Q, V>
+        extends AbstractTerminal<Q, V, DoesNotContain<Q, V>> {
+
+        private final Object element;
+
+        DoesNotContain(final Where<Q, V> where,
+                       final Object element) {
+
+            super(where);
+            this.element = element;
+        }
+
+        @Override
+        public Stream<Q> findAll() {
+            return this.where.select.stream(this.scope)
+                .filter(q -> !Contains.containsElement(this.where.function.apply(q), this.element));
+        }
+    }
+
+    /**
      * Obtains the resolved {@link Indexable} (non-{@link Unique}) {@link Function}s for the specified {@link Class}.
      *
      * @param indexableClass the {@link Class} of queryable
@@ -462,7 +653,9 @@ public abstract class AbstractHeapBasedIndex implements Index {
      */
     protected static Streamable<Function<Object, Object>> resolveIndexableFunctions(final Class<?> indexableClass) {
         return Streamable.of(Introspection.getAllDeclaredFields(indexableClass)
-            .filter(field -> isIndexableFunctionField(field) && field.getAnnotation(Unique.class) == null)
+            .filter(field -> isIndexableFunctionField(field)
+                && !field.getAnnotation(Indexable.class).each()
+                && field.getAnnotation(Unique.class) == null)
             .map(AbstractHeapBasedIndex::resolveFunction));
     }
 
@@ -488,6 +681,24 @@ public abstract class AbstractHeapBasedIndex implements Index {
     protected static Streamable<Function<Object, Object>> resolveDynamicNonUniqueFunctions(final Class<?> indexableClass) {
         return Streamable.of(Introspection.getAllDeclaredFields(indexableClass)
             .filter(field -> isIndexableFunctionField(field)
+                && !field.getAnnotation(Indexable.class).each()
+                && field.getAnnotation(Dynamic.class) != null
+                && field.getAnnotation(Unique.class) == null)
+            .map(AbstractHeapBasedIndex::resolveFunction));
+    }
+
+    protected static Streamable<Function<Object, Object>> resolveEachFunctions(final Class<?> indexableClass) {
+        return Streamable.of(Introspection.getAllDeclaredFields(indexableClass)
+            .filter(field -> isIndexableFunctionField(field)
+                && field.getAnnotation(Indexable.class).each()
+                && field.getAnnotation(Unique.class) == null)
+            .map(AbstractHeapBasedIndex::resolveFunction));
+    }
+
+    protected static Streamable<Function<Object, Object>> resolveDynamicEachFunctions(final Class<?> indexableClass) {
+        return Streamable.of(Introspection.getAllDeclaredFields(indexableClass)
+            .filter(field -> isIndexableFunctionField(field)
+                && field.getAnnotation(Indexable.class).each()
                 && field.getAnnotation(Dynamic.class) != null
                 && field.getAnnotation(Unique.class) == null)
             .map(AbstractHeapBasedIndex::resolveFunction));
@@ -684,6 +895,16 @@ public abstract class AbstractHeapBasedIndex implements Index {
         @Override
         public Terminal<Q, Matches<Q, V>> matches(final Predicate<? super V> predicate) {
             return new Matches<>(this, predicate);
+        }
+
+        @Override
+        public Terminal<Q, ?> contains(final Object element) {
+            return new Contains<Q, V>(this, element);
+        }
+
+        @Override
+        public Terminal<Q, ?> doesNotContain(final Object element) {
+            return new DoesNotContain<Q, V>(this, element);
         }
     }
 

--- a/base-query/src/main/java/build/base/query/Condition.java
+++ b/base-query/src/main/java/build/base/query/Condition.java
@@ -20,8 +20,10 @@ package build.base.query;
  * #L%
  */
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * Provides a mechanism to specify a condition for filtering {@link Object}s of a specific {@link Class} being queried
@@ -67,4 +69,28 @@ public interface Condition<Q, V> {
     default Terminal<Q, ?> doesNotMatch(final Predicate<? super V> predicate) {
         return matches(predicate.negate());
     }
+
+    /**
+     * Specifies an element that must be contained within the extracted value, which is expected to be a
+     * {@link Collection}, {@link Stream}, or {@link Iterable}.
+     * <p>
+     * When the underlying {@link Indexable} {@link java.util.function.Function} has been indexed, this performs an O(1)
+     * lookup; otherwise it falls back to a linear scan.
+     *
+     * @param element the element that must be present
+     * @return a {@link Terminal} that can be used to obtain the results
+     */
+    Terminal<Q, ?> contains(Object element);
+
+    /**
+     * Specifies an element that must not be contained within the extracted value, which is expected to be a
+     * {@link java.util.Collection}, {@link java.util.stream.Stream}, or {@link Iterable}.
+     * <p>
+     * This always performs a linear scan because the reverse index only supports positive membership lookups; negation
+     * cannot be answered from the index alone without enumerating all objects.
+     *
+     * @param element the element that must be absent
+     * @return a {@link Terminal} that can be used to obtain the results
+     */
+    Terminal<Q, ?> doesNotContain(Object element);
 }

--- a/base-query/src/main/java/build/base/query/Indexable.java
+++ b/base-query/src/main/java/build/base/query/Indexable.java
@@ -38,4 +38,14 @@ import java.util.function.Function;
 @Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Indexable {
 
+    /**
+     * When {@code true}, the function is expected to return a {@link java.util.stream.Stream},
+     * {@link java.util.Collection}, or {@link Iterable}, and each element of that container is indexed
+     * individually as a separate key.  This enables O(1) {@link Condition#contains} lookups.
+     * <p>
+     * When {@code false} (the default), the return value of the function is treated as a single scalar key.
+     *
+     * @return {@code true} if each element should be indexed separately
+     */
+    boolean each() default false;
 }

--- a/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
+++ b/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
@@ -3,10 +3,12 @@ package build.base.query;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -802,6 +804,253 @@ public interface IndexCompatibilityTests {
     }
 
     /**
+     * Demonstrates the difference between a plain {@link Indexable} function and one annotated with
+     * {@code @Indexable(each = true)}.
+     *
+     * <p>Both fields on {@link ScalarVsEach} return a {@link List}{@code <Color>}, but they are indexed differently:
+     * <ul>
+     *   <li>{@code COLORS_SCALAR} — the whole {@link List} is the key; {@code isEqualTo(list)} finds the object and
+     *       {@code contains(element)} returns nothing because no individual element is a key.</li>
+     *   <li>{@code COLORS_EACH} — each {@link Color} is an individual key; {@code contains(element)} finds the object
+     *       and {@code isEqualTo(list)} returns nothing because the whole list is not a key.</li>
+     * </ul>
+     */
+    @Test
+    default void shouldDistinguishScalarIndexingFromEachIndexing() {
+        final var index = createIndex();
+        final var object = new ScalarVsEach(Color.RED, Color.GREEN);
+        index.index(object);
+
+        // scalar: the whole list is the key
+        assertThat(index.match(ScalarVsEach.class)
+            .where(ScalarVsEach.COLORS_SCALAR)
+            .isEqualTo(List.of(Color.RED, Color.GREEN))
+            .findAll())
+            .containsExactly(object);
+
+        assertThat(index.match(ScalarVsEach.class)
+            .where(ScalarVsEach.COLORS_SCALAR)
+            .contains(Color.RED)
+            .findAll())
+            .isEmpty();
+
+        // each: individual elements are keys
+        assertThat(index.match(ScalarVsEach.class)
+            .where(ScalarVsEach.COLORS_EACH)
+            .contains(Color.RED)
+            .findAll())
+            .containsExactly(object);
+
+        assertThat(index.match(ScalarVsEach.class)
+            .where(ScalarVsEach.COLORS_EACH)
+            .isEqualTo(List.of(Color.RED, Color.GREEN))
+            .findAll())
+            .isEmpty();
+    }
+
+    /**
+     * Ensure objects with a multi-valued {@link Indexable} function can be queried with {@code contains}.
+     */
+    @Test
+    default void shouldIndexAndQueryClassWithMultiValuedIndexableField() {
+        final var index = createIndex();
+
+        final var redGreen = new MultiColored(Color.RED, Color.GREEN);
+        final var greenBlue = new MultiColored(Color.GREEN, Color.BLUE);
+        index.index(redGreen);
+        index.index(greenBlue);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .contains(Color.RED)
+            .findAll())
+            .containsExactly(redGreen);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .contains(Color.GREEN)
+            .findAll())
+            .containsExactlyInAnyOrder(redGreen, greenBlue);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .contains(Color.BLUE)
+            .findAll())
+            .containsExactly(greenBlue);
+    }
+
+    /**
+     * Ensure objects with a multi-valued {@link Indexable} function can be unindexed cleanly.
+     */
+    @Test
+    default void shouldUnindexObjectWithMultiValuedIndexableField() {
+        final var index = createIndex();
+
+        final var redGreen = new MultiColored(Color.RED, Color.GREEN);
+        final var greenBlue = new MultiColored(Color.GREEN, Color.BLUE);
+        index.index(redGreen);
+        index.index(greenBlue);
+
+        index.unindex(redGreen);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .contains(Color.RED)
+            .findAll())
+            .isEmpty();
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .contains(Color.GREEN)
+            .findAll())
+            .containsExactly(greenBlue);
+    }
+
+    /**
+     * Ensure a multi-valued {@link Indexable} function that returns a {@link java.util.Collection} is indexed and
+     * queried correctly (exercises the {@code Collection} branch of the indexing path).
+     */
+    @Test
+    default void shouldIndexAndQueryClassWithCollectionMultiValuedField() {
+        final var index = createIndex();
+
+        final var redGreen = new MultiColoredWithList(Color.RED, Color.GREEN);
+        final var greenBlue = new MultiColoredWithList(Color.GREEN, Color.BLUE);
+        index.index(redGreen);
+        index.index(greenBlue);
+
+        assertThat(index.match(MultiColoredWithList.class)
+            .where(MultiColoredWithList.COLORS)
+            .contains(Color.RED)
+            .findAll())
+            .containsExactly(redGreen);
+
+        assertThat(index.match(MultiColoredWithList.class)
+            .where(MultiColoredWithList.COLORS)
+            .contains(Color.GREEN)
+            .findAll())
+            .containsExactlyInAnyOrder(redGreen, greenBlue);
+    }
+
+    /**
+     * Ensure a multi-valued {@link Indexable} function that returns a plain {@link Iterable} (not a
+     * {@link java.util.Collection}) is indexed and queried correctly (exercises the {@code Iterable} branch).
+     */
+    @Test
+    default void shouldIndexAndQueryClassWithIterableMultiValuedField() {
+        final var index = createIndex();
+
+        final var redGreen = new MultiColoredWithIterable(Color.RED, Color.GREEN);
+        final var greenBlue = new MultiColoredWithIterable(Color.GREEN, Color.BLUE);
+        index.index(redGreen);
+        index.index(greenBlue);
+
+        assertThat(index.match(MultiColoredWithIterable.class)
+            .where(MultiColoredWithIterable.COLORS)
+            .contains(Color.RED)
+            .findAll())
+            .containsExactly(redGreen);
+
+        assertThat(index.match(MultiColoredWithIterable.class)
+            .where(MultiColoredWithIterable.COLORS)
+            .contains(Color.GREEN)
+            .findAll())
+            .containsExactlyInAnyOrder(redGreen, greenBlue);
+    }
+
+    /**
+     * Ensure reindexing a multi-valued object removes the old element keys and adds the new ones.
+     */
+    @Test
+    default void shouldReindexObjectWithMultiValuedIndexableField() {
+        final var index = createIndex();
+
+        final var object = new MutableMultiColored(Color.RED, Color.GREEN);
+        index.index(object);
+
+        object.setColors(Color.GREEN, Color.BLUE);
+        index.reindex(object);
+
+        assertThat(index.match(MutableMultiColored.class)
+            .where(MutableMultiColored.COLORS)
+            .contains(Color.RED)
+            .findAll())
+            .isEmpty();
+
+        assertThat(index.match(MutableMultiColored.class)
+            .where(MutableMultiColored.COLORS)
+            .contains(Color.GREEN)
+            .findAll())
+            .containsExactly(object);
+
+        assertThat(index.match(MutableMultiColored.class)
+            .where(MutableMultiColored.COLORS)
+            .contains(Color.BLUE)
+            .findAll())
+            .containsExactly(object);
+    }
+
+    /**
+     * Ensure {@code contains} falls back to a linear scan when the function is not {@link Indexable}.
+     */
+    @Test
+    default void shouldContainsFallBackToLinearScanForNonIndexedFunction() {
+        final var index = createIndex();
+
+        final var redGreen = new MultiColored(Color.RED, Color.GREEN);
+        final var greenBlue = new MultiColored(Color.GREEN, Color.BLUE);
+        index.index(redGreen);
+        index.index(greenBlue);
+
+        final Function<MultiColored, Stream<Color>> nonIndexed = c -> MultiColored.COLORS.apply(c);
+
+        assertThat(index.match(MultiColored.class)
+            .where(nonIndexed)
+            .contains(Color.RED)
+            .findAll())
+            .containsExactly(redGreen);
+
+        assertThat(index.match(MultiColored.class)
+            .where(nonIndexed)
+            .contains(Color.GREEN)
+            .findAll())
+            .containsExactlyInAnyOrder(redGreen, greenBlue);
+    }
+
+    /**
+     * Ensure {@code doesNotContain} returns objects whose multi-valued field does not include the specified element.
+     */
+    @Test
+    default void shouldQueryDoesNotContainWithMultiValuedField() {
+        final var index = createIndex();
+
+        final var redGreen = new MultiColored(Color.RED, Color.GREEN);
+        final var greenBlue = new MultiColored(Color.GREEN, Color.BLUE);
+        final var onlyBlue = new MultiColored(Color.BLUE);
+        index.index(redGreen);
+        index.index(greenBlue);
+        index.index(onlyBlue);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .doesNotContain(Color.RED)
+            .findAll())
+            .containsExactlyInAnyOrder(greenBlue, onlyBlue);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .doesNotContain(Color.GREEN)
+            .findAll())
+            .containsExactly(onlyBlue);
+
+        assertThat(index.match(MultiColored.class)
+            .where(MultiColored.COLORS)
+            .doesNotContain(Color.BLUE)
+            .findAll())
+            .containsExactly(redGreen);
+    }
+
+    /**
      * A simple {@link Enum} for testing.
      */
     @Indexable
@@ -1007,6 +1256,125 @@ public interface IndexCompatibilityTests {
 
         public void setId(final String id) {
             this.id = id;
+        }
+    }
+
+    /**
+     * A class with two {@link Indexable} functions over the same {@link List}{@code <Color>} field, one scalar and
+     * one each, used to demonstrate the difference between the two indexing modes.
+     */
+    class ScalarVsEach {
+
+        /** The whole {@link List} is the index key. */
+        @Indexable
+        public static final Function<ScalarVsEach, List<Color>> COLORS_SCALAR = o -> o.colors;
+
+        /** Each {@link Color} in the {@link List} is an individual index key. */
+        @Indexable(each = true)
+        public static final Function<ScalarVsEach, List<Color>> COLORS_EACH = o -> o.colors;
+
+        private final List<Color> colors;
+
+        ScalarVsEach(final Color... colors) {
+            this.colors = List.of(colors);
+        }
+    }
+
+    /**
+     * A class with a multi-valued {@link Indexable} function that returns a {@link Stream}.
+     */
+    class MultiColored {
+
+        @Indexable(each = true)
+        public static final Function<MultiColored, Stream<Color>> COLORS = c -> c.colors.stream();
+
+        private final List<Color> colors;
+
+        MultiColored(final Color... colors) {
+            this.colors = List.of(colors);
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof MultiColored mc && this.colors.equals(mc.colors);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.colors.hashCode();
+        }
+    }
+
+    /**
+     * A class with a multi-valued {@link Indexable} function that returns a {@link List} (exercises the
+     * {@link java.util.Collection} indexing branch).
+     */
+    class MultiColoredWithList {
+
+        @Indexable(each = true)
+        public static final Function<MultiColoredWithList, List<Color>> COLORS = c -> c.colors;
+
+        private final List<Color> colors;
+
+        MultiColoredWithList(final Color... colors) {
+            this.colors = List.of(colors);
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof MultiColoredWithList mc && this.colors.equals(mc.colors);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.colors.hashCode();
+        }
+    }
+
+    /**
+     * A class with a multi-valued {@link Indexable} function that returns a plain {@link Iterable} that is not a
+     * {@link java.util.Collection} (exercises the {@code Iterable} indexing branch).
+     */
+    class MultiColoredWithIterable {
+
+        @Indexable(each = true)
+        public static final Function<MultiColoredWithIterable, Iterable<Color>> COLORS =
+            c -> () -> c.colors.iterator();
+
+        private final List<Color> colors;
+
+        MultiColoredWithIterable(final Color... colors) {
+            this.colors = List.of(colors);
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof MultiColoredWithIterable mc && this.colors.equals(mc.colors);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.colors.hashCode();
+        }
+    }
+
+    /**
+     * A mutable class with a multi-valued {@link Indexable} function, used to verify that reindexing after mutation
+     * removes the old element keys and adds the new ones.
+     */
+    class MutableMultiColored {
+
+        @Indexable(each = true)
+        public static final Function<MutableMultiColored, Stream<Color>> COLORS = c -> c.colors.stream();
+
+        private List<Color> colors;
+
+        MutableMultiColored(final Color... colors) {
+            this.colors = List.of(colors);
+        }
+
+        void setColors(final Color... colors) {
+            this.colors = List.of(colors);
         }
     }
 }


### PR DESCRIPTION
- `@Indexable` gains an `each()` attribute (default `false`). When `each = true`, the function is expected to return a `Stream`, `Collection`, or `Iterable`, and each element is indexed individually as a separate reverse-map key. When `each = false` (the default), the return value is treated as a single scalar key, exactly as before. Intent is declared at the field rather than inferred at runtime from the return type, so a function returning `List<Tag>` is never silently treated as multi-valued unless the author explicitly opts in.
- `AbstractHeapBasedIndex` routes scalar and each functions through entirely separate code paths (`indexNonUnique`/`indexEach`, `reindexNonUnique`/`reindexEach`) backed by two new memoizers. The previous `putNonUniqueValue` with its runtime `instanceof` dispatch is removed. If an `each = true` function returns a non-container value, it throws at index time with a clear message.
- `Condition` gains `contains(Object element)` for O(1) indexed membership lookup (falling back to a linear scan for non-indexed functions) and `doesNotContain(Object element)` which always scans. A `matches`-based default was considered for `doesNotContain` and rejected: `Matches.findAll()` iterates over individual reverse-map keys rather than the original container, which would return wrong results for indexed each-functions.
- `shouldDistinguishScalarIndexingFromEachIndexing` puts both modes side by side on the same `List<Color>` field -- `COLORS_SCALAR` with `isEqualTo(list)` and `COLORS_EACH` with `contains(element)` — making the difference concrete and executable. Additional contract tests cover `Collection` and `Iterable` element types, reindex after mutation, the non-indexed fallback path, and `doesNotContain` exclusion semantics.