### PR TITLE
chore(base-logging): move LogRecordPublisher from base-flow to base-logging

### DIFF
--- a/base-flow/src/main/java/module-info.java
+++ b/base-flow/src/main/java/module-info.java
@@ -24,7 +24,6 @@
  * @since Oct-2024
  */
 module build.base.flow {
-    requires java.logging;
     requires build.base.foundation;
 
     exports build.base.flow;

--- a/base-logging/pom.xml
+++ b/base-logging/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>base-foundation</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>build.base</groupId>
+            <artifactId>base-flow</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -33,12 +38,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>build.base</groupId>
-            <artifactId>base-flow</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/base-logging/src/main/java/build/base/logging/LogRecordPublisher.java
+++ b/base-logging/src/main/java/build/base/logging/LogRecordPublisher.java
@@ -1,8 +1,8 @@
-package build.base.flow;
+package build.base.logging;
 
 /*-
  * #%L
- * base.build Flow
+ * base.build Logging
  * %%
  * Copyright (C) 2025 Workday Inc
  * %%
@@ -19,6 +19,10 @@ package build.base.flow;
  * limitations under the License.
  * #L%
  */
+
+import build.base.flow.Publisher;
+import build.base.flow.Subscriber;
+import build.base.flow.SubscriberRegistry;
 
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;

--- a/base-logging/src/main/java/module-info.java
+++ b/base-logging/src/main/java/module-info.java
@@ -25,6 +25,7 @@
  */
 module build.base.logging {
     requires java.logging;
+    requires build.base.flow;
     requires build.base.foundation;
 
     exports build.base.logging;

--- a/base-logging/src/test/java/build/base/logging/LoggerTests.java
+++ b/base-logging/src/test/java/build/base/logging/LoggerTests.java
@@ -1,6 +1,5 @@
 package build.base.logging;
 
-import build.base.flow.LogRecordPublisher;
 import build.base.flow.RecordingSubscriber;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
`LogRecordPublisher` is a `java.util.logging` `Handler` that publishes `LogRecord`s to `base-flow` subscribers, but it lived in `base-flow`, forcing that module to `require java.logging` for the sake of a single class that's really about logging integration, not flow itself.

This moves `LogRecordPublisher` into `base-logging` under the `build.base.logging` package, drops `requires java.logging` from `base-flow/module-info.java`, and adds `build.base.flow` as a compile-scope (previously test-scope) dependency of `base-logging` so it can still use `Publisher`, `Subscriber`, and `SubscriberRegistry`. `base-logging/module-info.java` now `requires build.base.flow` accordingly, and `LoggerTests` no longer needs the old `build.base.flow.LogRecordPublisher` import.