### PR TITLE
fix(base-telemetry): improve Completed and Progress toString() formatting

### DIFF
--- a/base-telemetry/src/main/java/build/base/telemetry/Completed.java
+++ b/base-telemetry/src/main/java/build/base/telemetry/Completed.java
@@ -122,12 +122,13 @@ public interface Completed<T>
                 final long minutes = duration.toMinutes() % 60;
                 final long seconds = duration.getSeconds() % 60;
                 final long millis = duration.toMillis() % 1000;
+                final boolean showMillis = millis > 0 || duration.toMillis() == 0;
 
                 final String duration = (days > 0 ? days + " days " : "")
                     + (hours > 0 ? hours + " hrs " : "")
                     + (minutes > 0 ? minutes + " mins " : "")
                     + (seconds > 0 ? seconds + " secs " : "")
-                    + (millis > 0 ? millis + " ms" : "");
+                    + (showMillis ? millis + " ms" : "");
 
                 return "[" + uri + "] "
                     + "[Completed] " + message

--- a/base-telemetry/src/main/java/build/base/telemetry/Progress.java
+++ b/base-telemetry/src/main/java/build/base/telemetry/Progress.java
@@ -22,6 +22,7 @@ package build.base.telemetry;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -146,7 +147,7 @@ public interface Progress
                 return "[" + uri + "] "
                     + "[Progress] " + message
                     + " " + currentLabel + " of " + maximumLabel
-                    + " (" + percentage() + "%)";
+                    + String.format(Locale.ROOT, " (%.1f%%)", percentage());
             }
         };
     }

--- a/base-telemetry/src/test/java/build/base/telemetry/CompletedTests.java
+++ b/base-telemetry/src/test/java/build/base/telemetry/CompletedTests.java
@@ -51,4 +51,23 @@ class CompletedTests {
             .doesNotContain("hrs")
             .doesNotContain("mins");
     }
+
+    /**
+     * Verify a near-instantaneous (sub-millisecond) duration still renders an explicit millisecond
+     * component, e.g. "0 ms", rather than omitting the duration entirely.
+     */
+    @Test
+    void toStringShouldFormatNearInstantaneousDurationWithExplicitMillis() {
+        final var commenced = Instant.now();
+        final var completed = Completed.create(URI, null, commenced, "task");
+
+        final var text = completed.toString();
+
+        assertThat(text)
+            .containsPattern("\\(\\d+ ms\\)")
+            .doesNotContain("days")
+            .doesNotContain("hrs")
+            .doesNotContain("mins")
+            .doesNotContain("secs");
+    }
 }

--- a/base-telemetry/src/test/java/build/base/telemetry/ProgressTests.java
+++ b/base-telemetry/src/test/java/build/base/telemetry/ProgressTests.java
@@ -1,0 +1,66 @@
+package build.base.telemetry;
+
+/*-
+ * #%L
+ * base.build Telemetry
+ * %%
+ * Copyright (C) 2025 Workday Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Progress}.
+ */
+class ProgressTests {
+
+    private static final URI URI = java.net.URI.create("test://uri");
+
+    /**
+     * Verify {@link Progress#toString()} formats the percentage to a single decimal place,
+     * rather than the (much longer) default {@code double} representation.
+     */
+    @Test
+    void toStringShouldFormatPercentageToOneDecimalPlace() {
+        final var progress = Progress.create(URI, 1, 3, "task");
+
+        final var text = progress.toString();
+
+        assertThat(progress.percentage())
+            .isEqualTo(33.33333333333333);
+
+        assertThat(text)
+            .contains("(33.3%)")
+            .doesNotContain("33.33333333333333");
+    }
+
+    /**
+     * Verify a whole-number percentage still renders with a single trailing decimal digit.
+     */
+    @Test
+    void toStringShouldFormatWholePercentageWithTrailingDecimal() {
+        final var progress = Progress.create(URI, 1, 2, "task");
+
+        final var text = progress.toString();
+
+        assertThat(text)
+            .contains("(50.0%)");
+    }
+}


### PR DESCRIPTION
`Completed#toString()` previously omitted the millisecond component whenever `millis == 0`, which meant a near-instantaneous (sub-millisecond) duration rendered with no duration text at all instead of an explicit `0 ms`. It now shows the millisecond component whenever the entire `Duration` is zero, so the near-instantaneous case still produces readable output.

`Progress#toString()` previously embedded the raw `double` from `percentage()` directly, producing long, noisy values like `33.33333333333333%`. It now formats the percentage with `String.format(Locale.ROOT, "%.1f%%", ...)`, giving a consistent single-decimal-place value such as `33.3%` or `50.0%`.