### PR TITLE
fix(base-io): stop excessive re-reads in LookaheadReader's single-char lookahead path

### DIFF
--- a/base-io/src/main/java/build/base/io/LookaheadReader.java
+++ b/base-io/src/main/java/build/base/io/LookaheadReader.java
@@ -171,7 +171,7 @@ public class LookaheadReader
      * available
      */
     private boolean prepare() {
-        return prepare(DEFAULT_LOOKAHEAD);
+        return prepare(1);
     }
 
     /**

--- a/base-io/src/test/java/build/base/io/LookaheadReaderTests.java
+++ b/base-io/src/test/java/build/base/io/LookaheadReaderTests.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -254,5 +255,35 @@ public class LookaheadReaderTests {
 
         assertThat(reader.consume(initialBufferSize * 2))
             .isEqualTo(Strings.repeat("a", initialBufferSize * 2));
+    }
+
+    // prepare() previously passed DEFAULT_LOOKAHEAD as the desired size even for single-character
+    // operations, so "remaining < desired" became true again after consuming just one character
+    // from a full buffer, forcing a fresh underlying read() on every single consume(). Asserting
+    // on the raw read() call count (rather than just consumed output) is what catches that.
+    @Test
+    void shouldNotRereadUnderlyingStreamForEverySingleCharacterConsumed() {
+        final var content = Strings.repeat("a", 10_000);
+        final var readCalls = new AtomicInteger();
+
+        final var reader = new LookaheadReader(new StringReader(content) {
+            @Override
+            public int read(char [] cbuf, int off, int len) throws IOException {
+                readCalls.incrementAndGet();
+                return super.read(cbuf, off, len);
+            }
+        });
+
+        int consumed = 0;
+        while (reader.available()) {
+            reader.consume();
+            consumed++;
+        }
+
+        assertThat(consumed)
+            .isEqualTo(content.length());
+
+        assertThat(readCalls.get())
+            .isLessThan(content.length() / 10);
     }
 }


### PR DESCRIPTION
`LookaheadReader.prepare()` (the no-arg overload used by `consume()`, `peek()`, `available()`, and `follows()`) delegated to `prepare(DEFAULT_LOOKAHEAD)`, requesting a full 4096-character lookahead even for single-character operations.

Because the internal buffer is sized to exactly `DEFAULT_LOOKAHEAD` by default, this made the "not enough room" shuffle condition (`index + desired > buffer.length`) true again immediately after consuming just one character, forcing a fresh underlying `read()` call on essentially every single `consume()`. The fix changes the no-arg `prepare()` to request a `desired` of `1` instead, so the refill only triggers when the buffer is actually empty; the top-up read still fills as much of the buffer as is available, so bulk consumption via `consume(int)` is unaffected.