### PR TITLE
fix(base-foundation, base-io): add toString() to Exceptional and PathSet

### DIFF
--- a/base-foundation/src/main/java/build/base/foundation/Exceptional.java
+++ b/base-foundation/src/main/java/build/base/foundation/Exceptional.java
@@ -449,6 +449,17 @@ public final class Exceptional<T>
         return Objects.hash(this.value, this.exception);
     }
 
+    @Override
+    public String toString() {
+        if (this.value != null) {
+            return "Exceptional[" + this.value + "]";
+        } else if (this.exception != null) {
+            return "Exceptional[" + this.exception + "]";
+        } else {
+            return "Exceptional.empty";
+        }
+    }
+
     /**
      * Obtains the empty {@link Exceptional}, without a value and a {@link Exception}.
      *

--- a/base-foundation/src/test/java/build/base/foundation/ExceptionalTests.java
+++ b/base-foundation/src/test/java/build/base/foundation/ExceptionalTests.java
@@ -787,4 +787,19 @@ class ExceptionalTests {
                 .isEqualTo("Not supported mate");
         }
     }
+
+    /**
+     * Ensure {@link Exceptional#toString()} renders the value, exception, or empty state.
+     */
+    @Test
+    void shouldRenderToString() {
+        assertThat(Exceptional.of(42).toString())
+            .isEqualTo("Exceptional[42]");
+
+        assertThat(Exceptional.ofException(new IllegalStateException("boom")).toString())
+            .isEqualTo("Exceptional[java.lang.IllegalStateException: boom]");
+
+        assertThat(Exceptional.empty().toString())
+            .isEqualTo("Exceptional.empty");
+    }
 }

--- a/base-io/src/main/java/build/base/io/PathSet.java
+++ b/base-io/src/main/java/build/base/io/PathSet.java
@@ -178,7 +178,7 @@ public interface PathSet
 
         @Override
         public String toString() {
-            return "PathSet.empty()";
+            return "[]";
         }
     }
 }

--- a/base-io/src/main/java/build/base/io/PathSetBuilder.java
+++ b/base-io/src/main/java/build/base/io/PathSetBuilder.java
@@ -216,5 +216,10 @@ public class PathSetBuilder {
         public int hashCode() {
             return Objects.hash(this.paths);
         }
+
+        @Override
+        public String toString() {
+            return this.paths.toString();
+        }
     }
 }

--- a/base-io/src/test/java/build/base/io/PathSetTests.java
+++ b/base-io/src/test/java/build/base/io/PathSetTests.java
@@ -279,4 +279,42 @@ class PathSetTests {
         assertThat(pathSet1.hashCode())
             .isEqualTo(pathSet2.hashCode());
     }
+
+    /**
+     * Ensure {@link PathSet#toString()} renders the contained {@link Path}s.
+     */
+    @Test
+    void shouldRenderToString() {
+        final var first = Paths.get("/usr/local/bin");
+        final var second = Paths.get("/usr/bin");
+
+        final var pathSet = PathSetBuilder
+            .create(first, second)
+            .build();
+
+        assertThat(pathSet.toString())
+            .isEqualTo(Stream.of(first, second).map(Path::toString).toList().toString());
+    }
+
+    /**
+     * Ensure an empty {@link PathSet#toString()} renders an empty list.
+     */
+    @Test
+    void shouldRenderEmptyToString() {
+        final var pathSet = PathSetBuilder
+            .create()
+            .build();
+
+        assertThat(pathSet.toString())
+            .isEqualTo("[]");
+    }
+
+    /**
+     * Ensure {@link PathSet#empty()} renders the same as an empty built {@link PathSet}.
+     */
+    @Test
+    void shouldRenderEmptyPathSetToString() {
+        assertThat(PathSet.empty().toString())
+            .isEqualTo("[]");
+    }
 }


### PR DESCRIPTION
`Exceptional` had no `toString()` override, so instances printed the default `Object` identity hash instead of anything useful for debugging or logging; this adds a `toString()` that renders `Exceptional[value]`, `Exceptional[exception]`, or `Exceptional.empty` depending on which of the three states the instance is in, matching the same three-way branching already used by `equals()` and `hashCode()`.

`PathSet`'s empty singleton previously rendered as the string `"PathSet.empty()"`, which reads like a factory-method reference rather than a value representation and doesn't match how a populated `PathSet` prints. This adds a `toString()` to the internal non-empty `PathSetBuilder` implementation that delegates to the underlying `LinkedHashSet<Path>`, and changes `PathSet.empty()`'s `toString()` from `"PathSet.empty()"` to `"[]"` so both the empty and non-empty cases render consistently with each other and with standard `Set` formatting.