### PR TITLE
feat(base-telemetry-javac): extract MessagerBasedTelemetryRecorder

### DIFF
--- a/base-telemetry-javac/pom.xml
+++ b/base-telemetry-javac/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>build.base</groupId>
+        <artifactId>base-project</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>base-telemetry-javac</artifactId>
+
+    <name>base.build Telemetry (javac)</name>
+
+    <description>Javac Messager-based Telemetry Recording for annotation processors</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-foundation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-telemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-telemetry-foundation</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/base-telemetry-javac/src/main/java/build/base/telemetry/javac/MessagerBasedTelemetryRecorder.java
+++ b/base-telemetry-javac/src/main/java/build/base/telemetry/javac/MessagerBasedTelemetryRecorder.java
@@ -1,8 +1,8 @@
-package build.base.telemetry.foundation;
+package build.base.telemetry.javac;
 
 /*-
  * #%L
- * base.build Telemetry Foundation
+ * base.build Telemetry (javac)
  * %%
  * Copyright (C) 2025 Workday Inc
  * %%
@@ -33,6 +33,7 @@ import build.base.telemetry.Telemetry;
 import build.base.telemetry.TelemetryRecorder;
 import build.base.telemetry.TelemetryRecorderFactory;
 import build.base.telemetry.Warning;
+import build.base.telemetry.foundation.AbstractTelemetryRecorder;
 
 import java.net.URI;
 import java.util.Objects;

--- a/base-telemetry-javac/src/main/java/module-info.java
+++ b/base-telemetry-javac/src/main/java/module-info.java
@@ -1,15 +1,15 @@
 /*-
  * #%L
- * base.build Telemetry Foundation
+ * base.build Telemetry (javac)
  * %%
- * Copyright (C) 2025 Workday Inc
+ * Copyright (C) 2026 Workday Inc
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,14 +18,17 @@
  * #L%
  */
 /**
- * Defines the <i>Base Telemetry</i> foundation classes.
+ * Defines the <i>javac Messager-based Telemetry Recorder</i> for use in annotation processors.
  *
- * @author brian.oliver
- * @since May-2024
+ * @author reed.vonredwitz
+ * @since Jun-2026
  */
-module build.base.telemetry.foundation {
+module build.base.telemetry.javac {
+    requires java.compiler;
+
     requires build.base.foundation;
     requires build.base.telemetry;
+    requires build.base.telemetry.foundation;
 
-    exports build.base.telemetry.foundation;
+    exports build.base.telemetry.javac;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <module>base-telemetry</module>
         <module>base-telemetry-ansi</module>
         <module>base-telemetry-foundation</module>
+        <module>base-telemetry-javac</module>
         <module>base-template</module>
         <module>base-template-processor</module>
         <module>base-template-test</module>
@@ -248,6 +249,11 @@
             <dependency>
                 <groupId>build.base</groupId>
                 <artifactId>base-telemetry-foundation</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>build.base</groupId>
+                <artifactId>base-telemetry-javac</artifactId>
                 <version>${revision}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
`java.compiler` is a tooling module with no place in a production runtime image. Any library depending on `base-telemetry-foundation` previously inherited it transitively, which unnecessarily inflated jlink images. The extraction follows the same boundary principle as `base-telemetry-ansi`: one module per recorder backend, named for its dependency.

- Introduces a new `base-telemetry-javac` module containing `MessagerBasedTelemetryRecorder`, previously in `base-telemetry-foundation`
- Removes `requires java.compiler` from `base-telemetry-foundation`, so consumers of the telemetry foundation no longer transitively pull in the compiler tooling module
- The new module lives at `build.base.telemetry.javac` and explicitly declares `requires java.compiler`, keeping that dependency scoped to annotation processor consumers only