### PR TITLE
feat(base-query): add isIn/isNotIn, isNull/isNotNull, and Terminal.count()

### DIFF
--- a/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
+++ b/base-query/src/main/java/build/base/query/AbstractHeapBasedIndex.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -40,6 +41,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -906,6 +908,11 @@ public abstract class AbstractHeapBasedIndex implements Index {
         public Terminal<Q, ?> doesNotContain(final Object element) {
             return new DoesNotContain<Q, V>(this, element);
         }
+
+        @Override
+        public IsIn<Q, V> isIn(final Collection<? extends V> values) {
+            return new IsIn<>(this, values);
+        }
     }
 
 
@@ -1021,6 +1028,55 @@ public abstract class AbstractHeapBasedIndex implements Index {
 
             return this.where.select.stream(this.scope)
                 .filter(queryable -> !Objects.equals(this.where.nonNull(this.where.function.apply(queryable)), this.value));
+        }
+    }
+
+
+    /**
+     * A {@link Terminal} implementation for checking if a value is one of a specified set of values.
+     * <p>
+     * When the underlying {@link Indexable} function has been indexed, performs one reverse-map lookup per value and
+     * unions the results. Falls back to a linear scan testing membership for unindexed objects.
+     *
+     * @param <Q> the type of {@link Object}
+     * @param <V> the type of value
+     */
+    private class IsIn<Q, V>
+        extends AbstractTerminal<Q, V, IsIn<Q, V>> {
+
+        /**
+         * The non-{@code null} values to compare against.
+         */
+        private final Set<Object> values;
+
+        IsIn(final Where<Q, V> where, final Collection<? extends V> values) {
+            super(where);
+            this.values = values.stream()
+                .map(where::nonNull)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        @Override
+        public Stream<Q> findAll() {
+            final var uniquePairs = this.where.matchingUniquePairs();
+            if (!uniquePairs.isEmpty()) {
+                return uniquePairs.stream()
+                    .flatMap(pair -> this.values.stream().map(pair.second()::get))
+                    .filter(Objects::nonNull)
+                    .map(this.where.select.objectClass::cast);
+            }
+
+            final var indexPairs = this.where.matchingIndexPairs();
+            if (!indexPairs.isEmpty()) {
+                return indexPairs.stream()
+                    .flatMap(pair -> this.values.stream().map(pair.second()::get))
+                    .filter(objects -> objects != null && !objects.isEmpty())
+                    .flatMap(Set::stream)
+                    .map(this.where.select.objectClass::cast);
+            }
+
+            return this.where.select.stream(this.scope)
+                .filter(queryable -> this.values.contains(this.where.nonNull(this.where.function.apply(queryable))));
         }
     }
 

--- a/base-query/src/main/java/build/base/query/Condition.java
+++ b/base-query/src/main/java/build/base/query/Condition.java
@@ -53,6 +53,55 @@ public interface Condition<Q, V> {
     Terminal<Q, ?> isNotEqualTo(V value);
 
     /**
+     * Specifies that the extracted value must be {@code null}.
+     * <p>
+     * The index normalizes {@code null} to an internal sentinel, so this is a thin wrapper around
+     * {@link #isEqualTo(Object)} and benefits from the same indexed lookup.
+     *
+     * @return a {@link Terminal} that can be used to obtain the results
+     */
+    default Terminal<Q, ?> isNull() {
+        return isEqualTo(null);
+    }
+
+    /**
+     * Specifies that the extracted value must not be {@code null}.
+     * <p>
+     * A thin wrapper around {@link #isNotEqualTo(Object)}.
+     *
+     * @return a {@link Terminal} that can be used to obtain the results
+     */
+    default Terminal<Q, ?> isNotNull() {
+        return isNotEqualTo(null);
+    }
+
+    /**
+     * Specifies a {@link Collection} of values, one of which must successfully compare with the extracted value
+     * using {@link Objects#equals(Object, Object)}.
+     * <p>
+     * When the underlying {@link Indexable} {@link java.util.function.Function} has been indexed, this performs one
+     * reverse-map lookup per value and unions the results; otherwise it falls back to a linear scan.
+     *
+     * @param values the values, one of which must successfully compare
+     * @return a {@link Terminal} that can be used to obtain the results
+     */
+    Terminal<Q, ?> isIn(Collection<? extends V> values);
+
+    /**
+     * Specifies a {@link Collection} of values, none of which may successfully compare with the extracted value
+     * using {@link Objects#equals(Object, Object)}.
+     * <p>
+     * This always performs a linear scan because the reverse index only supports positive membership lookups;
+     * negation cannot be answered from the index alone without enumerating all objects.
+     *
+     * @param values the values, none of which may successfully compare
+     * @return a {@link Terminal} that can be used to obtain the results
+     */
+    default Terminal<Q, ?> isNotIn(final Collection<? extends V> values) {
+        return doesNotMatch(values::contains);
+    }
+
+    /**
      * Specifies a {@link Predicate} that must successfully match the extracted value.
      *
      * @param predicate the {@link Predicate} that must match

--- a/base-query/src/main/java/build/base/query/Terminal.java
+++ b/base-query/src/main/java/build/base/query/Terminal.java
@@ -128,4 +128,13 @@ public interface Terminal<Q, T extends Terminal<Q, T>> {
             throw new NoSuchElementException("No single matching value available satisfying the query");
         }
     }
+
+    /**
+     * Obtains the number of {@link Object}s that match the query.
+     *
+     * @return the number of matching {@link Object}s
+     */
+    default long count() {
+        return findAll().count();
+    }
 }

--- a/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
+++ b/base-query/src/test/java/build/base/query/IndexCompatibilityTests.java
@@ -3,6 +3,7 @@ package build.base.query;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -577,6 +578,122 @@ public interface IndexCompatibilityTests {
             .isNotEqualTo(null)
             .findFirst()
         ).isEmpty();
+    }
+
+    /**
+     * Ensure {@link Condition#isNull()} finds objects whose extracted value is {@code null}, delegating to
+     * {@link Condition#isEqualTo(Object) isEqualTo(null)}.
+     */
+    @Test
+    default void shouldFindObjectsWithNullValue() {
+        final var index = createIndex();
+        final var withNull = new NullColorful();
+        index.index(withNull);
+
+        assertThat(index.match(NullColorful.class)
+            .where(NullColorful.COLOR)
+            .isNull()
+            .findFirst()
+        ).contains(withNull);
+    }
+
+    /**
+     * Ensure {@link Condition#isNotNull()} excludes objects whose extracted value is {@code null}, delegating to
+     * {@link Condition#isNotEqualTo(Object) isNotEqualTo(null)}.
+     */
+    @Test
+    default void shouldExcludeObjectsWithNullValueWhenIsNotNull() {
+        final var index = createIndex();
+        final var withNull = new NullColorful();
+        index.index(withNull);
+
+        assertThat(index.match(NullColorful.class)
+            .where(NullColorful.COLOR)
+            .isNotNull()
+            .findFirst()
+        ).isEmpty();
+    }
+
+    /**
+     * Ensure {@link Terminal#count()} returns the number of matching objects without requiring callers to write
+     * {@code findAll().count()}.
+     */
+    @Test
+    default void shouldCountMatchingObjects() {
+        final var index = createIndex();
+        index.index(Color.RED);
+        index.index(Color.GREEN);
+        index.index(Color.BLUE);
+
+        assertThat(index.match(Color.class).findAll().count()).isEqualTo(3);
+        assertThat(index.match(Color.class).count()).isEqualTo(3);
+
+        assertThat(index.match(Color.class)
+            .where(Color.NAME)
+            .isNotEqualTo("RED")
+            .count()
+        ).isEqualTo(2);
+    }
+
+    /**
+     * Ensure {@link Condition#isIn(java.util.Collection)} returns objects whose indexed value matches any of the
+     * specified values, using the indexed path.
+     */
+    @Test
+    default void shouldReturnObjectsInValueSet() {
+        final var index = createIndex();
+        index.index(Color.RED);
+        index.index(Color.GREEN);
+        index.index(Color.BLUE);
+
+        assertThat(index.match(Color.class)
+            .where(Color.NAME)
+            .isIn(List.of("RED", "BLUE"))
+            .findAll()
+            .toList()
+        ).containsExactlyInAnyOrder(Color.RED, Color.BLUE);
+
+        assertThat(index.match(Color.class)
+            .where(Color.NAME)
+            .isIn(List.of())
+            .findAll()
+        ).isEmpty();
+    }
+
+    /**
+     * Ensure {@link Condition#isIn(java.util.Collection)} falls back to a linear scan on the non-{@link Indexable}
+     * path, and correctly matches a {@code null} member of the value set.
+     */
+    @Test
+    default void shouldReturnObjectsInValueSetOnFallbackPath() {
+        final var index = createIndex();
+        final var withNull = new NullFallbackColorful();
+        index.add(NullFallbackColorful.class, withNull);
+
+        assertThat(index.match(NullFallbackColorful.class)
+            .where(NullFallbackColorful.COLOR)
+            .isIn(Arrays.asList(Color.RED, null))
+            .findFirst()
+        ).contains(withNull);
+    }
+
+    /**
+     * Ensure {@link Condition#isNotIn(java.util.Collection)} excludes objects whose indexed value matches any of the
+     * specified values.
+     */
+    @Test
+    default void shouldReturnObjectsNotInValueSet() {
+        final var index = createIndex();
+        index.index(Color.RED);
+        index.index(Color.GREEN);
+        index.index(Color.BLUE);
+
+        assertThat(index.match(Color.class)
+            .where(Color.NAME)
+            .isNotIn(List.of("RED", "BLUE"))
+            .findAll()
+            .toList()
+        ).containsExactly(Color.GREEN);
     }
 
     /**


### PR DESCRIPTION
This adds three query operators to base-query's `Condition`/`Terminal` API. `Condition.isIn(Collection<V>)` performs one reverse-map lookup per value and unions the results when the underlying `Indexable` function is indexed, falling back to a linear scan otherwise; `Condition.isNotIn(Collection<V>)` is a default method built on `doesNotMatch(values::contains)` since negation cannot be answered from a positive reverse-index without enumerating every object. `Condition.isNull()` and `Condition.isNotNull()` are thin default wrappers around `isEqualTo(null)` and `isNotEqualTo(null)`, so they inherit the same indexed-vs-scan behavior for free. `Terminal.count()` is a small convenience default delegating to `findAll().count()`, sparing callers from writing that boilerplate themselves.